### PR TITLE
Graph editor improvements: port picker, preview controls, presets, EXR support, preview perf overhaul

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,6 +34,33 @@
          graph views, and cheap enough not to gate on lazy view selection). -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="https://unpkg.com/three@0.128.0/examples/js/loaders/RGBELoader.js"></script>
+    <!-- EXRLoader: self-hosted, patched copy at js/vendor/EXRLoader.js
+         (see the provenance header in that file for full detail). It starts
+         from three@0.147.0's examples/js UMD build — pinned newer than the
+         r128 core because that's the newest version unpkg still serves
+         under examples/js (0.148.0+ 404s; the legacy non-module bundle was
+         discontinued around r147/r148) — verified source-compatible with
+         the r128 THREE core: 0.147.0's EXRLoader.js only touches
+         THREE.DataTextureLoader, THREE.FloatType/HalfFloatType,
+         THREE.RGBAFormat/RedFormat, THREE.LinearEncoding, THREE.LinearFilter
+         and THREE.DataUtils.toHalfFloat — all present with matching
+         signatures in three@0.128.0/build/three.js.
+         On top of that base, the DWA decode path is back-ported from three's
+         current examples/jsm/loaders/EXRLoader.js (mrdoob/three.js PRs
+         #27982/#30709/#33216) to fix "Cannot read properties of undefined
+         (reading 'width') at lossyDctDecode" on real .exr files whose
+         channels are layer-prefixed (e.g. "RGBA.R" — the default naming many
+         DCC exporters use); r147's naive `cd.name==rule.name` channel-rule
+         check never matched such names and then called lossyDctDecode()
+         unconditionally.
+         fflate: EXRLoader needs the global `fflate` (its ZIP/DWA-compressed
+         decode paths call fflate.unzlibSync) — must load before
+         js/vendor/EXRLoader.js. 0.147.0's libs/fflate.min.js is
+         byte-identical to 0.128.0's (still fflate 0.6.9, same exports);
+         kept on the 0.147.0 CDN tag purely so the version tag matches what
+         js/vendor/EXRLoader.js was forked from. -->
+    <script src="https://unpkg.com/three@0.147.0/examples/js/libs/fflate.min.js"></script>
+    <script src="js/vendor/EXRLoader.js"></script>
     <script src="https://unpkg.com/three@0.128.0/examples/js/loaders/GLTFLoader.js"></script>
     <script src="https://unpkg.com/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
 

--- a/js/graph-app.jsx
+++ b/js/graph-app.jsx
@@ -27,6 +27,102 @@
         const ReactFlowComp = RF.ReactFlow || RF.default;
         const { Background, MiniMap, Handle, Position, MarkerType } = RF;
 
+        // Port-picker popover (item 2): offered when a connection drag ends
+        // on a NODE BODY instead of a precise handle (see onConnectEnd in
+        // NodeGraphApp below) — lets the user pick which compatible port on
+        // that node to wire up. Styled to match AddNodeSearch (js/graph/
+        // panels.jsx) — same container chrome, same row layout (name left,
+        // muted type tag right), same footer hint bar — plus a filter input
+        // since AddNodeSearch's type-filter dropdown doesn't apply here
+        // (every candidate is already type-compatible). A real component
+        // (not a plain render helper) because it owns its own filter-text
+        // and selection-index state across re-renders while it's open.
+        // portPicker: { x, y, candidates, targetName }; rootRef is forwarded
+        // so the parent's outside-pointerdown-closes effect keeps working;
+        // Escape is handled by the parent's useEscapeToClose (window-level),
+        // so this component doesn't need its own Escape handling.
+        const PORT_PICKER_ROW_H = 26;
+        function PortPickerPopover({ portPicker, rootRef, onPick }) {
+            const [q, setQ] = React.useState('');
+            const [hi, setHi] = React.useState(0);
+            const inputRef = React.useRef(null);
+            const listRef = React.useRef(null);
+            React.useEffect(() => {
+                const t = setTimeout(() => { if (inputRef.current) inputRef.current.focus(); }, 0);
+                return () => clearTimeout(t);
+            }, []);
+            const items = React.useMemo(() => {
+                const s = q.trim().toLowerCase();
+                const pool = portPicker.candidates;
+                return s ? pool.filter((c) => c.label.toLowerCase().indexOf(s) !== -1) : pool;
+            }, [portPicker.candidates, q]);
+            React.useEffect(() => { setHi(0); }, [q]);
+            React.useEffect(() => { // keep the highlighted row in view
+                const el = listRef.current && listRef.current.children[hi];
+                if (el && el.scrollIntoView) el.scrollIntoView({ block: 'nearest' });
+            }, [hi, items]);
+            const onKeyDown = (e) => {
+                if (e.key === 'ArrowDown') { e.preventDefault(); setHi((h) => Math.min(h + 1, Math.max(items.length - 1, 0))); }
+                else if (e.key === 'ArrowUp') { e.preventDefault(); setHi((h) => Math.max(h - 1, 0)); }
+                else if (e.key === 'Enter') { e.preventDefault(); if (items[hi]) onPick(items[hi]); }
+                // Escape: let it bubble to the parent's window-level
+                // useEscapeToClose listener — nothing to do here.
+            };
+            const width = 260;
+            const inputH = 38, footerH = 26;
+            const height = inputH + Math.min(items.length, 8) * PORT_PICKER_ROW_H + footerH;
+            const flip = portPicker.y + height > window.innerHeight;
+            const style = {
+                position: 'fixed', zIndex: 9999, width,
+                left: Math.max(4, Math.min(portPicker.x, window.innerWidth - width - 4)),
+            };
+            if (flip) style.bottom = Math.max(4, window.innerHeight - portPicker.y + 4);
+            else style.top = portPicker.y + 4;
+            return (
+                <div
+                    ref={rootRef}
+                    onPointerDown={(e) => e.stopPropagation()}
+                    style={style}
+                    className="bg-gray-800/95 backdrop-blur border border-gray-600 rounded-lg shadow-2xl overflow-hidden"
+                >
+                    <div className="flex items-stretch border-b border-gray-700">
+                        <input
+                            ref={inputRef}
+                            className="flex-1 min-w-0 bg-gray-900 px-3 py-2 text-sm font-mono text-gray-100 placeholder-gray-500 focus:outline-none"
+                            placeholder={'Filter ports on ' + portPicker.targetName + '…'}
+                            value={q}
+                            spellCheck={false}
+                            onChange={(e) => setQ(e.target.value)}
+                            onKeyDown={onKeyDown}
+                        />
+                    </div>
+                    <div ref={listRef} className="max-h-[300px] overflow-y-auto custom-scrollbar">
+                        {!items.length && (
+                            <div className="px-3 py-3 text-[11px] text-gray-500">No port matches {'“'}{q}{'”'}.</div>
+                        )}
+                        {items.map((c, i) => (
+                            <button
+                                key={c.label}
+                                type="button"
+                                onMouseEnter={() => setHi(i)}
+                                onClick={() => onPick(c)}
+                                className={'w-full flex items-center gap-2 px-3 py-1.5 text-left text-[12px] font-mono transition-colors '
+                                    + (i === hi ? 'bg-blue-600/30 text-gray-100' : 'text-gray-300 hover:bg-gray-700/60')}
+                            >
+                                <span className="w-2 h-2 rounded-full flex-none" style={{ background: typeColor(c.type) }} />
+                                <span className="flex-1 truncate">{c.label}</span>
+                                {c.connected && <span className="flex-none text-gray-500">(connected)</span>}
+                                <span className="ml-auto flex-none text-[9px] uppercase tracking-wider" style={{ color: typeColor(c.type) }}>{c.type}</span>
+                            </button>
+                        ))}
+                    </div>
+                    <div className="px-3 py-1.5 border-t border-gray-700 text-[10px] text-gray-500">
+                        {'↑↓'} select {'·'} Enter connect {'·'} Esc close
+                    </div>
+                </div>
+            );
+        }
+
         // ---- App ---------------------------------------------------------------
 
         function NodeGraphApp({ active = true } = {}) {
@@ -94,6 +190,14 @@
             // (and locks) AddNodeSearch's type dropdown so only compatible
             // nodes show, and drives the auto-wire once one is picked.
             const [portAddFilter, setPortAddFilter] = React.useState(null);
+            // Port-picker popover (item 2): set when a connection drag ends
+            // on a NODE BODY (not a handle, not the empty pane) — offers
+            // every compatible port on that node instead of demanding
+            // pixel-precise aim. { x, y, candidates, targetName } or null;
+            // see onConnectEnd (candidate list) and the popover render
+            // below (portPickerRef, useEscapeToClose, outside-pointerdown).
+            const [portPicker, setPortPicker] = React.useState(null);
+            const portPickerRef = React.useRef(null);
             // Keybinds reference popup ("?" button, top-right).
             const [helpOpen, setHelpOpen] = React.useState(false);
             // In-tab docs viewer (parameter panel "?" button): { url, fullUrl, label }
@@ -109,6 +213,20 @@
             // dialog opens (see the useEffect gated on validateOpen below).
             const [validateOpen, setValidateOpen] = React.useState(false);
             const [validateResult, setValidateResult] = React.useState(null);
+            // Export dialog (toolbar "Export" button, item B1): holds
+            // { defaultName, textures } computed once when the dialog is
+            // opened (openExportDialog below), or null while closed — same
+            // "computed once by the caller, not on every render" contract
+            // as xmlDialogXml/validateResult above.
+            const [exportDialog, setExportDialog] = React.useState(null);
+            // Presets dialog (toolbar "Presets" button, item F3.2): a
+            // curated list of official MaterialX example documents (see
+            // MTLX_PRESETS in js/graph/dialogs.jsx). `presetsBusyPath`
+            // tracks WHICH preset is fetching so the dialog can spin just
+            // that row while every row is disabled.
+            const [presetsOpen, setPresetsOpen] = React.useState(false);
+            const [presetsBusy, setPresetsBusy] = React.useState(false);
+            const [presetsBusyPath, setPresetsBusyPath] = React.useState(null);
             // Freezes the preview panel to a specific node regardless of
             // what gets selected afterward (item 10's pin toggle) — same
             // { scope, id } shape as previewSel, reset alongside it.
@@ -181,6 +299,23 @@
             // overlay existed.
             const changeScope = (next) => {
                 if (next === scopeRef.current) return;
+                // Entering/jumping into a nodegraph (non-empty target
+                // scope): aim the initial selection+preview at the graph's
+                // RESULT (its first output) instead of falling back to the
+                // last/global selection — mirrors the scope-EXIT convention
+                // above (Backspace/breadcrumb seed 'g:'+name into
+                // pendingScopeSelectRef before calling changeScope; here we
+                // seed 'o:'+name on the way IN). Skipped when a pin owns
+                // the preview, or when an exit call site already seeded the
+                // ref (that selection must win).
+                if (next && !pendingScopeSelectRef.current && !pinnedTarget) {
+                    const firstOutputName = mxSafe(() => {
+                        const g = parsedRef.current && parsedRef.current.doc.getNodeGraph(next);
+                        const outs = g ? vecToArray(g.getOutputs()) : [];
+                        return outs.length ? mxElName(outs[0]) : null;
+                    }, null);
+                    if (firstOutputName) pendingScopeSelectRef.current = 'o:' + firstOutputName;
+                }
                 setScopeBusy(true);
                 (async () => {
                     // A single requestAnimationFrame callback fires just
@@ -559,7 +694,15 @@
                 }
             };
 
-            const ingest = async (map) => {
+            // `rootKey` (optional): when the caller already knows which
+            // .mtlx key is the document to load — e.g. loadPreset below,
+            // whose map may also contain xi:include dependency docs that
+            // are ALSO .mtlx-suffixed — skip the "ambiguous drop, ask the
+            // user to pick" heuristic below and load it directly. Omitted
+            // by every other caller (drag-drop, the default-document
+            // fetch), which keeps relying on that heuristic exactly as
+            // before.
+            const ingest = async (map, rootKey) => {
                 setError(null);
                 try {
                     await expandZips(map);
@@ -592,7 +735,8 @@
                     return;
                 }
                 if (droppedMtlx.length) {
-                    const pick = mtlx.length === 1 ? mtlx[0] : null;
+                    const pick = (rootKey && mtlx.indexOf(rootKey) !== -1)
+                        ? rootKey : (mtlx.length === 1 ? mtlx[0] : null);
                     setChosenMtlx(pick);
                     if (pick) loadDocument(pick, merged);
                     else setStatus('This drop contains several .mtlx files — pick one below.');
@@ -1222,6 +1366,36 @@
                 }
             };
 
+            // Derives the default export base name (no extension) from the
+            // parsed document's label — shared by the direct one-click
+            // Export & Continue path (exportMtlx below) and the Export
+            // dialog's (item B1) prefilled filename field.
+            const defaultExportBase = () => String((parsed && parsed.label) || 'document').split('/').pop().replace(/\.mtlx$/i, '');
+
+            // Hand the current document off to the material viewer — item
+            // F2.2's "Send to Viewer", the reverse of the receive-side
+            // machinery below (the 'mtlx-load-document' effect handles the
+            // viewer's own "Send to Editor" button the same way, in
+            // reverse). Serializes through the SAME resolveDocXml() the
+            // Export path uses just above, so it copes with the transient
+            // '__pv_*' preview-tap race identically rather than re-deriving
+            // that retry logic. `files` mirrors viewer-app.jsx's sendToEditor
+            // filter: every dropped session file that ISN'T a .mtlx (loose
+            // textures the graph carries alongside the document).
+            const sendToViewer = async () => {
+                if (!parsed) return;
+                const { xml, error } = await resolveDocXml();
+                if (xml == null) {
+                    setError('Send to Viewer failed: ' + error);
+                    return;
+                }
+                const files = {};
+                Object.keys(fileMapRef.current || {}).forEach((k) => {
+                    if (!/\.mtlx$/i.test(k)) files[k] = fileMapRef.current[k];
+                });
+                openInViewer({ xml, name: defaultExportBase(), files });
+            };
+
             // Serialize the CURRENT document — edits, connections, layout
             // positions, everything — and write it out as .mtlx. The stdlib
             // is attached via setDataLibrary (referenced, not contained), so
@@ -1229,15 +1403,18 @@
             // save-file picker (lets the user choose where the file goes /
             // overwrite in place) and falls back to the anchor-download
             // mechanism when the picker API is unavailable or fails for a
-            // reason other than the user canceling.
-            const doExportMtlx = async () => {
+            // reason other than the user canceling. `nameOverride` (item
+            // B1's Export dialog) supersedes the label-derived base name;
+            // every existing caller passes nothing, so behavior there is
+            // byte-identical.
+            const doExportMtlx = async (nameOverride) => {
                 if (!parsed) return false;
                 const { xml, error } = await resolveDocXml();
                 if (xml == null) {
                     setError('Export failed: ' + error);
                     return false;
                 }
-                const base = String(parsed.label || 'document').split('/').pop().replace(/\.mtlx$/i, '');
+                const base = nameOverride || defaultExportBase();
                 const blob = new Blob([xml], { type: 'application/xml' });
                 if (typeof window.showSaveFilePicker === 'function') {
                     let handle = null;
@@ -1271,19 +1448,334 @@
                 markSaved(); // the just-downloaded file matches the current document
                 return true;
             };
+            // Same document, packaged as a .zip alongside every texture the
+            // Export dialog (item B1) found a session-file match for.
+            // `resolvedTextures` is the { ref, key }[] list ExportDialog was
+            // opened with (scanExportTextures below) — reused as-is rather
+            // than rescanning, since the modal backdrop closes on any
+            // outside click, so the live doc can't drift out from under an
+            // open dialog. Each texture is stored under its AUTHORED
+            // reference path (forward slashes, no leading './') so
+            // re-dropping the zip later resolves textures through the
+            // normal import path (readDroppedItems -> expandZips ->
+            // findFileForRef, which suffix/basename-matches — see
+            // js/mtlx-engine.js) — not lowercased/renamed the way
+            // findFileForRef's own normPath would for MATCHING purposes.
+            const doExportZip = async (name, resolvedTextures) => {
+                if (!parsed) return false;
+                const { xml, error } = await resolveDocXml();
+                if (xml == null) {
+                    setError('Export failed: ' + error);
+                    return false;
+                }
+                if (!window.JSZip) {
+                    setError('Export failed: JSZip failed to load from the CDN.');
+                    return false;
+                }
+                const zip = new JSZip();
+                zip.file(name + '.mtlx', xml);
+                const seenPaths = new Set();
+                for (const t of (resolvedTextures || [])) {
+                    const zipPath = String(t.ref || '').replace(/\\/g, '/').replace(/^\.?\/+/, '');
+                    if (!zipPath || seenPaths.has(zipPath)) continue;
+                    seenPaths.add(zipPath);
+                    const blob = fileMapRef.current[t.key];
+                    if (blob) zip.file(zipPath, blob);
+                }
+                let blob;
+                try {
+                    blob = await zip.generateAsync({ type: 'blob' });
+                } catch (e) {
+                    setError('Export failed: ' + String(e && e.message || e));
+                    return false;
+                }
+                const a = document.createElement('a');
+                a.href = URL.createObjectURL(blob);
+                a.download = name + '.zip';
+                a.click();
+                setTimeout(() => URL.revokeObjectURL(a.href), 5000);
+                markSaved(); // the just-downloaded zip's document matches the current one
+                return true;
+            };
             // A second picker opening mid-export (e.g. a fast double-click)
-            // would race the first — guard exportMtlx itself so only one
-            // export runs at a time; the retry recursion above stays
+            // would race the first — guard exportMtlx/exportZip themselves
+            // so only one export runs at a time (shared across both
+            // formats, since only one export can meaningfully be in flight
+            // at once); the retry recursion in resolveDocXml above stays
             // unguarded so it can keep looping inside that single run.
             const exportBusyRef = React.useRef(false);
-            const exportMtlx = async () => {
+            const exportMtlx = async (nameOverride) => {
                 if (exportBusyRef.current) return false;
                 exportBusyRef.current = true;
                 try {
-                    return await doExportMtlx();
+                    return await doExportMtlx(nameOverride);
                 } finally {
                     exportBusyRef.current = false;
                 }
+            };
+            const exportZip = async (name, resolvedTextures) => {
+                if (exportBusyRef.current) return false;
+                exportBusyRef.current = true;
+                try {
+                    return await doExportZip(name, resolvedTextures);
+                } finally {
+                    exportBusyRef.current = false;
+                }
+            };
+
+            // Scan the WHOLE document (root nodes + every nodegraph's
+            // nodes — same one-level-deep container walk ungroupNodegraph's
+            // `connectables` helper uses below) for authored `filename`
+            // inputs, and resolve each ref against this session's dropped
+            // files (fileMapRef.current). Only run when opening the Export
+            // dialog (item B1), to preview what a "ZIP with textures"
+            // export would bundle. Reuses collectPorts (js/graph/model.jsx)
+            // for its existing filename-input + value resolution — the
+            // same helper copySelection relies on to capture a node's
+            // texture refs (see its comment above) — rather than
+            // re-deriving port types by hand.
+            const scanExportTextures = () => {
+                const resolved = [];
+                const unresolved = [];
+                if (!parsed) return { resolved, unresolved };
+                const seenRefs = new Set();
+                const allNodes = vecToArray(mxSafe(() => parsed.doc.getNodes(), [])).slice();
+                for (const g of vecToArray(mxSafe(() => parsed.doc.getNodeGraphs(), []))) {
+                    allNodes.push.apply(allNodes, vecToArray(mxSafe(() => g.getNodes(), [])));
+                }
+                for (const n of allNodes) {
+                    const ports = collectPorts(n, { authoredOnly: true });
+                    for (const i of ports.inputs) {
+                        if (i.type !== 'filename' || !i.value) continue;
+                        if (seenRefs.has(i.value)) continue;
+                        seenRefs.add(i.value);
+                        const hit = findFileForRef(fileMapRef.current, i.value);
+                        if (hit) resolved.push({ ref: i.value, key: hit.key });
+                        else unresolved.push(i.value);
+                    }
+                }
+                return { resolved, unresolved };
+            };
+
+            // Toolbar "Presets" button (item F3.2): fetch a curated
+            // official example .mtlx (js/graph/dialogs.jsx's MTLX_PRESETS)
+            // and hand it to ingest() much like a drag-drop — the same
+            // fetch->Blob->ingestRef.current(map) pipeline the default
+            // startup document uses above, extended into a small
+            // breadth-first crawl (see loadPreset below) since a preset
+            // may pull in sibling documents and textures of its own.
+            // Gated behind the same confirmReplace unsaved-changes confirm
+            // as every other document-replacing action (guardedIngest, the
+            // document-picker <select>'s onChange) since a preset always
+            // introduces a new .mtlx. `presetsOpen` is deliberately left
+            // open through the fetch (busy=true disables/spins its rows)
+            // so a failed fetch's setError leaves the dialog up for
+            // another pick, rather than punting the user back to a bare
+            // canvas.
+            //
+            // Two things a plain single-doc fetch misses, both exercised
+            // by the official MaterialX example set:
+            //  (1) xi:include: "look" files (e.g. "Brass (tiled look)")
+            //      pull in a separate sibling .mtlx for the actual
+            //      material — resolveIncludes (js/mtlx-engine.js:535,
+            //      invoked from loadDocument above) inlines those from
+            //      the SAME dropped-file map this preset flow builds, but
+            //      only if that sibling doc was actually fetched into it.
+            //  (2) filename refs that escape the preset's own directory
+            //      via literal "../" segments in the authored value AND/OR
+            //      an inheritable `fileprefix="..."` attribute (MaterialX
+            //      spec: set on an ancestor element — the document root or
+            //      a <nodegraph> — and prepended, plain string
+            //      concatenation, to every descendant filename input's raw
+            //      `value`). E.g. "Wood (tiled)"'s <nodegraph
+            //      fileprefix="../../../Images/"> makes
+            //      value="wood_color.jpg" resolve to
+            //      "../../../Images/wood_color.jpg", which lands outside
+            //      the preset's own directory (resources/Images/, a
+            //      sibling of resources/Materials/) — a plain
+            //      dir-relative fetch 404s on it.
+            //
+            // Below: `visited` (resolved doc URLs) + `queue` seed with the
+            // preset doc; every fetched doc is (a) scanned for xi:include
+            // hrefs, resolved against THAT doc's own URL and enqueued for
+            // its own scan, and (b) scanned for fileprefix-resolved
+            // filename refs (extractFilenameRefs below), fetched relative
+            // to THAT doc's own URL. `visited.size` is capped at
+            // MAX_DOCS: these examples nest at most one include deep in
+            // practice, so this is purely a guard against a
+            // malformed/circular include chain spinning forever, not an
+            // expected limit. Texture fetches stay best-effort (warn +
+            // skip on failure — a skipped ref just shows the UV checker
+            // like any unresolved texture). A SAFETY GUARD only ever
+            // fetches URLs under this tag's resources/ root (derived from
+            // MTLX_PRESETS_BASE, not hardcoded a second time); refs that
+            // are absolute URLs (scheme://) or resolve outside that root
+            // are skipped.
+            //
+            // Blobs for included docs are keyed the same way
+            // mtlx-engine.js's resolveIncludes composes its own lookup
+            // when it later runs (fromDir-of-the-including-key + '/' +
+            // href — see resolveIncludes, js/mtlx-engine.js:547).
+            // Blobs for textures are keyed by the fileprefix-resolved ref
+            // string (e.g. "../../../Images/wood_color.jpg") — findFileForRef
+            // (js/mtlx-engine.js:517) matches an exact normalized path
+            // first, then a unique path-suffix, then a unique basename, so
+            // this key resolves correctly whether the WASM binding reports
+            // that resolved path or the bare authored filename as the
+            // input's value at bind time (bindDroppedTextures,
+            // js/mtlx-engine.js:659).
+            //
+            // Finally: ingestRef.current(map, baseName) passes the root
+            // doc's key explicitly, because ingest()'s default
+            // "auto-pick only when exactly one .mtlx is in the map"
+            // heuristic (js/graph-app.jsx, ingest() above) would otherwise
+            // see the included docs' .mtlx keys too and stop to ask the
+            // user which one to load — wrong for a preset, which always
+            // knows its own root doc.
+            const MTLX_RESOURCES_ROOT = MTLX_PRESETS_BASE.slice(
+                0, MTLX_PRESETS_BASE.indexOf('resources/') + 'resources/'.length);
+            const isSafePresetUrl = (url) => url.indexOf(MTLX_RESOURCES_ROOT) === 0;
+            const isSchemeOrRootedRef = (ref) =>
+                /^[a-z][a-z0-9+.\-]*:\/\//i.test(ref) || ref.startsWith('/');
+            // Filename refs authored in a preset doc, resolved against any
+            // <materialx fileprefix="..."> (document-wide) and/or
+            // <nodegraph fileprefix="..."> (scoped to that nodegraph's
+            // own body) ancestor per MaterialX's inheritable-attribute
+            // semantics — see the comment above. Splits the raw xml into
+            // "scopes" (each nodegraph's body, plus everything outside any
+            // nodegraph) so each <input type="filename"> tag picks up the
+            // right accumulated prefix; a two-pass tag scan within each
+            // scope, same shape as the original single-doc version of
+            // this function.
+            const extractFilenameRefs = (xml) => {
+                const rootAttrs = (/<materialx\b([^>]*)>/.exec(xml) || [])[1] || '';
+                const rootPrefix = (/\bfileprefix\s*=\s*"([^"]*)"/.exec(rootAttrs) || [])[1] || '';
+                const scopes = [];
+                let cursor = 0;
+                const NG = /<nodegraph\b([^>]*)>([\s\S]*?)<\/nodegraph>/g;
+                let ngm;
+                while ((ngm = NG.exec(xml)) !== null) {
+                    scopes.push({ text: xml.slice(cursor, ngm.index), prefix: rootPrefix });
+                    const ngPrefix = (/\bfileprefix\s*=\s*"([^"]*)"/.exec(ngm[1]) || [])[1] || '';
+                    scopes.push({ text: ngm[2], prefix: rootPrefix + ngPrefix });
+                    cursor = ngm.index + ngm[0].length;
+                }
+                scopes.push({ text: xml.slice(cursor), prefix: rootPrefix });
+                const refs = [];
+                for (const scope of scopes) {
+                    const tags = scope.text.match(/<input\b[^>]*>/g) || [];
+                    for (const tag of tags) {
+                        if (!/\btype\s*=\s*"filename"/.test(tag)) continue;
+                        const m = /\bvalue\s*=\s*"([^"]*)"/.exec(tag);
+                        const raw = m && m[1];
+                        if (!raw) continue;
+                        refs.push(scope.prefix + raw);
+                    }
+                }
+                return refs;
+            };
+            const loadPreset = (preset) => {
+                confirmReplace(true, () => {
+                    (async () => {
+                        setPresetsBusy(true);
+                        setPresetsBusyPath(preset.path);
+                        setError(null);
+                        try {
+                            const docUrl = MTLX_PRESETS_BASE + preset.path;
+                            const baseName = preset.path.split('/').pop();
+                            const map = {};
+                            const seenRefs = new Set();
+                            const textureFetches = [];
+                            const MAX_DOCS = 12; // guard only — see comment above
+                            const visited = new Set([docUrl]);
+                            const queue = [{ url: docUrl, key: baseName }];
+                            while (queue.length) {
+                                const { url, key } = queue.shift();
+                                let xml;
+                                try {
+                                    const res = await fetch(url);
+                                    if (!res.ok) throw new Error('HTTP ' + res.status + ' fetching ' + url);
+                                    xml = await res.text();
+                                } catch (e) {
+                                    if (key === baseName) throw e; // the root doc must load
+                                    console.warn('preset include fetch failed (skipped):', url, e);
+                                    continue;
+                                }
+                                map[key] = new Blob([xml], { type: 'application/xml' });
+
+                                // (a) xi:include siblings — same
+                                // attribute-order/quote tolerant href
+                                // extraction as resolveIncludes
+                                // (js/mtlx-engine.js:540), resolved against
+                                // THIS doc's own URL.
+                                const INC = /<xi:include\b[^>]*?href\s*=\s*(?:"([^"]*)"|'([^']*)')[^>]*?\/?>/g;
+                                let incM;
+                                while ((incM = INC.exec(xml)) !== null) {
+                                    const href = incM[1] || incM[2];
+                                    if (!href || isSchemeOrRootedRef(href)) continue;
+                                    let incUrl;
+                                    try { incUrl = new URL(href, url).href; } catch (e) { continue; }
+                                    if (!isSafePresetUrl(incUrl)) continue;
+                                    if (visited.has(incUrl) || visited.size >= MAX_DOCS) continue;
+                                    visited.add(incUrl);
+                                    const dirKey = key.indexOf('/') >= 0 ? key.slice(0, key.lastIndexOf('/')) : '';
+                                    const incKey = dirKey ? dirKey + '/' + href : href;
+                                    queue.push({ url: incUrl, key: incKey });
+                                }
+
+                                // (b) filename refs, fileprefix-resolved,
+                                // fetched relative to THIS doc's own URL —
+                                // best-effort, doesn't block the queue.
+                                for (const ref of extractFilenameRefs(xml)) {
+                                    if (isSchemeOrRootedRef(ref) || seenRefs.has(ref)) continue;
+                                    seenRefs.add(ref);
+                                    let texUrl;
+                                    try { texUrl = new URL(ref, url).href; } catch (e) { continue; }
+                                    if (!isSafePresetUrl(texUrl)) continue;
+                                    textureFetches.push((async () => {
+                                        try {
+                                            const r = await fetch(texUrl);
+                                            if (!r.ok) throw new Error('HTTP ' + r.status);
+                                            map[ref] = await r.blob();
+                                        } catch (texErr) {
+                                            console.warn('preset texture fetch failed (falls back to the checker):', ref, texErr);
+                                        }
+                                    })());
+                                }
+                            }
+                            await Promise.all(textureFetches);
+
+                            ingestRef.current(map, baseName);
+                            setPresetsOpen(false);
+                        } catch (e) {
+                            setError('Could not load preset: ' + String(e && e.message || e));
+                        } finally {
+                            setPresetsBusy(false);
+                            setPresetsBusyPath(null);
+                        }
+                    })();
+                });
+            };
+
+            // Toolbar "Export" button (item B1): opens the Export dialog
+            // with a prefilled filename and a preview of which textures a
+            // ZIP export would bundle, instead of exporting immediately.
+            const openExportDialog = () => {
+                if (!parsed) return;
+                setExportDialog({ defaultName: defaultExportBase(), textures: scanExportTextures() });
+            };
+            // Export dialog's onExport — routes to the .mtlx or .zip
+            // writer per the user's format choice, through the same
+            // exportBusyRef-guarded wrappers the toolbar/Export & Continue
+            // flows use. A thrown error here is caught by ExportDialog
+            // itself (js/graph/dialogs.jsx), which leaves the dialog open
+            // (the setError banner above already surfaces the reason) so
+            // the user can retry without re-entering the filename.
+            const handleExportDialogSubmit = async ({ name, format }) => {
+                const ok = format === 'zip'
+                    ? await exportZip(name, (exportDialog && exportDialog.textures.resolved) || [])
+                    : await exportMtlx(name);
+                if (!ok) throw new Error('export failed');
             };
 
             // View-only XML dialog (item 8's "Document" button): same
@@ -1507,7 +1999,15 @@
                         : (restoredValue != null
                             ? { connected: false, authored: true, value: restoredValue }
                             : (reverts
-                                ? { connected: false, authored: false,
+                                // keepRow (flow-state only, never written to the
+                                // document): keeps the just-disconnected port
+                                // visible in 'authored' mode so the user can
+                                // immediately reconnect it — visiblePortsFor
+                                // would otherwise drop it the instant authored
+                                // flips false. The next full rebuild (scope
+                                // change/reload) re-derives visibility from
+                                // document truth and drops this flag.
+                                ? { connected: false, authored: false, keepRow: true,
                                     value: i.defValue !== undefined ? i.defValue : i.value }
                                 : { connected: false })));
                 const allInputs = (n.data.allInputs || n.data.inputs || []).map(upd);
@@ -1684,6 +2184,10 @@
             // onto the target input, replace any edge already feeding it
             // (an input has exactly one source), and add the new edge.
             const onConnect = (params) => {
+                // React Flow only calls onConnect when the drop actually
+                // resolved to a handle — mark the gesture as "connected" so
+                // onConnectEnd skips the port-picker/add-search popup.
+                connectDidRunRef.current = true;
                 if (!isValidConnection(params)) return;
                 const { source, sourceHandle, target, targetHandle } = params;
                 const inputName = String(targetHandle || '').replace(/^in:/, '');
@@ -1772,41 +2276,166 @@
 
             // Drag a connection into EMPTY canvas (item 5): reuse the
             // port-dot double-click add-node flow (openPortAdd) instead of
-            // just dropping the half-made connection on the floor.
+            // just dropping the half-made connection on the floor. Also
+            // handles dropping onto a NODE BODY (not a precise handle) by
+            // offering a port-picker popover.
             // onConnectStart stashes the drag's origin port; onConnectEnd
             // resolves what the drag was actually dropped ON. Mouse: the
             // native event's own target. Touch: touch events keep `target`
             // pinned to wherever the touch STARTED (not where it ended), so
             // the drop point has to be resolved via elementFromPoint
-            // instead. Dropped on a handle/node → onConnect already ran,
-            // nothing to do here; dropped on the pane (class
-            // "react-flow__pane") → open the add-search pre-filtered to
-            // what plugs into the origin port, exactly like a port-dot
-            // double-click.
+            // instead. Dropped on a handle → onConnect already ran (or it
+            // was a zero-distance click), nothing to do here; dropped on a
+            // node body → open a port-picker popover; dropped on the pane
+            // (class "react-flow__pane", covering empty canvas and other
+            // non-node/non-handle descendants like the edges SVG) → open
+            // the add-search pre-filtered to what plugs into the origin
+            // port, exactly like a port-dot double-click.
             const connectOriginRef = React.useRef(null);
-            const onConnectStart = (event, params) => { connectOriginRef.current = params; };
+            // Tracks whether onConnect actually fired for this drag gesture.
+            // React Flow's connectionRadius (~20px) completes a connection
+            // when the drop lands NEAR a handle even though the DOM element
+            // under the cursor is the node body or the pane — so a DOM-only
+            // check in onConnectEnd can't distinguish "connected" from
+            // "dropped loose" and would wrongly pop up the port-picker/
+            // add-search on top of an already-made connection.
+            const connectDidRunRef = React.useRef(false);
+            const onConnectStart = (event, params) => {
+                connectDidRunRef.current = false;
+                connectOriginRef.current = params;
+            };
             const onConnectEnd = (event) => {
                 const origin = connectOriginRef.current;
                 connectOriginRef.current = null;
+                // This drag is an edge UPDATE (disconnect/reconnect) — React Flow runs
+                // the same handle-drag machinery for edge ends, so onConnectStart/End
+                // fire here too. onEdgeUpdateStart already flipped edgeUpdateDone false
+                // (and onEdgeUpdateEnd, which fires after us, will handle the
+                // disconnect); a new-connection drag never touches the flag.
+                if (!edgeUpdateDone.current) return;
+                // The drag actually completed a connection (connectionRadius
+                // snapped it onto a nearby handle) — no popup either way.
+                if (connectDidRunRef.current) return;
                 if (!origin || !origin.nodeId) return;
-                const dropEl = (event && event.changedTouches && event.changedTouches.length)
-                    ? document.elementFromPoint(event.changedTouches[0].clientX, event.changedTouches[0].clientY)
+                // Same touch-vs-mouse split as the drop-target resolution
+                // below: touch events keep `target`/coordinates pinned to
+                // where the touch STARTED, so the actual drop point has to
+                // come from changedTouches instead of event.clientX/Y.
+                const touchPoint = (event && event.changedTouches && event.changedTouches.length)
+                    ? event.changedTouches[0] : null;
+                const dropEl = touchPoint
+                    ? document.elementFromPoint(touchPoint.clientX, touchPoint.clientY)
                     : (event && event.target);
-                if (!dropEl || !dropEl.classList || !dropEl.classList.contains('react-flow__pane')) return;
-                const node = flow.nodes.find((n) => n.id === origin.nodeId);
-                if (!node) return;
-                const isTarget = origin.handleType === 'target';
-                // Handle ids are 'in:'/'out:'-prefixed port names (see
-                // node-component.jsx's <Handle id={'in:' + inp.name}> /
-                // <Handle id={'out:' + out.name}>).
-                const portName = String(origin.handleId || '').replace(isTarget ? /^in:/ : /^out:/, '');
-                const list = isTarget ? (node.data.inputs || []) : (node.data.outputs || []);
-                const port = list.find((p) => p.name === portName);
-                if (!port) return;
-                onPortAddRef.current({
-                    nodeId: origin.nodeId, port: portName, portType: port.type,
-                    dir: isTarget ? 'in' : 'out',
-                });
+                // Drop point in page/client coordinates (item A3) — lets
+                // addNodeFromCatalog place the picked node so the newly
+                // wired handle lands under the cursor instead of the
+                // viewport center; also used to position the node-body
+                // port-picker popover below.
+                const dropClient = touchPoint
+                    ? { x: touchPoint.clientX, y: touchPoint.clientY }
+                    : (event ? { x: event.clientX, y: event.clientY } : null);
+                // FIRST: dropped on a handle → React Flow already handled
+                // it (onConnect ran if the connection was valid); a plain
+                // click on a port is also a zero-distance drag that starts
+                // and ends on its own handle. Either way, nothing to do
+                // here — this also keeps port single-clicks inert so port
+                // DOUBLE-clicks reach the node-component dblclick handlers
+                // (openPortAdd) instead of being swallowed as a drag.
+                if (dropEl && dropEl.closest && dropEl.closest('.react-flow__handle')) return;
+                // SECOND: dropped on a NODE BODY — checked before the pane
+                // below because in React Flow 11 nodes are DOM descendants
+                // of the pane, so closest('.react-flow__pane') would match
+                // every drop otherwise. Offers a port-picker popover
+                // instead of demanding pixel-precise aim at the exact
+                // handle dot. Same node-lookup pattern as the native
+                // dblclick-to-open-scope handler above.
+                const nodeEl = dropEl && dropEl.closest && dropEl.closest('.react-flow__node');
+                if (nodeEl) {
+                    const targetId = nodeEl.getAttribute('data-id');
+                    if (!targetId || targetId === origin.nodeId) return;
+                    const targetNode = flow.nodes.find((n) => n.id === targetId);
+                    if (!targetNode) return;
+                    const candidates = [];
+                    if (origin.handleType === 'source') {
+                        // Dragging FROM an output: candidates are the target
+                        // node's inputs.
+                        const inputs = targetNode.data.allInputs || targetNode.data.inputs || [];
+                        for (const inp of inputs) {
+                            const params = {
+                                source: origin.nodeId, sourceHandle: origin.handleId,
+                                target: targetId, targetHandle: 'in:' + inp.name,
+                            };
+                            if (isValidConnection(params)) {
+                                candidates.push({ label: inp.name, type: inp.type, connected: !!inp.connected, params });
+                            }
+                        }
+                    } else {
+                        // Dragging FROM an input: candidates are the target
+                        // node's outputs.
+                        const outputs = targetNode.data.outputs || [];
+                        for (const out of outputs) {
+                            const params = {
+                                source: targetId, sourceHandle: 'out:' + out.name,
+                                target: origin.nodeId, targetHandle: origin.handleId,
+                            };
+                            if (isValidConnection(params)) {
+                                candidates.push({ label: out.name, type: out.type, connected: false, params });
+                            }
+                        }
+                    }
+                    if (!candidates.length) return; // nothing compatible — silent no-op drop
+                    setPortPicker({
+                        x: dropClient ? dropClient.x : 0, y: dropClient ? dropClient.y : 0,
+                        candidates, targetName: targetNode.data.name,
+                    });
+                    return;
+                }
+                // LAST: dropped on the pane (class "react-flow__pane").
+                // Handles and nodes are already ruled out above, so
+                // closest() is now safe here too and correctly covers pane
+                // descendants that aren't nodes/handles (e.g. the edges SVG
+                // layer, background) as an empty-canvas drop.
+                const paneEl = dropEl && dropEl.closest && dropEl.closest('.react-flow__pane');
+                if (paneEl) {
+                    const node = flow.nodes.find((n) => n.id === origin.nodeId);
+                    if (!node) return;
+                    const isTarget = origin.handleType === 'target';
+                    // Handle ids are 'in:'/'out:'-prefixed port names (see
+                    // node-component.jsx's <Handle id={'in:' + inp.name}> /
+                    // <Handle id={'out:' + out.name}>).
+                    const portName = String(origin.handleId || '').replace(isTarget ? /^in:/ : /^out:/, '');
+                    const list = isTarget ? (node.data.inputs || []) : (node.data.outputs || []);
+                    const port = list.find((p) => p.name === portName);
+                    if (!port) return;
+                    onPortAddRef.current({
+                        nodeId: origin.nodeId, port: portName, portType: port.type,
+                        dir: isTarget ? 'in' : 'out',
+                        dropClient,
+                    });
+                    return;
+                }
+            };
+
+            // Port-picker popover: Escape and outside-pointerdown both
+            // close it, same pattern as ColorSwatch (js/shared/mtlx-ui.jsx)
+            // — the popover itself stops propagation on its own
+            // pointerdown, so this effect only ever sees genuinely-outside
+            // clicks.
+            useEscapeToClose(() => setPortPicker(null), !!portPicker);
+            React.useEffect(() => {
+                if (!portPicker) return undefined;
+                const onDown = (e) => {
+                    if (portPickerRef.current && portPickerRef.current.contains(e.target)) return;
+                    setPortPicker(null);
+                };
+                window.addEventListener('pointerdown', onDown);
+                return () => window.removeEventListener('pointerdown', onDown);
+            }, [portPicker]);
+            // Commit a candidate pick: wire it exactly like a completed
+            // drag-to-handle connection, then close the popover.
+            const pickPort = (candidate) => {
+                onConnect(candidate.params);
+                setPortPicker(null);
             };
 
             // Syntax validity of a candidate MaterialX element name: prefer
@@ -1919,7 +2548,7 @@
                 const { descs, edges } = buildScope(parsed, scope);
                 const rebuilt = toFlow(descs, edges, {
                     portMode: globalPortsRef.current,
-                    onOpenScope: setScope,
+                    onOpenScope: changeScope,
                     onTogglePorts: (id2) => togglePortsRef.current(id2),
                     onPortAdd: (info) => onPortAddRef.current(info),
                 });
@@ -2113,22 +2742,88 @@
                     onTogglePorts: () => togglePortsRef.current(id),
                     onPortAdd: (info) => onPortAddRef.current(info),
                 };
-                // Drop it at the center of the current viewport.
+                // Drop position (item A3): when this pick resolves a
+                // drag-to-empty connection (onConnectEnd stashed a
+                // dropClient on the pending info), place the node so the
+                // handle that's about to be WIRED lands under the cursor,
+                // instead of the viewport center. Plain Tab-palette adds and
+                // port-dot double-clicks (no dropClient) keep the old
+                // center-of-viewport placement.
                 let pos = { x: 40, y: 40 };
                 const inst = rfInstRef.current;
-                const host = panelRef.current;
-                if (inst && host) {
-                    const r = host.getBoundingClientRect();
-                    if (typeof inst.screenToFlowPosition === 'function') {
-                        pos = inst.screenToFlowPosition({ x: r.left + r.width / 2, y: r.top + r.height / 2 });
-                    } else if (typeof inst.project === 'function') {
-                        pos = inst.project({ x: r.width / 2, y: r.height / 2 });
+                const pending = pendingConnRef.current;
+                let placedAtDrop = false;
+                if (pending && pending.dropClient && inst) {
+                    // Mirror wirePendingConnection's own match (inMatch/
+                    // outMatch below) just far enough to predict which row
+                    // the wired port will render at — exact-pixel alignment
+                    // isn't required, landing the right row is.
+                    let wiredRowIndex;
+                    if (pending.dir === 'in') {
+                        // The new node's OUTPUT feeds the existing input —
+                        // its row comes after every visible input row.
+                        const outIdx = Math.max(0, data.outputs.findIndex((o) => o.type === pending.portType));
+                        wiredRowIndex = data.inputs.length + outIdx;
+                    } else {
+                        // dir === 'out': the new node's INPUT is fed by the
+                        // existing output — match against visible inputs.
+                        wiredRowIndex = Math.max(0, data.inputs.findIndex((i) => i.type === pending.portType));
+                    }
+                    const host = panelRef.current;
+                    const hostRect = host ? host.getBoundingClientRect() : null;
+                    const P = typeof inst.screenToFlowPosition === 'function'
+                        ? inst.screenToFlowPosition(pending.dropClient)
+                        : (typeof inst.project === 'function' && hostRect
+                            ? inst.project({ x: pending.dropClient.x - hostRect.left, y: pending.dropClient.y - hostRect.top })
+                            : null);
+                    if (P) {
+                        // Output handles sit on the right edge (dir 'in' —
+                        // new node feeds the drop target — needs its output
+                        // there); input handles sit on the left (dir 'out').
+                        const x = pending.dir === 'in' ? P.x - NODE_W : P.x;
+                        // 38 = header height, 2 = the port list's top
+                        // padding, 22 = row height, 11 = half a row (handle
+                        // vertical center) — see node-component.jsx.
+                        const y = P.y - (38 + 2 + wiredRowIndex * 22 + 11);
+                        pos = { x, y };
+                        placedAtDrop = true;
                     }
                 }
-                pos = {
-                    x: pos.x - NODE_W / 2,
-                    y: pos.y - nodeHeight({ inputs: data.inputs, outputs: data.outputs }) / 2,
-                };
+                if (!placedAtDrop && pending && pending.nodeId) {
+                    // Port-dblclick adds (no dropClient): put the new node beside the
+                    // node whose port was double-clicked — feeding nodes to the LEFT
+                    // (dir 'in': the new node's output feeds the clicked input), consumers
+                    // to the RIGHT (dir 'out'), with a fixed gap.
+                    const origin = flow.nodes.find((n) => n.id === pending.nodeId);
+                    if (origin && origin.position) {
+                        // Deliberately roomier than the auto-layout ranksep
+                        // (70, js/graph/style.jsx) so the new node reads as
+                        // a clearly separate column, as if it were placed by
+                        // a relative auto-layout pass around this node.
+                        const GAP = 120;
+                        pos = {
+                            x: pending.dir === 'in' ? origin.position.x - NODE_W - GAP : origin.position.x + NODE_W + GAP,
+                            y: origin.position.y,
+                        };
+                        placedAtDrop = true;
+                    }
+                }
+                if (!placedAtDrop) {
+                    // Drop it at the center of the current viewport.
+                    const host = panelRef.current;
+                    if (inst && host) {
+                        const r = host.getBoundingClientRect();
+                        if (typeof inst.screenToFlowPosition === 'function') {
+                            pos = inst.screenToFlowPosition({ x: r.left + r.width / 2, y: r.top + r.height / 2 });
+                        } else if (typeof inst.project === 'function') {
+                            pos = inst.project({ x: r.width / 2, y: r.height / 2 });
+                        }
+                    }
+                    pos = {
+                        x: pos.x - NODE_W / 2,
+                        y: pos.y - nodeHeight({ inputs: data.inputs, outputs: data.outputs }) / 2,
+                    };
+                }
                 // Persist the drop position right away (same convention as
                 // onNodeDragStop), so a scope round-trip keeps it.
                 mxSafe(() => { el.setAttribute('xpos', String(Math.round((pos.x / 240) * 10000) / 10000)); return true; }, false);
@@ -2322,15 +3017,20 @@
             // ---- Copy / paste (in-page clipboard, Ctrl/Cmd+C / Ctrl/Cmd+V) --
             // An in-memory snapshot of the selected REAL nodes' full
             // parameter set (collectPorts already reads texture filenames
-            // and their colorspace, plus every connection attribute) —
-            // nodegraphs/interface/output pseudo-nodes aren't copied as a
-            // unit, silently skipped. No system clipboard: in-page only, per
-            // the project's decision.
+            // and their colorspace, plus every connection attribute) plus
+            // any selected nodegraph INSTANCES (g: ids) — those are captured
+            // as just name+pos, their interior deep-copied via
+            // copyContentFrom on paste rather than replayed attribute by
+            // attribute. Interface/output pseudo-nodes still aren't copied
+            // as a unit, silently skipped. No system clipboard: in-page
+            // only, per the project's decision.
             const clipboardRef = React.useRef(null);
+
+            const isCopyableId = (id) => id.indexOf('n:') === 0 || id.indexOf('g:') === 0;
 
             const copySelection = () => {
                 if (!parsed) return;
-                const ids = flow.nodes.filter((n) => n.selected && n.id.indexOf('n:') === 0).map((n) => n.id);
+                const ids = flow.nodes.filter((n) => n.selected && isCopyableId(n.id)).map((n) => n.id);
                 if (!ids.length) return;
                 const idSet = new Set(ids);
                 const container = scopeContainer();
@@ -2343,11 +3043,22 @@
                 // they'd all collapse onto { x: 0, y: 0 } on paste.
                 const flowPosById = {};
                 flow.nodes.forEach((n) => {
-                    if (n.selected && n.id.indexOf('n:') === 0) flowPosById[n.id] = n.position;
+                    if (n.selected && isCopyableId(n.id)) flowPosById[n.id] = n.position;
                 });
                 const entries = [];
                 for (const id of ids) {
                     const name = id.slice(2);
+                    if (id.indexOf('g:') === 0) {
+                        // Nodegraph instance — g: ids only ever appear at
+                        // the document root (buildScope never emits them
+                        // for a nested scope), so the source is always
+                        // looked up on the doc, not scopeContainer().
+                        const gEl = mxSafe(() => parsed.doc.getNodeGraph(name), null);
+                        if (!gEl) continue;
+                        const pos = flowPosById[id] || storedPos(gEl) || { x: 0, y: 0 };
+                        entries.push({ kind: 'nodegraph', name, pos });
+                        continue;
+                    }
                     const el = mxSafe(() => container.getNode(name), null);
                     if (!el) continue;
                     const ports = collectPorts(el);
@@ -2372,6 +3083,7 @@
                         });
                     const pos = flowPosById[id] || storedPos(el) || { x: 0, y: 0 };
                     entries.push({
+                        kind: 'node',
                         name, category: mxElCat(el), type: mxElType(el),
                         nodedef: mxElAttr(el, 'nodedef') || '',
                         version: mxElAttr(el, 'version') || '',
@@ -2386,12 +3098,49 @@
                 if (!clip || !clip.nodes.length || !parsed) return;
                 const container = scopeContainer();
                 if (!container) return;
-                // First pass: create every node with a fresh unique name (the
-                // same mechanism addNodeFromCatalog uses) so the second pass
-                // can remap internal wires old-name → new-name.
+                const doc = parsed.doc;
+                // First pass: create every node/nodegraph with a fresh
+                // unique name (the same mechanism addNodeFromCatalog uses)
+                // so the second pass can remap internal wires old-name →
+                // new-name. Nodegraph entries are handled separately below —
+                // they're always doc-root children (MaterialX nodegraphs
+                // don't nest, same restriction encapsulate/ungroup apply),
+                // so a nodegraph entry is skipped (with a warning) when
+                // pasting into a non-root scope, while any plain-node
+                // entries in the same clipboard still paste normally.
                 const nameMap = {};
                 const created = [];
+                const createdGraphs = [];
+                let skippedNodegraphScope = false;
                 for (const entry of clip.nodes) {
+                    if (entry.kind === 'nodegraph') {
+                        if (scope !== '') { skippedNodegraphScope = true; continue; }
+                        // Look up the ORIGINAL by the name captured at copy
+                        // time — if it's gone/renamed since, skip gracefully
+                        // (same handling as a missing source in the node path).
+                        const originalGraph = mxSafe(() => doc.getNodeGraph(entry.name), null);
+                        if (!originalGraph) continue;
+                        let newName = entry.name;
+                        if (typeof doc.createValidChildName === 'function') {
+                            newName = mxSafe(() => doc.createValidChildName(entry.name), entry.name);
+                        } else {
+                            let i = 1;
+                            while (mxSafe(() => doc.getChild(newName), null)) newName = entry.name + '_copy' + (i++);
+                        }
+                        const newGraph = mxSafe(() => doc.addNodeGraph(newName), null);
+                        if (!newGraph) continue;
+                        // Deep-copy the interior in one call rather than
+                        // replaying attributes port by port.
+                        const copied = mxSafe(() => { newGraph.copyContentFrom(originalGraph); return true; }, false);
+                        if (!copied) {
+                            mxSafe(() => { doc.removeNodeGraph(newName); return true; }, false);
+                            continue;
+                        }
+                        if (parsed.nodegraphs) parsed.nodegraphs.push(newName); // scope dropdown
+                        nameMap[entry.name] = newName;
+                        createdGraphs.push({ el: newGraph, entry, newName });
+                        continue;
+                    }
                     let newName = entry.name;
                     if (typeof container.createValidChildName === 'function') {
                         newName = mxSafe(() => container.createValidChildName(entry.name), entry.name);
@@ -2406,7 +3155,8 @@
                     nameMap[entry.name] = newName;
                     created.push({ el, entry, newName });
                 }
-                if (!created.length) return;
+                if (skippedNodegraphScope) setError('Pasting a nodegraph is only available at the document root.');
+                if (!created.length && !createdGraphs.length) return;
                 // Second pass: write every input now that every new name is
                 // known — internal wires remap to the pasted copies (same
                 // attrs onConnect writes), everything else (literal values,
@@ -2457,6 +3207,12 @@
                     mxSafe(() => { el.setAttribute('xpos', String(Math.round((x / 240) * 10000) / 10000)); return true; }, false);
                     mxSafe(() => { el.setAttribute('ypos', String(Math.round((y / 240) * 10000) / 10000)); return true; }, false);
                 }
+                for (const { el, entry } of createdGraphs) {
+                    const x = center.x + (entry.pos.x - cx);
+                    const y = center.y + (entry.pos.y - cy);
+                    mxSafe(() => { el.setAttribute('xpos', String(Math.round((x / 240) * 10000) / 10000)); return true; }, false);
+                    mxSafe(() => { el.setAttribute('ypos', String(Math.round((y / 240) * 10000) / 10000)); return true; }, false);
+                }
                 setDocRev((r) => r + 1);
                 markDirty();
                 // Rebuild the whole scope from the document — the simplest
@@ -2465,17 +3221,21 @@
                 const { descs, edges } = buildScope(parsed, scope);
                 const rebuilt = toFlow(descs, edges, {
                     portMode: globalPortsRef.current,
-                    onOpenScope: setScope,
+                    onOpenScope: changeScope,
                     onTogglePorts: (id) => togglePortsRef.current(id),
                     onPortAdd: (info) => onPortAddRef.current(info),
                 });
-                const pastedIds = new Set(created.map((c) => 'n:' + c.newName));
+                const pastedIds = new Set(created.map((c) => 'n:' + c.newName)
+                    .concat(createdGraphs.map((c) => 'g:' + c.newName)));
                 setFlow({
                     edges: rebuilt.edges,
                     nodes: rebuilt.nodes.map((n) => (n.selected === pastedIds.has(n.id) ? n
                         : Object.assign({}, n, { selected: pastedIds.has(n.id) }))),
                 });
-                setSelectedId(created.length === 1 ? 'n:' + created[0].newName : null);
+                const totalCreated = created.length + createdGraphs.length;
+                setSelectedId(totalCreated === 1
+                    ? (created.length ? 'n:' + created[0].newName : 'g:' + createdGraphs[0].newName)
+                    : null);
                 setSelectedEdgeId(null);
                 setParamsOpen(true);
             };
@@ -2527,7 +3287,11 @@
                     for (const name of names) {
                         const el = mxSafe(() => doc.getNode(name), null);
                         if (!el) continue;
-                        const ports = collectPorts(el);
+                        // authoredOnly (item A4.2): this snapshot filters
+                        // `i.authored !== false` right below anyway, so skip
+                        // collectPorts' unauthored-nodedef-input enumeration
+                        // altogether instead of building and discarding it.
+                        const ports = collectPorts(el, { authoredOnly: true });
                         entries.push({
                             name, category: mxElCat(el), type: mxElType(el),
                             nodedef: mxElAttr(el, 'nodedef') || '',
@@ -2605,46 +3369,54 @@
                         }
                     }
 
-                    // 5: outbound boundary — one graph output per distinct
-                    // (source node, output name) pair fed to something
-                    // OUTSIDE the selection.
+                    // 5+6 (merged, item A4.1): outbound boundary AND the
+                    // rewrite of every external consumer, in one pass over
+                    // flow.edges instead of two. One graph output is still
+                    // created per distinct (source node, output name) pair
+                    // fed to something OUTSIDE the selection — on the FIRST
+                    // edge that needs it, exactly like the original two-pass
+                    // version's loop 5 (same iteration order over
+                    // flow.edges, so createValidChildName calls happen in
+                    // the same sequence/names as before); every edge that
+                    // shares that pair (including the one that just created
+                    // the pin) then immediately gets its consumer rewritten
+                    // to read from it, exactly like the original loop 6.
+                    // outPins doubling as a per-key cache is what makes the
+                    // single pass safe: a pin, once created, is reused by
+                    // every later edge with the same key, same as before.
+                    const nodesById = new Map(flow.nodes.map((n) => [n.id, n]));
                     const outPins = {}; // "srcName␟outname" -> pin name
                     for (const e of flow.edges) {
                         if (!idSet.has(e.source) || idSet.has(e.target)) continue;
                         const srcName = e.source.slice(2);
                         const outName = String(e.sourceHandle || '').replace(/^out:/, '');
                         const key = srcName + '␟' + outName;
-                        if (outPins[key]) continue;
-                        const innerEl = inner[srcName];
-                        if (!innerEl) continue;
-                        const srcNode = flow.nodes.find((n) => n.id === e.source);
-                        const outs = (srcNode && srcNode.data.outputs) || [];
-                        const type = flowPortType(e.source, e.sourceHandle, true) || entries.find((en) => en.name === srcName).type;
-                        const pinBase = srcName + '_out';
-                        const outPin = mxSafe(() => g.createValidChildName(pinBase), pinBase);
-                        const gout = mxSafe(() => g.addOutput(outPin, type), null);
-                        if (!gout) continue;
-                        if (mxElType(gout) !== type) {
-                            mxSafe(() => {
-                                if (typeof gout.setType === 'function') gout.setType(type);
-                                else gout.setAttribute('type', type);
-                                return true;
-                            }, false);
-                            if (mxElType(gout) !== type) mxSafe(() => { gout.setAttribute('type', type); return true; }, false);
+                        let outPin = outPins[key];
+                        if (!outPin) {
+                            const innerEl = inner[srcName];
+                            if (innerEl) {
+                                const srcNode = nodesById.get(e.source);
+                                const outs = (srcNode && srcNode.data.outputs) || [];
+                                const type = flowPortType(e.source, e.sourceHandle, true) || entries.find((en) => en.name === srcName).type;
+                                const pinBase = srcName + '_out';
+                                const newPin = mxSafe(() => g.createValidChildName(pinBase), pinBase);
+                                const gout = mxSafe(() => g.addOutput(newPin, type), null);
+                                if (gout) {
+                                    if (mxElType(gout) !== type) {
+                                        mxSafe(() => {
+                                            if (typeof gout.setType === 'function') gout.setType(type);
+                                            else gout.setAttribute('type', type);
+                                            return true;
+                                        }, false);
+                                        if (mxElType(gout) !== type) mxSafe(() => { gout.setAttribute('type', type); return true; }, false);
+                                    }
+                                    mxSafe(() => { gout.setAttribute('nodename', srcName); return true; }, false);
+                                    if (outName && outs.length > 1) mxSafe(() => { gout.setAttribute('output', outName); return true; }, false);
+                                    outPin = newPin;
+                                    outPins[key] = outPin;
+                                }
+                            }
                         }
-                        mxSafe(() => { gout.setAttribute('nodename', srcName); return true; }, false);
-                        if (outName && outs.length > 1) mxSafe(() => { gout.setAttribute('output', outName); return true; }, false);
-                        outPins[key] = outPin;
-                    }
-
-                    // 6: rewrite every external target input to read from
-                    // the new graph instead of the (soon to be removed)
-                    // original node.
-                    for (const e of flow.edges) {
-                        if (!idSet.has(e.source) || idSet.has(e.target)) continue;
-                        const srcName = e.source.slice(2);
-                        const outName = String(e.sourceHandle || '').replace(/^out:/, '');
-                        const outPin = outPins[srcName + '␟' + outName];
                         if (!outPin) continue;
                         const point = connectionPoint(e.target, e.targetHandle, true);
                         if (!point) continue;
@@ -2679,7 +3451,7 @@
                     const { descs, edges } = buildScope(parsed, scope);
                     const rebuilt = toFlow(descs, edges, {
                         portMode: globalPortsRef.current,
-                        onOpenScope: setScope,
+                        onOpenScope: changeScope,
                         onTogglePorts: (id) => togglePortsRef.current(id),
                         onPortAdd: (info) => onPortAddRef.current(info),
                     });
@@ -2704,6 +3476,363 @@
                 })();
             };
 
+            // ---- Ungroup (Ctrl/Cmd+Shift+G) — inverse of Encapsulate ---------
+            // Dissolve a collapsed nodegraph back into root-level nodes,
+            // preserving every wire — the mirror image of
+            // encapsulateSelection above: interface-pin connections/
+            // literals flow back onto the recreated nodes' inputs, sibling
+            // wires are recreated verbatim under the (reserved-up-front)
+            // new root names, and every root-level consumer that pointed at
+            // the graph is rewritten to read straight from the node that
+            // used to feed that pin. Root-only, same reason as encapsulate
+            // (MaterialX nodegraphs don't nest). Deferred behind the same
+            // double-rAF + actionBusy idiom for the same reason (the
+            // snapshot/recreate/rewire pass can take a beat on a big graph,
+            // then the docRev bump triggers a full shader regen).
+            const ungroupNodegraph = (gName) => {
+                if (!parsed || !gName) return;
+                if (scope !== '') {
+                    setError('Ungrouping is only available at the document root.');
+                    return;
+                }
+                const doc = parsed.doc;
+                const g = mxSafe(() => doc.getNodeGraph(gName), null);
+                if (!g) return; // stale target (renamed/removed since) — no-op
+                // Implementation graphs (nodedef= functional definitions,
+                // not a user-made group) are never ungroupable.
+                if (mxElAttr(g, 'nodedef')) return;
+                setActionBusy('Ungrouping' + '\u2026');
+                (async () => {
+                    await new Promise((r) => requestAnimationFrame(r));
+                    await new Promise((r) => requestAnimationFrame(r));
+                    // [mtlx-perf] timing — off unless MTLX_PERF_LOG.
+                    const __perfStart = MTLX_PERF_LOG ? performance.now() : 0;
+                    let __nodeCount = 0;
+                    try {
+                        // 1: snapshot EVERYTHING before any mutation —
+                        // collectPorts/storedPos read live document state,
+                        // and step 6 below removes g.
+                        const pinsSnapshot = vecToArray(mxSafe(() => g.getInputs(), [])).map((p) => ({
+                            name: mxElName(p), type: mxElType(p),
+                            value: mxSafe(() => p.getAttribute('value'), ''),
+                            colorspace: mxElAttr(p, 'colorspace'),
+                            nodename: mxElAttr(p, 'nodename'),
+                            nodegraph: mxElAttr(p, 'nodegraph'),
+                            output: mxElAttr(p, 'output'),
+                        }));
+                        const pinsByName = {};
+                        for (const p of pinsSnapshot) pinsByName[p.name] = p;
+
+                        const innerNodes = vecToArray(mxSafe(() => g.getNodes(), []));
+                        const innerNameSet = new Set(innerNodes.map((n) => mxElName(n)));
+                        const entries = innerNodes.map((n) => {
+                            // Full-mode collectPorts (no authoredOnly) —
+                            // this snapshot is filtered to authored inputs
+                            // right below anyway, but also needs `outputs`
+                            // for outputsCount (kept for diagnostics; step 5's
+                            // output= guard no longer conditions on it — see
+                            // 2c below).
+                            const ports = collectPorts(n);
+                            return {
+                                name: mxElName(n), category: mxElCat(n), type: mxElType(n),
+                                nodedef: mxElAttr(n, 'nodedef') || '',
+                                version: mxElAttr(n, 'version') || '',
+                                pos: storedPos(n),
+                                inputs: ports.inputs.filter((i) => i.authored !== false),
+                                outputsCount: ports.outputs.length,
+                            };
+                        });
+                        __nodeCount = entries.length;
+                        const outputsSnapshot = vecToArray(mxSafe(() => g.getOutputs(), [])).map((o) => ({
+                            name: mxElName(o),
+                            nodename: mxElAttr(o, 'nodename'),
+                            output: mxElAttr(o, 'output'),
+                            interfacename: mxElAttr(o, 'interfacename'),
+                        }));
+                        const graphPos = storedPos(g) || { x: 0, y: 0 };
+
+                        if (!entries.length) { setError('This nodegraph has no nodes to ungroup.'); return; }
+
+                        // 2: reserve every recreated node's new root-level
+                        // name BEFORE creating any of them, so collisions
+                        // with EXISTING root names resolve up front.
+                        // createValidChildName is called on the DOC — the
+                        // container the recreated nodes will actually live
+                        // in. It can't see names reserved-but-not-yet-
+                        // created in this very loop, so the `reserved` set
+                        // dedups those by hand (root has "foo", the graph
+                        // has both "foo" and "foo1" — both would otherwise
+                        // resolve to "foo1").
+                        const nameMap = {};
+                        const reserved = new Set();
+                        for (const entry of entries) {
+                            let nm = mxSafe(() => doc.createValidChildName(entry.name), entry.name);
+                            while (reserved.has(nm)) {
+                                nm = mxSafe(() => doc.createValidChildName(nm + '1'), nm + '1');
+                            }
+                            reserved.add(nm);
+                            nameMap[entry.name] = nm;
+                        }
+
+                        // Interior centroid of the inner nodes' stored
+                        // positions — nodes missing a stored pos don't
+                        // contribute (and don't get a position written
+                        // below either; layout picks them up instead).
+                        const posEntries = entries.filter((e) => e.pos);
+                        const centroid = posEntries.length
+                            ? {
+                                x: posEntries.reduce((a, e) => a + e.pos.x, 0) / posEntries.length,
+                                y: posEntries.reduce((a, e) => a + e.pos.y, 0) / posEntries.length,
+                            }
+                            : { x: 0, y: 0 };
+
+                        // 3: recreate every inner node AT ROOT under its
+                        // reserved name.
+                        const created = {}; // old inner name -> new root element
+                        for (const entry of entries) {
+                            const el = mxSafe(() => doc.addNode(entry.category, nameMap[entry.name], entry.type), null);
+                            if (!el) continue;
+                            if (entry.nodedef) mxSafe(() => { el.setAttribute('nodedef', entry.nodedef); return true; }, false);
+                            if (entry.version) mxSafe(() => { el.setAttribute('version', entry.version); return true; }, false);
+                            if (entry.pos) {
+                                const x = entry.pos.x + (graphPos.x - centroid.x);
+                                const y = entry.pos.y + (graphPos.y - centroid.y);
+                                mxSafe(() => { el.setAttribute('xpos', String(x)); return true; }, false);
+                                mxSafe(() => { el.setAttribute('ypos', String(y)); return true; }, false);
+                            }
+                            created[entry.name] = el;
+                        }
+                        if (!Object.keys(created).length) { setError('Could not recreate the grouped nodes.'); return; }
+
+                        // Apply a pin's resolved source — external
+                        // connection, else literal, else nothing — onto
+                        // `point`. Shared by step 4 (an interfacename=pin
+                        // input on a recreated node) and step 5's
+                        // pass-through <output> case (a graph output with
+                        // no nodename of its own, reading a pin straight
+                        // through).
+                        const applyPinSource = (point, pin) => {
+                            clearConnAttrs(point);
+                            if (pin.nodename || pin.nodegraph) {
+                                if (pin.nodename) mxSafe(() => { point.setAttribute('nodename', pin.nodename); return true; }, false);
+                                if (pin.nodegraph) mxSafe(() => { point.setAttribute('nodegraph', pin.nodegraph); return true; }, false);
+                                if (pin.output) mxSafe(() => { point.setAttribute('output', pin.output); return true; }, false);
+                            } else if (pin.value !== '' && pin.value != null) {
+                                mxSafe(() => { mxWriteValue(point, pin.value, pin.type); return true; }, false);
+                                if (pin.colorspace) {
+                                    mxSafe(() => {
+                                        if (typeof point.setColorSpace === 'function') point.setColorSpace(pin.colorspace);
+                                        else point.setAttribute('colorspace', pin.colorspace);
+                                        return true;
+                                    }, false);
+                                }
+                            }
+                            // else: the pin itself carried neither — leave
+                            // `point` as freshly created (unauthored).
+                        };
+
+                        // 4: rewire each recreated node's authored inputs —
+                        // the inverse of encapsulate's inbound-wiring trio.
+                        for (const entry of entries) {
+                            const el = created[entry.name];
+                            if (!el) continue;
+                            for (const inp of entry.inputs) {
+                                if (inp.interfacename) {
+                                    // Interface pin — resolve what THAT pin
+                                    // itself was fed by, one level up.
+                                    const pin = pinsByName[inp.interfacename];
+                                    if (!pin) continue;
+                                    const hasSource = !!(pin.nodename || pin.nodegraph)
+                                        || (pin.value !== '' && pin.value != null);
+                                    if (!hasSource) continue; // pin had neither -> leave input unauthored
+                                    const target = ensureTypedInput(doc, el, inp.name, inp.type);
+                                    if (!target) continue;
+                                    applyPinSource(target, pin);
+                                    continue;
+                                }
+                                if (!inp.nodegraph && inp.nodename && innerNameSet.has(inp.nodename)) {
+                                    // Sibling wire, kept verbatim under the
+                                    // sibling's new root-level name.
+                                    const target = ensureTypedInput(doc, el, inp.name, inp.type);
+                                    if (!target) continue;
+                                    clearConnAttrs(target);
+                                    mxSafe(() => { target.setAttribute('nodename', nameMap[inp.nodename]); return true; }, false);
+                                    if (inp.output) mxSafe(() => { target.setAttribute('output', inp.output); return true; }, false);
+                                    continue;
+                                }
+                                if (inp.nodegraph) {
+                                    // Interior input wired DIRECTLY to another
+                                    // (sibling) nodegraph — outside the graph
+                                    // being dissolved, so its name doesn't
+                                    // change; copy the reference verbatim, no
+                                    // nameMap remapping (mirrors applyPinSource
+                                    // above, which also writes nodename +
+                                    // nodegraph together — MaterialX allows
+                                    // nodegraph= with nodename= to select a
+                                    // node WITHIN that graph).
+                                    const target = ensureTypedInput(doc, el, inp.name, inp.type);
+                                    if (!target) continue;
+                                    clearConnAttrs(target);
+                                    mxSafe(() => { target.setAttribute('nodegraph', inp.nodegraph); return true; }, false);
+                                    if (inp.nodename) mxSafe(() => { target.setAttribute('nodename', inp.nodename); return true; }, false);
+                                    if (inp.output) mxSafe(() => { target.setAttribute('output', inp.output); return true; }, false);
+                                    continue;
+                                }
+                                if (inp.value !== '' && inp.value != null) {
+                                    const target = ensureTypedInput(doc, el, inp.name, inp.type);
+                                    if (!target) continue;
+                                    mxSafe(() => { mxWriteValue(target, inp.value, inp.type); return true; }, false);
+                                    if (inp.colorspace) {
+                                        mxSafe(() => {
+                                            if (typeof target.setColorSpace === 'function') target.setColorSpace(inp.colorspace);
+                                            else target.setAttribute('colorspace', inp.colorspace);
+                                            return true;
+                                        }, false);
+                                    }
+                                }
+                            }
+                        }
+
+                        // 5: rewrite every ROOT-level consumer that pointed
+                        // at g (nodegraph=gName) to read straight from the
+                        // recreated node instead — same "connectables"
+                        // traversal renameElement uses to find every
+                        // element that can carry a reference attribute.
+                        const connectables = (container) => {
+                            const out = [];
+                            for (const n of vecToArray(mxSafe(() => container.getNodes(), []))) {
+                                out.push.apply(out, vecToArray(mxSafe(() => n.getInputs(), [])));
+                            }
+                            out.push.apply(out, vecToArray(mxSafe(() => container.getOutputs(), [])));
+                            // Also recurse into every OTHER nodegraph's
+                            // interior — a node inside a sibling <nodegraph>
+                            // can legally reference this graph too (nodegraph=
+                            // is not restricted to root-level consumers), and
+                            // once this graph is deleted (step 6) any such
+                            // reference left unrewritten would dangle.
+                            for (const sib of vecToArray(mxSafe(() => container.getNodeGraphs(), []))) {
+                                if (mxElName(sib) === gName) continue; // the graph being dissolved itself
+                                for (const n of vecToArray(mxSafe(() => sib.getNodes(), []))) {
+                                    out.push.apply(out, vecToArray(mxSafe(() => n.getInputs(), [])));
+                                }
+                                out.push.apply(out, vecToArray(mxSafe(() => sib.getOutputs(), [])));
+                            }
+                            return out;
+                        };
+                        // Consumers whose `output` attribute is empty AND the
+                        // dissolved graph has more than one output — which
+                        // output they meant can't be resolved, so the
+                        // reference is left as-is (would otherwise dangle
+                        // once the graph is deleted in step 6). Collected
+                        // here and surfaced as a single warning after the
+                        // operation completes, without blocking the rest of
+                        // the ungroup.
+                        const ambiguousConsumers = [];
+                        for (const point of connectables(doc)) {
+                            if (mxElAttr(point, 'nodegraph') !== gName) continue;
+                            const outAttr = mxElAttr(point, 'output');
+                            const outSnap = outAttr
+                                ? outputsSnapshot.find((o) => o.name === outAttr)
+                                : (outputsSnapshot.length === 1 ? outputsSnapshot[0] : null);
+                            if (!outSnap) {
+                                // Identify the consumer as parent.self (e.g.
+                                // a node's "in1" input, or a graph's own
+                                // <output>) — same getParent() pattern used
+                                // elsewhere in this file to name a point.
+                                const par = mxSafe(() => point.getParent(), null);
+                                const parName = par ? mxElName(par) : '';
+                                const ptName = mxElName(point) || '(unnamed)';
+                                ambiguousConsumers.push(parName ? (parName + '.' + ptName) : ptName);
+                                continue;
+                            }
+                            if (outSnap.nodename) {
+                                const newName = nameMap[outSnap.nodename];
+                                if (!newName) continue;
+                                clearConnAttrs(point);
+                                mxSafe(() => { point.setAttribute('nodename', newName); return true; }, false);
+                                // output= whenever the ORIGINAL graph output
+                                // snapshot explicitly named a port — even if
+                                // the recreated source's own outputsCount
+                                // came back 0 (unresolved nodedef), that
+                                // still doesn't mean the source isn't
+                                // multi-output; only omit output= when the
+                                // original never had one to disambiguate.
+                                if (outSnap.output) {
+                                    mxSafe(() => { point.setAttribute('output', outSnap.output); return true; }, false);
+                                }
+                            } else if (outSnap.interfacename) {
+                                // Pass-through output: the graph's <output>
+                                // has no nodename of its own — it reads an
+                                // interface pin straight through, so the
+                                // consumer inherits THAT pin's own external
+                                // connection or literal instead.
+                                const pin = pinsByName[outSnap.interfacename];
+                                if (pin) applyPinSource(point, pin);
+                            }
+                        }
+
+                        // 6: remove the emptied graph RAW — NOT deleteNode(),
+                        // which would sever the very references just
+                        // rewired above (same reasoning as encapsulate's
+                        // raw removeNode for the originals, step 7 there).
+                        mxSafe(() => { doc.removeNodeGraph(gName); return true; }, false)
+                            || mxSafe(() => { doc.removeChild(gName); return true; }, false);
+                        if (parsed.nodegraphs) { // scope dropdown
+                            parsed.nodegraphs = parsed.nodegraphs.filter((n) => n !== gName);
+                        }
+
+                        setDocRev((r) => r + 1);
+                        markDirty();
+
+                        // 7: full scope rebuild — same reason encapsulate/
+                        // pasteClipboard/renameElement all do this: the
+                        // simplest correct way to pick up every recreated
+                        // node and rewritten reference.
+                        const { descs, edges } = buildScope(parsed, scope);
+                        const rebuilt = toFlow(descs, edges, {
+                            portMode: globalPortsRef.current,
+                            onOpenScope: changeScope,
+                            onTogglePorts: (id) => togglePortsRef.current(id),
+                            onPortAdd: (info) => onPortAddRef.current(info),
+                        });
+                        const recreatedIds = Object.keys(created).map((old) => 'n:' + nameMap[old]);
+                        const recreatedIdSet = new Set(recreatedIds);
+                        setFlow({
+                            edges: rebuilt.edges,
+                            nodes: rebuilt.nodes.map((n) => (n.selected === recreatedIdSet.has(n.id) ? n
+                                : Object.assign({}, n, { selected: recreatedIdSet.has(n.id) }))),
+                        });
+                        setSelectedId(recreatedIds.length === 1 ? recreatedIds[0] : null);
+                        setSelectedEdgeId(null);
+                        setParamsOpen(true);
+                        // Surface any ambiguous consumers found in step 5 —
+                        // doesn't block the rest of the operation, which has
+                        // already completed successfully by this point.
+                        if (ambiguousConsumers.length) {
+                            setError('Ungrouped, but ' + ambiguousConsumers.length
+                                + ' reference(s) with no explicit output selector could not be resolved — check the XML view.');
+                        }
+                    } catch (e) {
+                        setError('Ungroup failed: ' + String((e && e.message) || e));
+                    } finally {
+                        setActionBusy(null);
+                        if (MTLX_PERF_LOG) {
+                            console.log('[mtlx-perf] ungroup: '
+                                + (performance.now() - __perfStart).toFixed(1) + 'ms (' + __nodeCount + ' nodes)');
+                        }
+                    }
+                })();
+            };
+
+            // No-arg entry point for the Ctrl/Cmd+Shift+G keybind: applies
+            // to the single selected g: node (selectedId — this trigger is
+            // inherently single-target, unlike encapsulate's multi-select),
+            // no-op otherwise.
+            const ungroupSelection = () => {
+                if (!selectedId || selectedId.indexOf('g:') !== 0) return;
+                ungroupNodegraph(selectedId.slice(2));
+            };
+
             // Kept current every render so the [] -dep Ctrl/Cmd+C / +V / +G
             // keydown handlers below never call a stale closure (same
             // trick as openAddRef/deleteSelectionRef).
@@ -2713,6 +3842,8 @@
             pasteClipboardRef.current = pasteClipboard;
             const encapsulateSelectionRef = React.useRef(encapsulateSelection);
             encapsulateSelectionRef.current = encapsulateSelection;
+            const ungroupRef = React.useRef(ungroupSelection);
+            ungroupRef.current = ungroupSelection;
 
             // Ctrl/Cmd+C / Ctrl/Cmd+V: copy / paste the selected nodes.
             // Same focus rules as the other global shortcuts — typing in an
@@ -2738,12 +3869,13 @@
             }, []);
 
             // Ctrl/Cmd+G: encapsulate the current multi-selection into a
-            // new nodegraph. preventDefault is required here — the browser
-            // binds Ctrl/Cmd+G to "find again" otherwise.
+            // new nodegraph. Ctrl/Cmd+Shift+G: the inverse — ungroup the
+            // selected nodegraph. preventDefault is required here — the
+            // browser binds Ctrl/Cmd+G to "find again" otherwise.
             React.useEffect(() => {
                 const onKey = (e) => {
                     if (!activeRef.current) return;
-                    if ((e.key !== 'g' && e.key !== 'G') || !(e.ctrlKey || e.metaKey) || e.shiftKey || e.altKey) return;
+                    if ((e.key !== 'g' && e.key !== 'G') || !(e.ctrlKey || e.metaKey) || e.altKey) return;
                     const t = e.target;
                     const tag = ((t && t.tagName) || '').toLowerCase();
                     if (tag === 'input' || tag === 'textarea' || tag === 'select') return;
@@ -2752,7 +3884,8 @@
                         || (panelRef.current && t instanceof Node && panelRef.current.contains(t));
                     if (!inStage) return;
                     e.preventDefault();
-                    encapsulateSelectionRef.current();
+                    if (e.shiftKey) ungroupRef.current();
+                    else encapsulateSelectionRef.current();
                 };
                 window.addEventListener('keydown', onKey);
                 return () => window.removeEventListener('keydown', onKey);
@@ -2955,6 +4088,70 @@
                     ? [{ name: 'value', type: displayNode.data.type,
                          value: displayNode.data.value || '', connected: false }]
                     : (displayNode.data.allInputs || displayNode.data.inputs || []));
+            // Group panelInputs by uifolder (item F2.3): inputs without a
+            // uifolder render first, ungrouped, exactly as before; foldered
+            // ones are bucketed under a collapsible header, preserving the
+            // FIRST-appearance order of each folder name. A node with no
+            // uifolder attrs anywhere yields an empty `folders` array, so
+            // the render below falls back to the old flat list untouched.
+            const panelParamGroups = React.useMemo(() => {
+                // Sort by nodedef declaration order (item F3.0) before
+                // grouping, so a uifolder declared late in the nodedef
+                // (e.g. OpenPBR's "Geometry") doesn't render early just
+                // because its inputs happened to be authored/appended
+                // first in collectPorts' returned array (model.jsx) — that
+                // array's own order is left untouched since node cards,
+                // wiredRowIndex drop placement, and visiblePortsFor all
+                // consume it directly; this sorted COPY is only for the
+                // panel's grouping below. Array.prototype.sort is a stable
+                // sort in all modern engines, so inputs sharing a defIndex
+                // (or both lacking one) keep their relative order. Inputs
+                // absent from the nodedef (defIndex undefined — custom or
+                // legacy attrs) sink to the end via the Infinity fallback.
+                const sortedInputs = panelInputs.slice().sort((a, b) => {
+                    const ai = a.defIndex === undefined ? Infinity : a.defIndex;
+                    const bi = b.defIndex === undefined ? Infinity : b.defIndex;
+                    return ai - bi;
+                });
+                const ungrouped = [];
+                const folderOrder = [];
+                const byFolder = new Map();
+                for (const inp of sortedInputs) {
+                    const folder = inp.uifolder;
+                    if (!folder) { ungrouped.push(inp); continue; }
+                    if (!byFolder.has(folder)) { byFolder.set(folder, []); folderOrder.push(folder); }
+                    byFolder.get(folder).push(inp);
+                }
+                return { ungrouped, folders: folderOrder.map((name) => ({ name, inputs: byFolder.get(name) })) };
+            }, [panelInputs]);
+            // Open/closed state per folder name, default expanded (a name
+            // absent from this map reads as open — see `!== false` below).
+            // Reset whenever the displayed node changes, same key as the
+            // rename-edit reset above, so a folder collapsed on one node
+            // doesn't leak its state onto an unrelated node reusing a name.
+            const [panelFoldersOpen, setPanelFoldersOpen] = React.useState({});
+            React.useEffect(() => { setPanelFoldersOpen({}); }, [displayNode && displayNode.id]);
+            // One ParamRow, shared by the ungrouped list and every folder
+            // below so the markup doesn't drift between the two — only
+            // called once displayNode is known truthy (both call sites are
+            // inside the `displayNode ? [...] : (...)` branch).
+            const renderParamRow = (inp) => (
+                <ParamRow
+                    key={displayNode.id + '/' + inp.name}
+                    nodeId={displayNode.id}
+                    inp={inp}
+                    readOnly={panelReadOnly}
+                    sourceId={inp.connected ? sourceOfInput(displayNode.id, inp.name) : null}
+                    onJump={(id) => focusNode(id, true)}
+                    onCommit={(v) => applyParamEdit(displayNode.id, inp.name, v)}
+                    onLive={panelReadOnly || inp.connected ? undefined : (v) => { tryFastUniformUpdate(displayNode.id, inp.name, v, inp.type); }}
+                    onPickFile={(f) => {
+                        registerPickedFile(f);
+                        applyParamEdit(displayNode.id, inp.name, f.name);
+                    }}
+                    onSetColorspace={(cs) => applyColorspace(displayNode.id, inp.name, cs, inp.type)}
+                />
+            );
 
             // ---- Signature / version picker -------------------------------
             // Every nodedef sharing the displayed node's category is grouped
@@ -3016,6 +4213,19 @@
                 if (displayNode && !renameIssue(displayNode.id, nameDraft)) renameElement(displayNode.id, nameDraft);
                 setNameEditing(false);
             };
+
+            // Port-picker popover content (item 2) — portaled straight onto
+            // <body> below via ReactDOM.createPortal, same rationale as
+            // ColorSwatch's popover (js/shared/mtlx-ui.jsx): several
+            // ancestors here use `backdrop-blur`, which establishes a new
+            // containing block for `position: fixed` descendants, so a
+            // plain in-place fixed popover would land off-target. The
+            // popover itself (filter input, row list, footer hint) is the
+            // PortPickerPopover component defined above, styled to match
+            // AddNodeSearch (js/graph/panels.jsx).
+            const portPickerPopover = portPicker
+                ? <PortPickerPopover portPicker={portPicker} rootRef={portPickerRef} onPick={pickPort} />
+                : null;
 
             return (
                 <div ref={panelRef} className="absolute inset-0 bg-gray-900 overflow-hidden">
@@ -3080,6 +4290,20 @@
                             />
                         </ReactFlowComp>
                     </div>
+
+                    {/* Presets dialog ("Presets" button). Rendered BEFORE the
+                        unsaved-changes dialog below (same z-50 overlay class,
+                        but earlier in the DOM) so that dialog — which
+                        loadPreset's confirmReplace can pop up while this one
+                        is still open mid-fetch — paints on top instead of
+                        being hidden behind it. */}
+                    <PresetsDialog
+                        open={presetsOpen}
+                        onClose={() => setPresetsOpen(false)}
+                        onPick={loadPreset}
+                        busy={presetsBusy}
+                        busyPath={presetsBusyPath}
+                    />
 
                     {/* Unsaved-changes dialog: gates Import / drag-drop of a
                         new .mtlx / switching documents while dirty. See
@@ -3213,10 +4437,26 @@
                                 <span>Import</span>
                                 <input type="file" multiple className="hidden" onChange={onPickFiles} />
                             </label>
+                            <button
+                                onClick={() => setPresetsOpen(true)}
+                                title="Load a curated official MaterialX example document"
+                                className="h-7 inline-flex items-center gap-1.5 text-[11px] px-2 rounded border bg-gray-800/80 backdrop-blur border-gray-600 text-gray-300 hover:bg-gray-700/80 transition-colors"
+                            >
+                                {/* 'environment' renders as a framed photo/landscape
+                                    glyph (see MTLX_ICON_PATHS in mtlx-engine.js) — reads
+                                    as "browse a gallery of ready-made looks" and, unlike
+                                    file-code/file-plus/file-upload/file-download already
+                                    in this same New/Import/Export cluster, isn't reused
+                                    anywhere else in the graph editor's own toolbar (its
+                                    only other use is the unrelated env-map-background
+                                    toggle in the preview panel, js/shared/mtlx-ui.jsx). */}
+                                <MtlxIcon name="environment" className="w-3.5 h-3.5" />
+                                <span>Presets</span>
+                            </button>
                             {parsed && (
                                 <button
-                                    onClick={() => exportMtlx()}
-                                    title="Download the current document as .mtlx \u2014 edits, connections and layout positions included"
+                                    onClick={openExportDialog}
+                                    title="Export the current document as .mtlx or a .zip with textures \u2014 edits, connections and layout positions included"
                                     className="h-7 inline-flex items-center gap-1 text-[11px] px-2 rounded border bg-gray-800/80 backdrop-blur border-gray-600 text-gray-300 hover:bg-gray-700/80 transition-colors"
                                 >
                                     <MtlxIcon name="file-download" className="w-3.5 h-3.5" />
@@ -3387,6 +4627,12 @@
                     {/* Keybinds reference popup. */}
                     {helpOpen && <KeybindsHelp onClose={() => setHelpOpen(false)} active={active} />}
 
+                    {/* Port-picker popover (item 2): a connection dragged onto
+                        a node body (not a specific handle) opens this instead
+                        of silently dropping. Portaled onto <body> — see
+                        portPickerPopover above for why. */}
+                    {portPicker && ReactDOM.createPortal(portPickerPopover, document.body)}
+
                     {/* View-only XML dialog ("Document" button, item 8). */}
                     {xmlDialogOpen && (
                         <XmlDialog xml={xmlDialogXml} open={xmlDialogOpen} onClose={() => setXmlDialogOpen(false)} />
@@ -3395,6 +4641,17 @@
                     {/* Validation popup ("Validate" button, item 9). */}
                     {validateOpen && (
                         <ValidateDialog result={validateResult} open={validateOpen} onClose={() => setValidateOpen(false)} />
+                    )}
+
+                    {/* Export dialog ("Export" button, item B1). */}
+                    {exportDialog && (
+                        <ExportDialog
+                            open={!!exportDialog}
+                            defaultName={exportDialog.defaultName}
+                            textures={exportDialog.textures}
+                            onExport={handleExportDialogSubmit}
+                            onClose={() => setExportDialog(null)}
+                        />
                     )}
 
                     {/* In-tab docs viewer, opened from the parameter panel's
@@ -3438,6 +4695,15 @@
                                                 : 'bg-gray-900/70 border-gray-600 text-gray-300 hover:bg-gray-700/80')}
                                     >
                                         <MtlxIcon name={pinnedTarget ? 'pin-filled' : 'pin'} className="w-3.5 h-3.5" />
+                                    </button>
+                                }
+                                trailingChildren={
+                                    <button
+                                        onClick={sendToViewer}
+                                        title="Open in Material Viewer"
+                                        className="h-6 inline-flex items-center text-[11px] px-2 rounded border transition-colors bg-gray-800/80 border-gray-600 text-gray-300 hover:bg-gray-700/80"
+                                    >
+                                        <MtlxIcon name="share" className="w-3.5 h-3.5" />
                                     </button>
                                 }
                             />
@@ -3617,26 +4883,41 @@
                                         )}
                                     </div>
                                 ) : displayNode ? [
+                                    // Ungroup (inverse of Ctrl+G) — only for a
+                                    // single selected nodegraph at the document
+                                    // root, same gate as the keybind.
+                                    displayNode.data.kind === 'nodegraph' && scope === '' && selectedIds.length <= 1 && (
+                                        <div key="ungroup" className="py-1.5">
+                                            <button
+                                                onClick={() => ungroupNodegraph(displayNode.data.name)}
+                                                title="Dissolve this nodegraph back into its nodes, keeping every connection"
+                                                className="h-7 text-[11px] px-2 rounded border bg-gray-800/80 border-gray-600 text-gray-300 hover:bg-gray-700/80 transition-colors"
+                                            >
+                                                Ungroup (Ctrl+Shift+G)
+                                            </button>
+                                        </div>
+                                    ),
                                     !panelInputs.length && (
                                         <div key="none" className="text-[11px] text-gray-500 py-2">This node has no parameters.</div>
                                     ),
-                                    panelInputs.map((inp) => (
-                                        <ParamRow
-                                            key={displayNode.id + '/' + inp.name}
-                                            nodeId={displayNode.id}
-                                            inp={inp}
-                                            readOnly={panelReadOnly}
-                                            sourceId={inp.connected ? sourceOfInput(displayNode.id, inp.name) : null}
-                                            onJump={(id) => focusNode(id, true)}
-                                            onCommit={(v) => applyParamEdit(displayNode.id, inp.name, v)}
-                                            onLive={panelReadOnly || inp.connected ? undefined : (v) => { tryFastUniformUpdate(displayNode.id, inp.name, v, inp.type); }}
-                                            onPickFile={(f) => {
-                                                registerPickedFile(f);
-                                                applyParamEdit(displayNode.id, inp.name, f.name);
-                                            }}
-                                            onSetColorspace={(cs) => applyColorspace(displayNode.id, inp.name, cs, inp.type)}
-                                        />
-                                    )),
+                                    panelParamGroups.ungrouped.map(renderParamRow).concat(
+                                        panelParamGroups.folders.map((f) => {
+                                            const open = panelFoldersOpen[f.name] !== false;
+                                            return (
+                                                <div key={'folder:' + f.name} className="py-1 border-t border-gray-700/70 mt-1 pt-1">
+                                                    <button
+                                                        type="button"
+                                                        onClick={() => setPanelFoldersOpen((prev) => Object.assign({}, prev, { [f.name]: !open }))}
+                                                        className="w-full flex items-center gap-1.5 py-1 text-[11px] font-mono text-gray-300 hover:text-gray-100"
+                                                    >
+                                                        <MtlxIcon name={open ? 'chevron-down' : 'chevron-right'} className="flex-none w-3.5 h-3.5 text-gray-500" />
+                                                        <span className="truncate">{f.name}</span>
+                                                    </button>
+                                                    {open && f.inputs.map(renderParamRow)}
+                                                </div>
+                                            );
+                                        })
+                                    ),
                                 ] : (
                                     <div className="text-[11px] text-gray-500 py-2">
                                         Click a node to inspect and edit its parameters.

--- a/js/graph/dialogs.jsx
+++ b/js/graph/dialogs.jsx
@@ -28,6 +28,7 @@
             { keys: 'Ctrl/Cmd + C', desc: 'Copy the selected node(s)' },
             { keys: 'Ctrl/Cmd + V', desc: 'Paste the copied node(s)' },
             { keys: 'Ctrl/Cmd + G', desc: 'Encapsulate the selected nodes into a nodegraph' },
+            { keys: 'Ctrl/Cmd + Shift + G', desc: 'Ungroup the selected nodegraph (dissolve it, keeping connections)' },
             { keys: 'Ctrl/Cmd + Z', desc: 'Undo the last document edit' },
             { keys: 'Ctrl/Cmd + Shift + Z (or Ctrl/Cmd + Y)', desc: 'Redo' },
             { keys: 'Esc', desc: 'Close the add-node search, or exit full screen' },
@@ -266,4 +267,219 @@
             );
         }
 
-Object.assign(window, { KeybindsHelp, DocsDialog, XmlDialog, ValidateDialog });
+        // Export dialog (toolbar "Export" button): lets the user choose a
+        // filename and a format before writing anything out. Two formats:
+        // a bare .mtlx (identical to the old one-click Export), or a .zip
+        // that bundles the .mtlx alongside every texture the CALLER found a
+        // session-file match for (`textures.resolved`); refs the caller
+        // couldn't match are listed under `textures.unresolved` as a
+        // non-blocking warning — they simply won't be packaged. `onExport`
+        // does the actual work and returns a promise; the Export button
+        // stays disabled/busy until it settles, and the dialog only closes
+        // on success (a thrown/rejected promise leaves it open so the user
+        // can retry, matching ValidateDialog's request/render split but for
+        // a user-triggered action instead of an effect).
+        function ExportDialog({ open, onClose, defaultName, textures, onExport }) {
+            const [name, setName] = React.useState(defaultName || '');
+            const [format, setFormat] = React.useState('mtlx');
+            const [busy, setBusy] = React.useState(false);
+            useEscapeToClose(onClose, open && !busy);
+
+            // Reset to the caller's latest defaults each time the dialog is
+            // (re)opened — mirrors XmlDialog/ValidateDialog's "computed once
+            // per open by the caller" contract, just applied to local state
+            // instead of a prop that's recomputed from scratch.
+            const wasOpen = React.useRef(false);
+            React.useEffect(() => {
+                if (open && !wasOpen.current) {
+                    setName(defaultName || '');
+                    setFormat('mtlx');
+                    setBusy(false);
+                }
+                wasOpen.current = open;
+            }, [open, defaultName]);
+
+            if (!open) return null;
+
+            const resolved = (textures && textures.resolved) || [];
+            const unresolved = (textures && textures.unresolved) || [];
+            const zipDisabledTitle = resolved.length === 0
+                ? 'No textures in this document matched a file from this session — nothing to zip.'
+                : '';
+            const trimmedName = name.trim();
+
+            const doExport = async () => {
+                if (!trimmedName || busy) return;
+                setBusy(true);
+                try {
+                    await onExport({ name: trimmedName, format });
+                    onClose();
+                } catch (e) {
+                    // Leave the dialog open so the user can see the error
+                    // (surfaced by the caller via its own error state) and
+                    // retry without re-entering the filename.
+                } finally {
+                    setBusy(false);
+                }
+            };
+
+            return (
+                <div className="absolute inset-0 z-50 flex items-center justify-center bg-gray-950/70"
+                    onMouseDown={busy ? undefined : onClose}>
+                    <div className="bg-gray-800/95 backdrop-blur border border-gray-600 rounded-lg shadow-2xl w-[26rem] max-w-[90%] max-h-[80%] overflow-hidden flex flex-col"
+                        onMouseDown={(e) => e.stopPropagation()}>
+                        <div className="flex items-center justify-between px-4 py-2.5 border-b border-gray-700 bg-gray-900/70">
+                            <span className="text-[13px] font-bold text-gray-100">Export</span>
+                            <button onClick={onClose} disabled={busy} title="Close"
+                                className="text-gray-400 hover:text-gray-200 leading-none text-lg px-1 disabled:opacity-40">{'×'}</button>
+                        </div>
+                        <div className="overflow-y-auto custom-scrollbar px-4 py-3 space-y-3 text-[12px]">
+                            <label className="block space-y-1">
+                                <span className="text-gray-400">File name</span>
+                                <input
+                                    type="text"
+                                    value={name}
+                                    autoFocus
+                                    spellCheck={false}
+                                    onChange={(e) => setName(e.target.value)}
+                                    onKeyDown={(e) => { if (e.key === 'Enter' && trimmedName && !busy) doExport(); }}
+                                    className="w-full bg-gray-900 border border-gray-600 rounded px-2 py-1 text-gray-200 font-mono"
+                                />
+                            </label>
+                            <div className="space-y-1.5">
+                                <label className="flex items-center gap-2 cursor-pointer">
+                                    <input type="radio" name="export-format" checked={format === 'mtlx'}
+                                        onChange={() => setFormat('mtlx')} className="accent-blue-500" />
+                                    <span className="text-gray-200">MaterialX document (.mtlx)</span>
+                                </label>
+                                <label className={'flex items-center gap-2 ' + (resolved.length === 0 ? 'cursor-not-allowed' : 'cursor-pointer')}
+                                    title={zipDisabledTitle}>
+                                    <input type="radio" name="export-format" checked={format === 'zip'}
+                                        disabled={resolved.length === 0}
+                                        onChange={() => setFormat('zip')} className="accent-blue-500" />
+                                    <span className={resolved.length === 0 ? 'text-gray-500' : 'text-gray-200'}>
+                                        ZIP with textures (.zip)
+                                    </span>
+                                </label>
+                            </div>
+                            {resolved.length > 0 && (
+                                <div className="text-gray-500 text-[11px]">
+                                    {resolved.length} texture{resolved.length === 1 ? '' : 's'} will be packaged with the .zip.
+                                </div>
+                            )}
+                            {unresolved.length > 0 && (
+                                <div className="rounded border border-amber-700/60 bg-amber-900/20 px-2.5 py-2 space-y-1">
+                                    <div className="text-amber-400 font-bold text-[11px]">
+                                        Not found in this session, will not be packaged:
+                                    </div>
+                                    <ul className="list-disc list-inside space-y-0.5 text-amber-200/90 font-mono text-[11px]">
+                                        {unresolved.map((ref, i) => <li key={i}>{ref}</li>)}
+                                    </ul>
+                                </div>
+                            )}
+                        </div>
+                        <div className="flex justify-end gap-2 px-4 py-2.5 border-t border-gray-700 bg-gray-900/70">
+                            <button
+                                onClick={onClose}
+                                disabled={busy}
+                                className="h-7 text-[11px] px-2.5 rounded border bg-gray-800/80 border-gray-600 text-gray-300 hover:bg-gray-700/80 transition-colors disabled:opacity-40"
+                            >Cancel</button>
+                            <button
+                                onClick={doExport}
+                                disabled={busy || !trimmedName}
+                                className="h-7 text-[11px] px-2.5 rounded border bg-blue-600/70 border-blue-500 text-white hover:bg-blue-500/70 transition-colors disabled:opacity-40"
+                            >{busy ? 'Exporting…' : 'Export'}</button>
+                        </div>
+                    </div>
+                </div>
+            );
+        }
+
+        // Curated MaterialX example documents (item F3.2's "Presets"
+        // toolbar button), fetched straight from the official repo at the
+        // SAME tag/base URL the app already uses for its default startup
+        // document (js/graph/model.jsx's DEFAULT_GRAPH_URL) — so a preset
+        // pick behaves exactly like that first-load fetch, just chosen by
+        // the user instead of hardcoded. Every path below was verified to
+        // exist at this tag (HTTP 200 via GitHub's contents API and a
+        // direct raw.githubusercontent.com request) before being added;
+        // candidates that 404'd (e.g. StandardSurface's plain
+        // "standard_surface_brass_tiled.mtlx" — only the "_look_" variant
+        // exists at this tag; OpenPbr's "open_pbr_glass_tinted.mtlx" and
+        // "open_pbr_anisotropy.mtlx" — no such files at this tag) were
+        // dropped rather than guessed at.
+        const MTLX_PRESETS_BASE =
+            'https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/' +
+            'v1.39.5/resources/Materials/Examples/';
+        const MTLX_PRESETS = [
+            { label: 'Marble (solid)', desc: 'Noise-driven solid marble veining', path: 'StandardSurface/standard_surface_marble_solid.mtlx' },
+            { label: 'Jade', desc: 'Translucent jade stone with subsurface scattering', path: 'StandardSurface/standard_surface_jade.mtlx' },
+            { label: 'Gold', desc: 'Polished gold metal', path: 'StandardSurface/standard_surface_gold.mtlx' },
+            { label: 'Plastic', desc: 'Glossy colored plastic', path: 'StandardSurface/standard_surface_plastic.mtlx' },
+            { label: 'Copper', desc: 'Brushed copper metal', path: 'StandardSurface/standard_surface_copper.mtlx' },
+            { label: 'Car paint', desc: 'Multi-layer automotive car paint', path: 'StandardSurface/standard_surface_carpaint.mtlx' },
+            { label: 'Chess set', desc: 'Full chess set scene with several materials', path: 'StandardSurface/standard_surface_chess_set.mtlx' },
+            { label: 'Brass (tiled look)', desc: 'Tiled brass surface via a shared material look', path: 'StandardSurface/standard_surface_look_brass_tiled.mtlx' },
+            { label: 'Wood (tiled)', desc: 'Tiled wood grain surface', path: 'StandardSurface/standard_surface_wood_tiled.mtlx' },
+            { label: 'Velvet', desc: 'Sheen-driven velvet fabric', path: 'StandardSurface/standard_surface_velvet.mtlx' },
+            { label: 'Chrome', desc: 'Mirror-like chrome metal', path: 'StandardSurface/standard_surface_chrome.mtlx' },
+            { label: 'Glass', desc: 'Clear refractive glass', path: 'StandardSurface/standard_surface_glass.mtlx' },
+            { label: 'OpenPBR default', desc: 'The OpenPBR surface shader at its defaults', path: 'OpenPbr/open_pbr_default.mtlx' },
+            { label: 'OpenPBR car paint', desc: 'Multi-layer automotive car paint (OpenPBR)', path: 'OpenPbr/open_pbr_carpaint.mtlx' },
+            { label: 'OpenPBR honey', desc: 'Translucent honey with subsurface scattering (OpenPBR)', path: 'OpenPbr/open_pbr_honey.mtlx' },
+            { label: 'OpenPBR velvet', desc: 'Sheen-driven velvet fabric (OpenPBR)', path: 'OpenPbr/open_pbr_velvet.mtlx' },
+            { label: 'OpenPBR pearl', desc: 'Iridescent pearl surface (OpenPBR)', path: 'OpenPbr/open_pbr_pearl.mtlx' },
+            { label: 'OpenPBR soap bubble', desc: 'Thin-film iridescence on a soap bubble (OpenPBR)', path: 'OpenPbr/open_pbr_soapbubble.mtlx' },
+        ];
+
+        // Presets dialog (toolbar "Presets" button): a scrollable curated
+        // list of official MaterialX example documents. Clicking a row
+        // hands the preset straight to the caller (`onPick`) — this
+        // component owns no fetching itself, matching ExportDialog's
+        // "caller does the async work" split. `busy` (driven by the
+        // caller while it fetches) disables every row and shows a spinner
+        // on whichever one triggered it (`busyPath`) so the user gets
+        // feedback without the dialog needing its own network code. Same
+        // backdrop/Esc/stopPropagation contract as the other dialogs.
+        function PresetsDialog({ open, onClose, onPick, busy, busyPath }) {
+            useEscapeToClose(onClose, open && !busy);
+            if (!open) return null;
+            return (
+                <div className="absolute inset-0 z-50 flex items-center justify-center bg-gray-950/70"
+                    onMouseDown={busy ? undefined : onClose}>
+                    <div className="bg-gray-800/95 backdrop-blur border border-gray-600 rounded-lg shadow-2xl w-[28rem] max-w-[90%] max-h-[80%] overflow-hidden flex flex-col"
+                        onMouseDown={(e) => e.stopPropagation()}>
+                        <div className="flex items-center justify-between px-4 py-2.5 border-b border-gray-700 bg-gray-900/70">
+                            <span className="text-[13px] font-bold text-gray-100">Presets</span>
+                            <button onClick={onClose} disabled={busy} title="Close"
+                                className="text-gray-400 hover:text-gray-200 leading-none text-lg px-1 disabled:opacity-40">{'×'}</button>
+                        </div>
+                        <div className="overflow-y-auto custom-scrollbar px-2 py-2 text-[12px]">
+                            {MTLX_PRESETS.map((preset) => {
+                                const rowBusy = busy && busyPath === preset.path;
+                                return (
+                                    <button
+                                        key={preset.path}
+                                        onClick={() => onPick(preset)}
+                                        disabled={busy}
+                                        title={preset.path}
+                                        className={'w-full text-left px-2.5 py-2 rounded flex items-center justify-between gap-2 transition-colors '
+                                            + (busy ? 'cursor-not-allowed opacity-60' : 'hover:bg-gray-700/70 cursor-pointer')}
+                                    >
+                                        <span className="min-w-0">
+                                            <span className="block text-gray-100 font-medium truncate">{preset.label}</span>
+                                            <span className="block text-gray-400 text-[11px] truncate">{preset.desc}</span>
+                                        </span>
+                                        {rowBusy && (
+                                            <span className="shrink-0 w-3.5 h-3.5 rounded-full border-2 border-gray-500 border-t-blue-400 animate-spin" />
+                                        )}
+                                    </button>
+                                );
+                            })}
+                        </div>
+                    </div>
+                </div>
+            );
+        }
+
+Object.assign(window, { KeybindsHelp, DocsDialog, XmlDialog, ValidateDialog, ExportDialog, PresetsDialog, MTLX_PRESETS, MTLX_PRESETS_BASE });

--- a/js/graph/model.jsx
+++ b/js/graph/model.jsx
@@ -183,7 +183,16 @@
         // value (defValue) and an `authored` flag; inputs the document does
         // not author are appended from the nodedef (authored: false) so the
         // "all inputs" display mode can show them.
-        const collectPorts = (el) => {
+        // opts.authoredOnly (item A4.2, default false/undefined — every
+        // existing caller passes no second arg, so behavior there is
+        // byte-identical): skip the unauthored-nodedef-input enumeration
+        // below when the caller only wants what's actually written in the
+        // document — e.g. encapsulateSelection's snapshot immediately
+        // filters `i.authored !== false` right after calling collectPorts,
+        // so building those nodedef-default entries just to discard them
+        // is wasted WASM round-tripping on a big selection.
+        const collectPorts = (el, opts) => {
+            const authoredOnly = !!(opts && opts.authoredOnly);
             let defMemo; // undefined = not looked up yet; null = no def found
             const nodeDef = () => {
                 if (defMemo === undefined) {
@@ -214,6 +223,7 @@
                 uisoftmin: mxElAttr(dIn, 'uisoftmin'), uisoftmax: mxElAttr(dIn, 'uisoftmax'),
                 enumNames: mxElAttr(dIn, 'enum'), enumValues: mxElAttr(dIn, 'enumvalues'),
                 defColorspace: mxElAttr(dIn, 'colorspace'),
+                uifolder: mxElAttr(dIn, 'uifolder'),
             };
             // Node output type(s), resolved BEFORE the inputs below so each
             // input can be flagged colorManaged — colorspace only means
@@ -235,6 +245,30 @@
             const isColorType = (t) => t === 'color3' || t === 'color4';
             const colorManagedFor = (type) => (type === 'filename' && isColorOutput) || isColorType(type);
 
+            // name -> declaration index in the nodedef's input list (active
+            // inputs first, then plain inputs; first-seen name wins — same
+            // list the unauthored branch below iterates). Built independently
+            // of authoredOnly/def0 above so uifolder grouping downstream
+            // (graph-app.jsx panelParamGroups) can sort by NODEDEF order
+            // regardless of instance/document authoring order. undefined
+            // (via Map#get on a missing key) for names not in the def, e.g.
+            // custom/legacy instance inputs with no nodedef entry.
+            const defIndexOf = (() => {
+                const def = nodeDef();
+                const map = new Map();
+                if (def) {
+                    const defIns = vecToArray(mxSafe(() => def.getActiveInputs(), []))
+                        .concat(vecToArray(mxSafe(() => def.getInputs(), [])));
+                    let idx = 0;
+                    for (const dIn of defIns) {
+                        const nm = mxElName(dIn);
+                        if (!nm || map.has(nm)) continue;
+                        map.set(nm, idx++);
+                    }
+                }
+                return (nm) => map.get(nm);
+            })();
+
             const inputs = vecToArray(mxSafe(() => el.getInputs(), [])).map((inp) => {
                 const dIn = defInputEl(mxElName(inp));
                 const type = mxElType(inp) || defPortType(mxElName(inp), false);
@@ -250,13 +284,16 @@
                     interfacename: mxElAttr(inp, 'interfacename'),
                     output: mxElAttr(inp, 'output'),
                     colorManaged: colorManagedFor(type),
+                    defIndex: defIndexOf(mxElName(inp)),
                 }, uiMeta(dIn));
             });
             // Unauthored nodedef inputs (shown only in "all" mode). Their
-            // value IS the default.
+            // value IS the default. Skipped entirely in authoredOnly mode —
+            // callers that filter these back out right after calling
+            // collectPorts don't pay for building them.
             const authoredNames = new Set(inputs.map((i) => i.name));
             const def = nodeDef();
-            if (def) {
+            if (def && !authoredOnly) {
                 const defIns = vecToArray(mxSafe(() => def.getActiveInputs(), []))
                     .concat(vecToArray(mxSafe(() => def.getInputs(), [])));
                 const seen = new Set();
@@ -271,10 +308,13 @@
                         authored: false, colorspace: '',
                         nodename: '', nodegraph: '', interfacename: '', output: '',
                         colorManaged: colorManagedFor(type),
+                        defIndex: defIndexOf(nm),
                     }, uiMeta(dIn)));
                 }
             }
-            const outputs = vecToArray(mxSafe(() => el.getOutputs(), [])).map((o) => ({
+            // Reuse the elOutputs local from the outTypes computation above
+            // instead of a second el.getOutputs() WASM round trip.
+            const outputs = elOutputs.map((o) => ({
                 name: mxElName(o), type: mxElType(o) || defPortType(mxElName(o), true),
             }));
 

--- a/js/graph/panels.jsx
+++ b/js/graph/panels.jsx
@@ -426,17 +426,15 @@
                                         type="button"
                                         onClick={() => setCsOpen((v) => !v)}
                                         title="Colorspace…"
-                                        className="flex-none text-gray-400 hover:text-gray-200 text-[10px] leading-none px-0.5 self-stretch"
-                                    >{csOpen ? '▾' : '▸'}</button>
+                                        className="flex-none flex items-center text-gray-400 hover:text-gray-200 px-0.5 self-stretch"
+                                    ><MtlxIcon name={csOpen ? 'chevron-down' : 'chevron-right'} className="w-3.5 h-3.5" /></button>
                                 )}
                                 {isColor && (
-                                    <input
-                                        type="color"
+                                    <ColorSwatch
+                                        rgb={comps.slice(0, 3)}
                                         className="w-full self-stretch h-6 min-w-0 p-0 bg-transparent border border-gray-600 rounded cursor-pointer"
                                         title="Linear RGB — hex bytes map 1:1 onto the 0-1 values to the right"
-                                        value={rgbToHex(comps.slice(0, 3))}
-                                        onChange={(e) => {
-                                            const nv = hexToRgb(e.target.value);
+                                        onChange={(nv) => {
                                             if (vecN === 4) nv.push(comps[3]);
                                             setCompText(nv.map(numStr));
                                             commitSoon(nv.map(numStr).join(', '));

--- a/js/graph/preview.jsx
+++ b/js/graph/preview.jsx
@@ -346,8 +346,12 @@
         // default — rendered with the SAME createMtlxRenderView pipeline
         // as the docs page. Re-inits whenever the target, the document,
         // or a committed parameter edit (docRev) changes.
-        function NodePreview({ parsed, target, docRev, fileMap, viewRef, active = true, overlay }) {
+        function NodePreview({ parsed, target, docRev, fileMap, viewRef, active = true, overlay, trailingChildren }) {
             const canvasRef = React.useRef(null);
+            // The viewport CONTAINER (not the canvas) goes fullscreen, so
+            // the overlaid ViewportControls stay visible — same contract as
+            // node-preview.jsx / viewer-app.jsx.
+            const viewportRef = React.useRef(null);
             // Mirrors NodeGraphApp's activeRef — pauses the render loop while
             // a future multi-view shell hides this view without unmounting it.
             const activeRef = React.useRef(active);
@@ -365,14 +369,103 @@
             const lastFrameRef = React.useRef(null);
             const [lastFrame, setLastFrame] = React.useState(null);
 
+            // ---- Viewport controls (item F2.1) — mirrors node-preview.jsx's
+            // copy exactly. Preview geometry (persisted): shares the SAME
+            // localStorage key as the docs previewer ('mtlx_preview_geom')
+            // since it's the identical setting in spirit — a value picked in
+            // one view carries over to the other. Falls back to 'shaderball'
+            // (this preview's long-standing hardcoded default) rather than
+            // node-preview.jsx's 'sphere' when nothing is stored yet.
+            const [geom, setGeom] = React.useState(() => {
+                const valid = ['shaderball', 'sphere', 'cube'];
+                try {
+                    const g = localStorage.getItem('mtlx_preview_geom');
+                    return valid.indexOf(g) !== -1 ? g : 'shaderball';
+                } catch (e) { return 'shaderball'; }
+            });
+            const pickGeom = (g) => {
+                try { localStorage.setItem('mtlx_preview_geom', g); } catch (e) { /* best-effort */ }
+                setGeom(g);
+            };
+            // Auto-orbit + env-background toggles, applied live via the view
+            // handle (the SAME ref the parent passes in and reads elsewhere
+            // — see previewViewRef in graph-app.jsx) and re-read fresh at
+            // creation time so they survive a geometry-triggered rebuild.
+            const [rotating, toggleRotating] = useViewToggle(viewRef, 'setAutoRotate', false);
+            const [envBg, toggleEnvBg] = useViewToggle(viewRef, 'setEnvBackground', false);
+            const [envAvail, setEnvAvail] = React.useState(false);
+            const [isFullscreen, toggleFullscreenView] = useFullscreen(viewportRef);
+            const takeScreenshot = () => {
+                const view = viewRef && viewRef.current;
+                if (!view || !view.snapshot) return;
+                try {
+                    downloadSnapshot(view, label + '_' + geom);
+                } catch (e) { /* best-effort */ }
+            };
+
+            // Component-lifetime handle to the CURRENTLY LIVE, GL-compiled
+            // render view (if any) — persists ACROSS the main effect's
+            // docRev-triggered re-runs so a fast-refresh (item F3c below)
+            // can reuse it instead of tearing it down. Only the rebuild
+            // path (a real shader-source change) or unmount ever dispose
+            // it; a superseded/stale run must never touch it (see the
+            // mounted-staleness comments below).
+            const liveViewRef = React.useRef(null);
+
+            // Mount-once: disposes whatever view is still live when this
+            // component actually UNMOUNTS. Not the per-docRev cleanup —
+            // that's handled inline by the rebuild path inside the main
+            // effect below (only a run that itself proceeds to rebuild
+            // ever disposes the previous view). No last-frame snapshot is
+            // taken here since nothing will render this preview again.
+            React.useEffect(() => {
+                return () => {
+                    if (liveViewRef.current) {
+                        try { liveViewRef.current.dispose(); } catch (e) { /* best-effort */ }
+                    }
+                    liveViewRef.current = null;
+                    if (viewRef) viewRef.current = null;
+                };
+            }, []);
+
             React.useEffect(() => {
                 let mounted = true;
-                let viewHandle = null;
-                setLastFrame(lastFrameRef.current);
                 (async () => {
-                    setLoading(true); setError(null); setNotice(null);
+                    setError(null); setNotice(null);
                     try {
                         const { mx, gen, genContext, lightData } = await getMxEnv();
+                        if (!mounted) return;
+                        // Let the graph paint before the heavy synchronous
+                        // regen below runs. getMxEnv() above resolves from a
+                        // cached promise, so without this yield the
+                        // buildPreviewRenderable + createMtlxRenderView work
+                        // runs in the same microtask/frame as a just-added/
+                        // deleted/grouped node's setFlow commit, blocking the
+                        // very frame that node should first appear in. Same
+                        // double-rAF-defer idiom as changeScope (graph-app.jsx)
+                        // — the graph's commit paints first, the regen follows.
+                        await new Promise((r) => requestAnimationFrame(r));
+                        await new Promise((r) => requestAnimationFrame(r));
+                        // Re-check staleness: another run may have started
+                        // (and this effect's cleanup set mounted = false)
+                        // while we were yielding across those two frames.
+                        if (!mounted) return;
+                        // Coalesce rapid successive triggers: a doc mutation
+                        // (e.g. adding a node) bumps docRev and fires this
+                        // effect while `target` is still the OLD selection,
+                        // then ~a frame later the selection moves to the
+                        // just-added node and fires it again for the real
+                        // target. The build below is synchronous, so without
+                        // this delay the FIRST run would block the main
+                        // thread and the superseding commit couldn't cancel
+                        // it (flip `mounted` to false) until that wasted
+                        // compile — measured at ~330ms-3s on heavy materials
+                        // — already ran. Waiting here lets the newest
+                        // trigger's cleanup cancel every stale run first, so
+                        // only the final target actually compiles; the cost
+                        // is a barely perceptible extra delay before a
+                        // legitimately final rebuild starts.
+                        await new Promise((r) => setTimeout(r, 120));
                         if (!mounted) return;
                         // [mtlx-perf] timing (item 3) — off unless
                         // MTLX_PERF_LOG (bare window global, model.jsx
@@ -390,6 +483,11 @@
                             setLoading(false);
                             setLastFrame(null);
                             lastFrameRef.current = null;
+                            if (liveViewRef.current) {
+                                try { liveViewRef.current.dispose(); } catch (e) { /* best-effort */ }
+                            }
+                            liveViewRef.current = null;
+                            if (viewRef) viewRef.current = null;
                             if (canvasRef.current) {
                                 const c = canvasRef.current;
                                 const w = c.width, h = c.height;
@@ -397,6 +495,74 @@
                                 c.width = w; c.height = h;
                             }
                             return;
+                        }
+
+                        // FAST PATH (item F3c) — before any teardown: try
+                        // to refresh the EXISTING compiled view in place
+                        // instead of a full rebuild. Only attempted when a
+                        // live view exists for the SAME geometry (a geom
+                        // switch is also a `geom` dep change that re-runs
+                        // this effect and lands here, but the mesh/material
+                        // pairing means it always needs a real rebuild).
+                        const live = liveViewRef.current;
+                        if (live && live.__geom === geom) {
+                            let res = { refreshed: false };
+                            try {
+                                res = tryRefreshRenderView({
+                                    view: live, mx, gen, genContext,
+                                    renderable: built.renderable,
+                                    label: built.label || parsed.label,
+                                    isMounted: () => mounted,
+                                });
+                            } finally {
+                                // The '__pv_*' wrappers only exist for shader
+                                // generation — remove them before anything
+                                // can rebuild the graph from the live
+                                // document. Only needed here when the
+                                // refresh actually took (view kept as-is);
+                                // when it didn't, `built` stays alive
+                                // uncleaned and the rebuild path's own
+                                // try/finally below cleans it up once.
+                                if (res.refreshed) built.cleanup();
+                            }
+                            if (res.refreshed) {
+                                // Bind any dropped texture files onto the
+                                // shader's filename uniforms (same pass as
+                                // the viewer/rebuild path). Missing
+                                // references keep the built-in checker
+                                // texture.
+                                const rep = bindDroppedTextures(live, fileMap || {});
+                                if (rep.missing.length) {
+                                    console.warn('node-graph preview: texture file(s) not found among dropped files:', rep.missing);
+                                }
+                                setLabel(built.label || '');
+                                setLoading(false);
+                                setLastFrame(null);
+                                return;
+                            }
+                            // Not refreshed (source actually changed, or
+                            // generation errored/bailed) — fall through to
+                            // the full rebuild below.
+                        }
+
+                        // REBUILD PATH — full teardown + recreate. Only
+                        // NOW do we blink the loading overlay / hold the
+                        // last frame; a successful fast-refresh above never
+                        // reaches this point, so it never blinks.
+                        setLoading(true);
+                        setLastFrame(lastFrameRef.current);
+                        if (liveViewRef.current) {
+                            // Grab the last-drawn frame before tearing the
+                            // view down so the overlay above can paint it
+                            // over the checker-texture gap instead of
+                            // showing a blank/flashing canvas.
+                            try {
+                                const shot = liveViewRef.current.snapshot && liveViewRef.current.snapshot();
+                                if (shot) lastFrameRef.current = shot;
+                            } catch (e) { /* best-effort — keep the previous frame */ }
+                            liveViewRef.current.dispose();
+                            liveViewRef.current = null;
+                            if (viewRef) viewRef.current = null;
                         }
                         setLabel(built.label || '');
                         // The canvas may need a frame to mount after a
@@ -413,9 +579,9 @@
                                 canvas, mx, gen, genContext, renderable: built.renderable, lightData,
                                 label: built.label || parsed.label,
                                 needsLighting: true,
-                                geomName: 'shaderball',
-                                autoRotate: false,
-                                envBackground: false,
+                                geomName: geom,
+                                autoRotate: rotating,
+                                envBackground: envBg,
                                 // The preview is square now — pull the camera
                                 // in so the shaderball fills the frame.
                                 cameraDistance: 2.55,
@@ -431,8 +597,10 @@
                         }
                         if (!view) return;
                         if (!mounted) { view.dispose(); return; }
-                        viewHandle = view;
+                        view.__geom = geom;
+                        liveViewRef.current = view;
                         if (viewRef) viewRef.current = view;
+                        setEnvAvail(!!(view.hasEnvBackground && view.hasEnvBackground()));
                         // Bind any dropped texture files onto the shader's
                         // filename uniforms (same pass as the viewer). Missing
                         // references keep the built-in checker texture.
@@ -454,52 +622,80 @@
                         }
                     }
                 })();
+                // Per-run cleanup ONLY flips `mounted` — a superseded run
+                // must never dispose the live view (it might still be the
+                // one on screen). Disposal now happens inline: on the
+                // no-renderable path and the rebuild path above (both only
+                // reachable by a run that itself passed every `mounted`
+                // check up to that point), or on actual unmount (the
+                // mount-once effect above).
                 return () => {
-                    if (viewRef) viewRef.current = null;
                     mounted = false;
-                    if (viewHandle) {
-                        // Grab the last-drawn frame before tearing the view
-                        // down so the NEXT run (see setLastFrame above) can
-                        // paint it over the checker-texture gap instead of
-                        // showing a blank/flashing canvas.
-                        try {
-                            const shot = viewHandle.snapshot && viewHandle.snapshot();
-                            if (shot) lastFrameRef.current = shot;
-                        } catch (e) { /* best-effort — keep the previous frame */ }
-                        viewHandle.dispose();
-                    }
                 };
-            }, [parsed, target, docRev, fileMap]);
+            }, [parsed, target, docRev, fileMap, geom]);
 
             return (
-                <div className="relative flex-none w-full aspect-square border-b border-gray-700 bg-gray-900/60">
-                    <canvas ref={canvasRef} className="block w-full h-full" />
-                    {loading && lastFrame && !notice && !error && (
-                        // Hold the previous frame over the canvas while the
-                        // view rebuilds \u2014 otherwise the checker-texture
-                        // placeholder (and blank canvas) flash for a beat on
-                        // every committed parameter edit.
-                        <img src={lastFrame} className="absolute inset-0 w-full h-full object-cover pointer-events-none" alt="" />
-                    )}
-                    {loading && !notice && !error && (
-                        <div className="absolute inset-0 flex items-center justify-center text-[11px] text-gray-500 animate-pulse pointer-events-none bg-gray-900/40">
-                            Rendering material {'\u2026'}
-                        </div>
-                    )}
-                    {notice && (
-                        <div className="absolute inset-0 flex items-center justify-center text-[11px] text-gray-500 px-3 text-center bg-gray-900/60">
-                            {notice}
-                        </div>
-                    )}
-                    {error && (
-                        <div className="absolute inset-0 overflow-y-auto custom-scrollbar text-[10px] text-red-300 bg-red-950/80 px-2 py-1 break-words">
-                            {error}
-                        </div>
-                    )}
-                    {/* Rendered last so it stacks above the loading/notice/
-                        error overlays regardless of z-index ties (item 10's
-                        pin toggle, passed in by the caller). */}
-                    {overlay}
+                <div
+                    ref={viewportRef}
+                    className="flex flex-col flex-none w-full border-b border-gray-700"
+                    style={isFullscreen ? { height: '100%' } : undefined}
+                >
+                    {/* Viewport controls (item F2.1): geometry picker,
+                        rotate/env toggles, screenshot, fullscreen \u2014 the same
+                        strip node-preview.jsx and viewer-app.jsx use. Moved
+                        above the canvas (item F2c) so it has its own row
+                        instead of floating over the square preview. The
+                        pin toggle below keeps its own top-left overlay slot
+                        (unchanged) since it doesn't share the strip's
+                        top-right corner or button styling; trailingChildren
+                        carries the new "send to Material Viewer" button. */}
+                    <ViewportControls
+                        geom={geom}
+                        onGeomChange={pickGeom}
+                        rotating={rotating}
+                        onToggleRotating={toggleRotating}
+                        envBg={envBg}
+                        onToggleEnvBg={toggleEnvBg}
+                        envAvail={envAvail}
+                        onScreenshot={takeScreenshot}
+                        isFullscreen={isFullscreen}
+                        onToggleFullscreen={toggleFullscreenView}
+                        trailingChildren={trailingChildren}
+                        containerClassName="flex items-center justify-end gap-1 px-2 py-1 border-b border-gray-700 bg-gray-900/70 flex-none"
+                    />
+                    <div
+                        className={`relative w-full bg-gray-900/60 ${isFullscreen ? 'flex-1 min-h-0' : 'aspect-square'}`}
+                    >
+                        <canvas ref={canvasRef} className="block w-full h-full" />
+                        {loading && lastFrame && !notice && !error && (
+                            // Hold the previous frame over the canvas while the
+                            // view rebuilds \u2014 otherwise the checker-texture
+                            // placeholder (and blank canvas) flash for a beat on
+                            // every committed parameter edit.
+                            <img src={lastFrame} className="absolute inset-0 w-full h-full object-cover pointer-events-none" alt="" />
+                        )}
+                        <LoadingOverlay
+                            show={loading && !notice && !error}
+                            label={'Rendering material\u2026'}
+                            className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-3 bg-gray-900/70 pointer-events-none"
+                            labelClassName="text-[12px] text-gray-200 animate-pulse"
+                            barWidthClass="w-32"
+                        />
+                        {notice && (
+                            <div className="absolute inset-0 flex items-center justify-center text-[11px] text-gray-500 px-3 text-center bg-gray-900/60">
+                                {notice}
+                            </div>
+                        )}
+                        {error && (
+                            <div className="absolute inset-0 overflow-y-auto custom-scrollbar text-[10px] text-red-300 bg-red-950/80 px-2 py-1 break-words">
+                                {error}
+                            </div>
+                        )}
+                        {/* Rendered last so it stacks above the loading/notice/
+                            error overlays regardless of z-index ties (item 10's
+                            pin toggle, passed in by the caller). */}
+                        {overlay}
+                    </div>
                 </div>
             );
         }

--- a/js/graph/style.jsx
+++ b/js/graph/style.jsx
@@ -129,9 +129,12 @@
         // Input display, per node: 'authored' (only inputs written in the
         // document — "set") or 'all' (plus every nodedef input at its
         // default value). Connected inputs are ALWAYS visible so no edge
-        // ever dangles.
+        // ever dangles. keepRow (patchInputConn, js/graph-app.jsx) is a
+        // flow-state-only flag that pins a just-disconnected port visible
+        // for one more render in 'authored' mode, so it doesn't vanish out
+        // from under the user the instant they disconnect it.
         const visiblePortsFor = (all, mode) => all.filter((inp) =>
-            inp.connected || mode === 'all' || inp.authored !== false);
+            inp.connected || inp.keepRow || mode === 'all' || inp.authored !== false);
 
         const toFlow = (descs, edges, opts) => {
             const o = opts || {};

--- a/js/mtlx-engine.js
+++ b/js/mtlx-engine.js
@@ -579,12 +579,87 @@ const textureCacheKey = (blob, fallback) => {
     return fallback; // e.g. the fileMap key, when identity fields are missing
 };
 
+// Parse a dropped .exr Blob into a three.js texture via THREE.EXRLoader
+// (script tag pinned to three@0.147.0 — newer than the r128 core, see
+// index.html for why — alongside RGBELoader/GLTFLoader, same
+// DataTextureLoader family). EXRLoader.parse always returns RGBAFormat
+// data — the implementation hardcodes numChannels = 4 — so unlike
+// RGBELoader's env path (see prepareEnv/padToRGBA above) there's no
+// RGB->RGBA repack needed here. setDataType(FloatType) is explicit
+// (mirrors loadHdrTexture below): 0.147.0's EXRLoader constructor
+// defaults this.type to HalfFloatType, not FloatType like older
+// versions, and leaving it on the default would silently swap d.data
+// from a Float32Array to a half-float Uint16Array.
+// A THREE.DataTexture already defaults to generateMipmaps=false and
+// NearestFilter (see three's DataTexture ctor); left at no-mipmaps
+// (forcing mips on Float/HalfFloat data hits the same "not
+// color-renderable" WebGL restriction padToRGBA works around for the
+// env textures, and a material preview swatch doesn't need mip levels)
+// but bumped to LinearFilter for both min/mag so it isn't blocky —
+// LinearFilter is mipmap-free and texture-completeness-safe without a
+// mip chain, unlike a LinearMipmapLinear* filter would be.
+const loadExrTexture = async (blob) => {
+    if (typeof THREE.EXRLoader === 'undefined') {
+        console.warn('mtlx-engine: THREE.EXRLoader unavailable (script blocked/offline) — .exr textures fall back to the checker.');
+        return null;
+    }
+    try {
+        const buf = await blob.arrayBuffer();
+        const d = new THREE.EXRLoader().setDataType(THREE.FloatType).parse(buf);
+        if (!d || !d.data) return null;
+        const tex = new THREE.DataTexture(d.data, d.width, d.height, d.format, d.type);
+        tex.minFilter = tex.magFilter = THREE.LinearFilter;
+        return tex;
+    } catch (e) {
+        console.warn('mtlx-engine: failed to parse dropped .exr texture, falling back to the checker:', e);
+        return null;
+    }
+};
+
+// Parse a dropped .hdr Blob via the already-loaded THREE.RGBELoader.
+// r128's DataTextureLoader family exposes a synchronous .parse(buffer)
+// alongside the async .load(url, ...) used for the built-in environment
+// (loadHDR below) — same class, just called directly instead of via the
+// FileLoader roundtrip. Explicitly set to FloatType (not the default
+// UnsignedByteType/RGBE byte packing) so the plain MaterialX sampler
+// shader — which has no RGBE decode step — reads linear values
+// directly; that yields RGBFormat (3-channel) data per RGBELoader's
+// source, which THREE.DataTexture accepts as-is. Same no-mipmap
+// reasoning as loadExrTexture above: RGB16F/RGB32F can't safely
+// generateMipmap on WebGL2, but nothing here asks it to, so
+// padToRGBA's repack (needed only when mips ARE forced, as prepareEnv
+// does for the IBL environment) is unnecessary for this sampler-only
+// use.
+const loadHdrTexture = async (blob) => {
+    if (typeof THREE.RGBELoader === 'undefined') {
+        console.warn('mtlx-engine: THREE.RGBELoader unavailable — .hdr textures fall back to the checker.');
+        return null;
+    }
+    try {
+        const buf = await blob.arrayBuffer();
+        const d = new THREE.RGBELoader().setDataType(THREE.FloatType).parse(buf);
+        if (!d || !d.data) return null;
+        const tex = new THREE.DataTexture(d.data, d.width, d.height, d.format, d.type);
+        tex.minFilter = tex.magFilter = THREE.LinearFilter;
+        return tex;
+    } catch (e) {
+        console.warn('mtlx-engine: failed to parse dropped .hdr texture, falling back to the checker:', e);
+        return null;
+    }
+};
+
 // After the view is up: bind dropped textures onto the shader's
 // filename sampler uniforms by their document-referenced paths.
-// Cache hits assign synchronously; cache misses fall back to the
-// async TextureLoader path. `onBound` (optional) is invoked once per
-// texture that finishes binding (sync for cache hits, async
-// otherwise) so callers can re-render as textures land.
+// Cache hits assign synchronously; cache misses fall back to an async
+// load — THREE.TextureLoader for anything a plain <img> can decode,
+// or the arrayBuffer+parse loaders above for .exr/.hdr, which three's
+// TextureLoader can't handle (bindDroppedTextures previously fell
+// silently through to the UV checker for both). `onBound` (optional)
+// is invoked once per texture that finishes binding (sync for cache
+// hits, async otherwise) so callers can re-render as textures land —
+// on a failed/unsupported parse it's simply never called for that
+// uniform, same as a TextureLoader error, leaving the checker default
+// the sampler uniforms are created with (see getDefaultTexture) as-is.
 // Returns { bound: [...], missing: [...] } for the UI report.
 const bindDroppedTextures = (view, fileMap, onBound) => {
     const bound = [], missing = [];
@@ -605,14 +680,26 @@ const bindDroppedTextures = (view, fileMap, onBound) => {
             if (view.uniforms[u.name]) view.uniforms[u.name].value = cached;
             if (onBound) onBound();
         } else {
-            const url = URL.createObjectURL(blob);
-            new THREE.TextureLoader().load(url, (tex) => {
-                configureLoadedTexture(tex);
-                TEXTURE_CACHE.set(cacheKey, tex);
-                if (view.uniforms[u.name]) view.uniforms[u.name].value = tex;
-                URL.revokeObjectURL(url);
-                if (onBound) onBound();
-            }, undefined, () => URL.revokeObjectURL(url));
+            const ext = (hit.key.split('.').pop() || ref.split('.').pop() || '').toLowerCase();
+            if (ext === 'exr' || ext === 'hdr') {
+                const parsePromise = ext === 'exr' ? loadExrTexture(blob) : loadHdrTexture(blob);
+                parsePromise.then((tex) => {
+                    if (!tex) return; // unsupported/corrupt — checker default stands
+                    configureLoadedTexture(tex);
+                    TEXTURE_CACHE.set(cacheKey, tex);
+                    if (view.uniforms[u.name]) view.uniforms[u.name].value = tex;
+                    if (onBound) onBound();
+                });
+            } else {
+                const url = URL.createObjectURL(blob);
+                new THREE.TextureLoader().load(url, (tex) => {
+                    configureLoadedTexture(tex);
+                    TEXTURE_CACHE.set(cacheKey, tex);
+                    if (view.uniforms[u.name]) view.uniforms[u.name].value = tex;
+                    URL.revokeObjectURL(url);
+                    if (onBound) onBound();
+                }, undefined, () => URL.revokeObjectURL(url));
+            }
         }
         bound.push(ref + '  →  ' + hit.key);
     }
@@ -1219,6 +1306,379 @@ const getEnvironment = () => {
 const COLORSPACES = ['srgb_texture', 'lin_rec709', 'g22_rec709', 'g18_rec709',
     'acescg', 'lin_ap1', 'srgb_displayp3', 'lin_displayp3', 'adobergb', 'lin_adobergb', 'none'];
 
+// One persistent hidden WebGL2 context used ONLY to pre-warm driver shader
+// compiles (KHR_parallel_shader_compile). Created lazily once, on a 1x1
+// canvas that never enters the DOM, and NEVER disposed — its GL objects are
+// completely decoupled from every preview canvas/renderer lifecycle, so
+// rebuild churn can't invalidate handles mid-poll (the source of the old
+// glGetProgramiv console warnings). ANGLE/Chrome cache compiled programs
+// per GPU process keyed by source, so a compile finished here makes the
+// display context's compile of the SAME source a fast cache hit.
+// null = not tried yet; false = unavailable (no WebGL2 or no extension).
+let MTLX_WARM_CTX = null;
+const getWarmContext = () => {
+    if (MTLX_WARM_CTX !== null) return MTLX_WARM_CTX;
+    try {
+        const canvas = document.createElement('canvas');
+        canvas.width = 1;
+        canvas.height = 1;
+        const gl = canvas.getContext('webgl2');
+        const ext = gl && gl.getExtension('KHR_parallel_shader_compile');
+        MTLX_WARM_CTX = (gl && ext) ? { gl, ext } : false;
+    } catch (e) {
+        MTLX_WARM_CTX = false;
+    }
+    return MTLX_WARM_CTX;
+};
+
+// Shader sources already pre-warmed (or fully display-compiled) this
+// session — the driver cache is primed for these, so a repeat pre-warm
+// would only ADD ~300ms of pointless background wait before the display
+// compile's cache hit. Keyed by a fast djb2 hash of the concatenated
+// sources (collisions are harmless: a false "already warmed" just means
+// one un-warmed sync compile, same as pre-warm-less behavior).
+const MTLX_WARMED_SOURCES = new Set();
+// Small shaders compile synchronously in single-digit milliseconds —
+// pre-warming them only ADDs a poll-tick of latency (measured
+// 50-100ms). Only pre-warm sources big enough for the background
+// compile to plausibly matter. 128 KB is comfortably above every
+// simple-node preview shader and comfortably below the
+// standard_surface/OpenPBR material shaders the pre-warm exists for.
+const PREWARM_MIN_SOURCE_BYTES = 128 * 1024;
+const warmKey = (vs, fs) => {
+    let h = 5381;
+    const s = vs + ' ' + fs;
+    for (let i = 0; i < s.length; i++) h = ((h * 33) ^ s.charCodeAt(i)) >>> 0;
+    return s.length + ':' + h;
+};
+
+// Pre-compile vs/fs on the hidden warm context and resolve when the driver
+// reports completion (or on bail/timeout). Returns 'done' | 'bailed' |
+// 'skipped'. Never throws; a warm failure must never break the preview.
+//
+// The throwaway source below must match byte-for-byte what three.js's
+// WebGLProgram will itself submit for the DISPLAY compile, or the driver's
+// source-keyed cache simply misses (never a correctness issue — just no
+// speed win, i.e. identical to not pre-warming at all). Verified from the
+// r128 source for our exact configuration (RawShaderMaterial +
+// glslVersion:GLSL3, WebGL2, no material.defines): prefixes reduce to
+// nothing (customDefines/customExtensions are empty; the WebGL2
+// built-in-material prefix block is skipped for RawShaderMaterial), and
+// resolveIncludes / replaceLightNums / replaceClippingPlaneNums /
+// unrollLoops are no-ops on MaterialX-generated GLSL (it uses none of
+// three's #include<>, NUM_*_LIGHTS, or #pragma unroll_loop_start
+// conventions). So three submits exactly '#version 300 es\n' + vs / + fs —
+// reproduced here.
+const prewarmShaderCompile = async ({ vs, fs, isMounted, label }) => {
+    const ctx = getWarmContext();
+    if (!ctx) return 'skipped';
+    const key = warmKey(vs, fs);
+    if (MTLX_WARMED_SOURCES.has(key)) {
+        if (window.MTLX_PERF_LOG) {
+            console.log('[mtlx-perf] GL prewarm skipped — source already warmed this session (target: ' + label + ')');
+        }
+        return 'skipped';
+    }
+    if (vs.length + fs.length < PREWARM_MIN_SOURCE_BYTES) {
+        if (window.MTLX_PERF_LOG) {
+            console.log('[mtlx-perf] GL prewarm skipped — small shader ('
+                + (vs.length + fs.length) + ' bytes, target: ' + label + ')');
+        }
+        return 'skipped';
+    }
+    const { gl, ext } = ctx;
+
+    const __warmPerfStart = window.MTLX_PERF_LOG ? performance.now() : 0;
+    let warmProgram = null, warmVShader = null, warmFShader = null;
+    try {
+        warmVShader = gl.createShader(gl.VERTEX_SHADER);
+        gl.shaderSource(warmVShader, '#version 300 es\n' + vs);
+        gl.compileShader(warmVShader);
+        warmFShader = gl.createShader(gl.FRAGMENT_SHADER);
+        gl.shaderSource(warmFShader, '#version 300 es\n' + fs);
+        gl.compileShader(warmFShader);
+        warmProgram = gl.createProgram();
+        gl.attachShader(warmProgram, warmVShader);
+        gl.attachShader(warmProgram, warmFShader);
+        gl.linkProgram(warmProgram);
+    } catch (e) {
+        // Defensive only: any failure here just skips the warm-up — falls
+        // through to today's (unwarmed) compile behavior.
+        try { if (warmProgram) gl.deleteProgram(warmProgram); } catch (e2) { /* context lost etc. */ }
+        try { if (warmVShader) gl.deleteShader(warmVShader); } catch (e2) { /* ditto */ }
+        try { if (warmFShader) gl.deleteShader(warmFShader); } catch (e2) { /* ditto */ }
+        return 'skipped';
+    }
+    if (window.MTLX_PERF_LOG) {
+        console.log('[mtlx-perf] GL compile submit: '
+            + (performance.now() - __warmPerfStart).toFixed(1) + 'ms (target: ' + label + ')');
+    }
+    const cleanup = () => {
+        try { if (warmProgram) gl.deleteProgram(warmProgram); } catch (e) { /* context lost etc. */ }
+        try { if (warmVShader) gl.deleteShader(warmVShader); } catch (e) { /* ditto */ }
+        try { if (warmFShader) gl.deleteShader(warmFShader); } catch (e) { /* ditto */ }
+    };
+
+    const WAIT_POLL_MS = 50, WAIT_POLL_FAST_MS = 16, WAIT_POLL_FAST_TICKS = 6, WAIT_TIMEOUT_MS = 15000;
+    const __waitStart = performance.now();
+    let timedOut = false;
+
+    // isProgram() is the silent validity check: it returns false for a
+    // deleted/invalid handle WITHOUT generating a GL error (unlike
+    // getProgramParameter on an invalid handle, which logs
+    // "GL_INVALID_VALUE: glGetProgramiv: Program object expected" once
+    // per pre-warm on Chrome). isContextLost / the null-guard / the
+    // try/catch below stay as belt-and-suspenders inner fallbacks.
+    const isWarmDone = () => {
+        try {
+            if (gl.isContextLost()) return true;
+            if (!gl.isProgram(warmProgram)) return true;
+            const v = gl.getProgramParameter(warmProgram, ext.COMPLETION_STATUS_KHR);
+            // A GL error (invalid/deleted program) returns null WITHOUT
+            // throwing — treat it as "nothing left to wait for" instead of
+            // polling (and console-spamming GL_INVALID_VALUE) until the
+            // timeout cap.
+            return (v === null) ? true : !!v;
+        } catch (e) {
+            // Disposed/invalid handle — nothing left to wait for.
+            return true;
+        }
+    };
+
+    // Check once immediately, before the first sleep — a fast background
+    // compile may already be done before we'd otherwise pay a single poll
+    // tick of latency.
+    let tick = 0;
+    for (;;) {
+        if (isWarmDone()) break;
+        // Safety cap: on timeout just stop polling and proceed. The real
+        // compile below will then block for whatever compile time remains —
+        // same as not pre-warming, so this can never be WORSE, only equal
+        // or better.
+        if ((performance.now() - __waitStart) > WAIT_TIMEOUT_MS) {
+            timedOut = true;
+            break;
+        }
+        // Escalating poll interval: fast compiles typically resolve within
+        // about a frame, so the first ~6 ticks poll at 16ms; the longer
+        // 50ms tick only matters for multi-second compiles, where that
+        // granularity is irrelevant.
+        const pollMs = tick < WAIT_POLL_FAST_TICKS ? WAIT_POLL_FAST_MS : WAIT_POLL_MS;
+        tick++;
+        await new Promise((resolve) => setTimeout(resolve, pollMs));
+        // Lifecycle bail: a superseded build must stop and clean up rather
+        // than keep polling GL objects for a view nobody wants.
+        if (!isMounted()) {
+            cleanup();
+            return 'bailed';
+        }
+    }
+    if (window.MTLX_PERF_LOG) {
+        console.log('[mtlx-perf] GL compile wait: '
+            + (performance.now() - __waitStart).toFixed(1) + 'ms (target: ' + label + ')');
+    }
+    if (!timedOut) MTLX_WARMED_SOURCES.add(key);
+    cleanup();
+    return 'done';
+};
+
+
+// ------------------------------------------------------------------
+// generatePreviewSources — shader-generation slice of
+// createMtlxRenderView, extracted so tryRefreshRenderView can
+// regenerate + diff a target's sources against a live view's
+// compiled sources without paying for a full view rebuild (measured
+// gen.generate: 20-40ms, vs. WebGLRenderer init + GL compile for a
+// full rebuild). Args: { mx, gen, genContext, renderable, label,
+// isMounted }. Returns { mxShader, vs, fs, VERTEX_STAGE, PIXEL_STAGE }
+// (stage names included so callers — createMtlxRenderView's
+// introspection loop, tryRefreshRenderView's — don't re-derive them),
+// or null when isMounted() went false before generation started
+// (nothing GL-side exists yet at that point, so there's nothing to
+// clean up here; the caller decides whether it needs disposePartial).
+// Throws Error with a decoded MaterialX message on generation failure.
+// ------------------------------------------------------------------
+const generatePreviewSources = ({ mx, gen, genContext, renderable, label, isMounted = () => true }) => {
+    // OFFICIAL PARITY: per-material generation options. Transparency
+    // detection switches the generated blending path (glass etc.);
+    // COMPLETE interface exposes every input as a uniform for the
+    // editor.
+    try {
+        if (typeof mx.isTransparentSurface === 'function') {
+            genContext.getOptions().hwTransparency =
+                mx.isTransparentSurface(renderable, gen.getTarget());
+        }
+    } catch (e) { /* keep previous value */ }
+    try {
+        if (mx.ShaderInterfaceType) {
+            genContext.getOptions().shaderInterfaceType =
+                mx.ShaderInterfaceType.SHADER_INTERFACE_COMPLETE;
+        }
+    } catch (e) { /* default interface */ }
+    // Generated shaders use the generator's default FIS
+    // specular-environment method. hwSpecularEnvironmentMethod
+    // is NOT settable through this JsMaterialXGenShader build —
+    // the embind setter rejects both the unexposed enum object
+    // and raw ints (verified at runtime, 2026-07). Don't retry.
+
+    // Bail before the ~expensive shader-generation call if this
+    // build has already been superseded (caller's effect
+    // cleanup flipped `mounted` while we were awaiting above) —
+    // nothing GL-side exists yet, so there's nothing for the
+    // caller to dispose either.
+    if (!isMounted()) return null;
+    let mxShader;
+    const __genPerfStart = window.MTLX_PERF_LOG ? performance.now() : 0;
+    try {
+        mxShader = gen.generate('PreviewShader', renderable, genContext);
+    } catch (genErr) {
+        // Decode the REAL MaterialX error (Emscripten throws
+        // numeric pointers) instead of a generic string.
+        throw new Error(`Shader generation failed for "${label}": ${mxErr(mx, genErr)}`);
+    }
+    if (window.MTLX_PERF_LOG) {
+        console.log('[mtlx-perf] gen.generate: '
+            + (performance.now() - __genPerfStart).toFixed(1) + 'ms (target: ' + label + ')');
+    }
+
+    // Stage identifiers: some JS builds don't expose the
+    // mx.Stage enum object (hence "Cannot read ... 'VERTEX'").
+    // The underlying constant values are just the strings
+    // "vertex" and "pixel", which getSourceCode accepts.
+    const VERTEX_STAGE = (mx.Stage && mx.Stage.VERTEX) || 'vertex';
+    const PIXEL_STAGE = (mx.Stage && mx.Stage.PIXEL) || 'pixel';
+    const vs = stripVersion(mxShader.getSourceCode(VERTEX_STAGE));
+    // hwSrgbEncodeOutput makes MaterialX emit its own sRGB
+    // encode (visible as srgb-named code in the source). Only
+    // inject our fallback when the option didn't take in this
+    // wasm build — double-encoding would wash everything out.
+    let fs = stripVersion(mxShader.getSourceCode(PIXEL_STAGE));
+    fs = patchUnlitLightingRefs(fs);
+    if (!/srgb/i.test(fs)) fs = encodeDisplay(fs);
+    else if (DEBUG_SHADERS) console.log('generator emitted sRGB encode (hwSrgbEncodeOutput) — no injection');
+
+    return { mxShader, vs, fs, VERTEX_STAGE, PIXEL_STAGE };
+};
+
+// ------------------------------------------------------------------
+// applyIntrospectedUniformDefaults — upload MaterialX's introspected
+// uniform DEFAULTS onto a three.js uniforms map. Two modes:
+//   overwrite=false (view creation): explicit bindings already
+//     present on `uniforms` win — skip those names; skip entries with
+//     no default (u.data == null, left for WebGL's implicit 0); then
+//     bind the default checker texture to every unset `filename`
+//     sampler so image/tiledimage nodes render out of the box.
+//   overwrite=true (fast-refresh, tryRefreshRenderView): the
+//     generated source is byte-identical to the live view's, so every
+//     name is already bound on `uniforms` — OVERWRITE each entry's
+//     .value in place (three.js RawShaderMaterial reads .value
+//     per-frame, so mutating it is enough; no material rebuild
+//     needed). Restricted to the 'PublicUniforms' block — that's
+//     where every document-driven input value lives; the
+//     'PrivateUniforms' block (transforms, env, lights) is explicitly
+//     bound by createMtlxRenderView at creation and several of its
+//     entries carry non-null generator defaults that would clobber
+//     those live bindings (u_numActiveLightSources → 0 kills the
+//     direct light; env mips/samples likewise). `filename` entries
+//     are never touched either — the caller rebinds textures via
+//     bindDroppedTextures afterward.
+// ------------------------------------------------------------------
+const PREVIEW_TRANSFORM_UNIFORM_NAMES = new Set([
+    'u_worldMatrix', 'u_viewProjectionMatrix', 'u_worldInverseTransposeMatrix', 'u_viewPosition',
+]);
+const applyIntrospectedUniformDefaults = (uniforms, introspected, { overwrite = false } = {}) => {
+    if (!overwrite) {
+        for (const u of introspected) {
+            if (uniforms[u.name] || u.data == null) continue; // explicit bindings win; no default → leave for WebGL 0
+            const tu = mxValueToThreeUniform(u.type, u.data);
+            if (tu) uniforms[u.name] = tu;
+        }
+        // Bind the default checker to every `filename` sampler
+        // so image/tiledimage nodes render out of the box —
+        // an unbound sampler reads black. (Env samplers are
+        // bound later by name and are not `filename` ports.)
+        for (const u of introspected) {
+            if (u.type === 'filename' && !uniforms[u.name]) {
+                uniforms[u.name] = { value: getDefaultTexture() };
+            }
+        }
+        return;
+    }
+    // Fast-refresh: same values just recomputed from a re-generated
+    // (but byte-identical-source) shader — overwrite in place.
+    for (const u of introspected) {
+        // ONLY the public uniform block: document-driven input values
+        // live exclusively in PublicUniforms. Everything in
+        // PrivateUniforms (transforms, env matrix/mips/samples,
+        // u_numActiveLightSources/u_lightData, refraction flags, ...)
+        // was explicitly bound by createMtlxRenderView at creation and
+        // must never be clobbered by a refresh — several private
+        // entries DO carry non-null generator defaults (e.g.
+        // u_numActiveLightSources defaults to 0, which would silently
+        // kill the direct light rig).
+        if (u.block !== 'PublicUniforms') continue;
+        if (u.data == null) continue;
+        if (u.type === 'filename') continue;
+        // Belt-and-suspenders: the transforms are private-block (so the
+        // block guard above already skips them), but they're the one
+        // thing that would visibly break every frame if ever touched.
+        if (PREVIEW_TRANSFORM_UNIFORM_NAMES.has(u.name)) continue;
+        const tu = mxValueToThreeUniform(u.type, u.data);
+        if (!tu) continue;
+        if (uniforms[u.name]) uniforms[u.name].value = tu.value;
+        else uniforms[u.name] = tu;
+    }
+};
+
+// ------------------------------------------------------------------
+// tryRefreshRenderView — attempt a cheap in-place refresh of an
+// EXISTING render view instead of a full teardown+rebuild. Re-runs
+// shader generation for `renderable` (gen.generate measures 20-40ms —
+// cheap relative to a full WebGLRenderer init + GL compile) and
+// compares the regenerated sources against the live view's compiled
+// vs/fs. When byte-identical (unconnected add/delete, edits on
+// branches that don't feed this preview target, group/ungroup
+// elsewhere in the graph — all cases where the target's shader didn't
+// actually change), only the uniform DEFAULTS are re-uploaded onto
+// the EXISTING compiled material/uniforms object in place — no GL
+// recompile. The caller still owns rebinding dropped textures
+// (bindDroppedTextures) since `filename` entries are intentionally
+// left untouched here.
+// Args: { view, mx, gen, genContext, renderable, label, isMounted }
+// where `view` is a previous createMtlxRenderView() return value.
+// Returns { refreshed: false } when the source changed (or generation
+// threw/bailed) — caller falls back to the full rebuild path, which
+// eats its own +20-40ms regen; that duplicate cost is judged
+// acceptable over plumbing the already-generated sources through,
+// since a real rebuild (renderer + GL compile) dwarfs it anyway.
+// Returns { refreshed: true } when `view.uniforms`/`view.introspected`
+// were updated in place.
+// ------------------------------------------------------------------
+const tryRefreshRenderView = ({ view, mx, gen, genContext, renderable, label, isMounted = () => true }) => {
+    const __t = window.MTLX_PERF_LOG ? performance.now() : 0;
+    let srcs;
+    try {
+        srcs = generatePreviewSources({ mx, gen, genContext, renderable, label, isMounted });
+    } catch (e) {
+        return { refreshed: false };
+    }
+    if (!srcs) return { refreshed: false };
+    if (srcs.vs !== view.vs || srcs.fs !== view.fs) return { refreshed: false };
+
+    let introspected = [];
+    for (const stageName of [srcs.VERTEX_STAGE, srcs.PIXEL_STAGE]) {
+        let st = null;
+        try { st = srcs.mxShader.getStage(stageName); } catch (e) { /* stage absent */ }
+        if (st) introspected = introspected.concat(collectMxUniforms(st));
+    }
+    view.introspected = introspected;
+    applyIntrospectedUniformDefaults(view.uniforms, introspected, { overwrite: true });
+    if (window.MTLX_PERF_LOG) {
+        console.log('[mtlx-perf] preview fast-refresh (source unchanged): '
+            + (performance.now() - __t).toFixed(1) + 'ms (target: ' + label + ')');
+    }
+    return { refreshed: true };
+};
 
 // ------------------------------------------------------------------
 // createMtlxRenderView — the ENTIRE render pipeline for one
@@ -1266,56 +1726,54 @@ const createMtlxRenderView = async ({
         if (controls) controls.dispose();
         if (renderer) renderer.dispose();
     };
+    // [mtlx-perf] whole-function total — everything below, from shader
+    // generation through the GL compile that makes the view handle ready
+    // to return. See the finer-grained gen.generate / WebGLRenderer init /
+    // GL compile timers further down for a breakdown.
+    const __totalPerfStart = window.MTLX_PERF_LOG ? performance.now() : 0;
     try {
-                // Generate the shader from the renderable surface node.
-                // OFFICIAL PARITY: per-material generation options.
-                // Transparency detection switches the generated blending
-                // path (glass etc.); COMPLETE interface exposes every
-                // input as a uniform for the editor.
-                try {
-                    if (typeof mx.isTransparentSurface === 'function') {
-                        genContext.getOptions().hwTransparency =
-                            mx.isTransparentSurface(renderable, gen.getTarget());
-                    }
-                } catch (e) { /* keep previous value */ }
-                try {
-                    if (mx.ShaderInterfaceType) {
-                        genContext.getOptions().shaderInterfaceType =
-                            mx.ShaderInterfaceType.SHADER_INTERFACE_COMPLETE;
-                    }
-                } catch (e) { /* default interface */ }
+                // Generate the shader from the renderable surface node
+                // (transparency + COMPLETE interface options, gen.generate,
+                // stage-source extraction/patching) — see
+                // generatePreviewSources for the full breakdown; extracted
+                // so tryRefreshRenderView can reuse it for a source diff
+                // without pulling in the rest of this function.
+                const __srcs = generatePreviewSources({ mx, gen, genContext, renderable, label, isMounted });
+                // Bail before the ~expensive shader-generation call if this
+                // build has already been superseded (caller's effect
+                // cleanup flipped `mounted` while we were awaiting above) —
+                // nothing GL-side exists yet (renderer isn't created until
+                // below), so disposePartial() is a safe, idempotent no-op
+                // here beyond flagging `stopped`.
+                if (!__srcs) { disposePartial(); return null; }
+                const { mxShader, vs, fs, VERTEX_STAGE, PIXEL_STAGE } = __srcs;
 
-                let mxShader;
-                try {
-                    mxShader = gen.generate('PreviewShader', renderable, genContext);
-                } catch (genErr) {
-                    // Decode the REAL MaterialX error (Emscripten throws
-                    // numeric pointers) instead of a generic string.
-                    throw new Error(`Shader generation failed for "${label}": ${mxErr(mx, genErr)}`);
-                }
-
-                // Stage identifiers: some JS builds don't expose the
-                // mx.Stage enum object (hence "Cannot read ... 'VERTEX'").
-                // The underlying constant values are just the strings
-                // "vertex" and "pixel", which getSourceCode accepts.
-                const VERTEX_STAGE = (mx.Stage && mx.Stage.VERTEX) || 'vertex';
-                const PIXEL_STAGE = (mx.Stage && mx.Stage.PIXEL) || 'pixel';
-                const vs = stripVersion(mxShader.getSourceCode(VERTEX_STAGE));
-                // hwSrgbEncodeOutput makes MaterialX emit its own sRGB
-                // encode (visible as srgb-named code in the source). Only
-                // inject our fallback when the option didn't take in this
-                // wasm build — double-encoding would wash everything out.
-                let fs = stripVersion(mxShader.getSourceCode(PIXEL_STAGE));
-                fs = patchUnlitLightingRefs(fs);
-                if (!/srgb/i.test(fs)) fs = encodeDisplay(fs);
-                else if (DEBUG_SHADERS) console.log('generator emitted sRGB encode (hwSrgbEncodeOutput) — no injection');
-
+                // Pre-warm the driver's shader compile on the persistent
+                // hidden GL context BEFORE the display renderer is created
+                // below. Running the warm first means the display context
+                // is created only AFTER the driver has finished (or is
+                // well underway with) compiling — instead of a fresh
+                // WebGLRenderer init contending with an in-flight
+                // background compile queue on the SAME context (measured
+                // 0.8-2.5s WebGLRenderer init stalls with the old
+                // after-renderer placement). The display path below is
+                // therefore byte-for-byte the original, un-warmed code —
+                // the pre-warm here is a pure side effect that primes the
+                // driver's source-keyed compile cache.
+                const warmResult = await prewarmShaderCompile({ vs, fs, isMounted, label });
+                if (warmResult === 'bailed' || !isMounted()) { disposePartial(); return null; }
 
                 // --- three.js scene (WebGL2) ---
                 // clientWidth can be 0 before layout; fall back so the
                 // viewport isn't 0×0 (which renders nothing → black).
                 const cw = canvas.clientWidth || (canvas.parentElement && canvas.parentElement.clientWidth) || 400;
                 const ch = canvas.clientHeight || 256;
+                // Bail before allocating the WebGL context if this build
+                // was superseded while shader generation was running above
+                // — still nothing GL-side exists yet, so disposePartial()
+                // stays a safe no-op.
+                if (!isMounted()) { disposePartial(); return null; }
+                const __rendererPerfStart = window.MTLX_PERF_LOG ? performance.now() : 0;
                 renderer = new THREE.WebGLRenderer({ canvas, antialias: true, alpha: true });
                 renderer.setSize(cw, ch, false);
                 renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
@@ -1327,6 +1785,10 @@ const createMtlxRenderView = async ({
                 if ('outputEncoding' in renderer) renderer.outputEncoding = THREE.sRGBEncoding;
                 renderer.toneMapping = THREE.ACESFilmicToneMapping;
                 renderer.toneMappingExposure = 1.0;
+                if (window.MTLX_PERF_LOG) {
+                    console.log('[mtlx-perf] WebGLRenderer init: '
+                        + (performance.now() - __rendererPerfStart).toFixed(1) + 'ms');
+                }
 
                 const scene = new THREE.Scene();
                 const camera = new THREE.PerspectiveCamera(45, cw / ch, 0.1, 100);
@@ -1399,20 +1861,7 @@ const createMtlxRenderView = async ({
                     try { st = mxShader.getStage(stageName); } catch (e) { /* stage absent */ }
                     if (st) introspected = introspected.concat(collectMxUniforms(st));
                 }
-                for (const u of introspected) {
-                    if (uniforms[u.name] || u.data == null) continue; // explicit bindings win; no default → leave for WebGL 0
-                    const tu = mxValueToThreeUniform(u.type, u.data);
-                    if (tu) uniforms[u.name] = tu;
-                }
-                // Bind the default checker to every `filename` sampler
-                // so image/tiledimage nodes render out of the box —
-                // an unbound sampler reads black. (Env samplers are
-                // bound later by name and are not `filename` ports.)
-                for (const u of introspected) {
-                    if (u.type === 'filename' && !uniforms[u.name]) {
-                        uniforms[u.name] = { value: getDefaultTexture() };
-                    }
-                }
+                applyIntrospectedUniformDefaults(uniforms, introspected);
                 if (DEBUG_SHADERS) {
                     console.log('introspected uniforms:',
                         introspected.map((u) => `${u.type} ${u.name}${u.data != null ? ' (default uploaded)' : ''}`));
@@ -1532,7 +1981,33 @@ const createMtlxRenderView = async ({
                 // ANGLE/fxc X4008-style warnings — see
                 // compileFilteringDriverNoise.)
                 setUniforms();
+
+                // [mtlx-perf] timing for the actual GL compile — separate
+                // from and nested inside js/graph/preview.jsx's
+                // buildPreviewRenderable timing, which wraps prep+compile
+                // together; this isolates just the renderer.compile() call
+                // below. It's one of several finer-grained timers in this
+                // function (see gen.generate / WebGLRenderer init above and
+                // the whole-function total near the return below) — this
+                // one used to be labeled 'createMtlxRenderView:', which read
+                // as if it covered the whole function; renamed to 'GL
+                // compile:' now that the total timer owns that label. Read
+                // window.MTLX_PERF_LOG defensively rather than the bare
+                // identifier: mtlx-engine.js is eager-loaded before
+                // js/graph/model.jsx (which sets the global), so a top-level
+                // reference could run before it exists — by the time a
+                // preview actually renders here, model.jsx has already
+                // loaded and set it, but this stays defensive on principle.
+                // With the pre-warm above, this is now typically an ANGLE
+                // cache hit (~270ms) instead of a fresh compile (~2.9s) —
+                // see the [mtlx-perf] GL compile wait log for how long the
+                // pre-warm actually took.
+                const __compilePerfStart = window.MTLX_PERF_LOG ? performance.now() : 0;
                 compileFilteringDriverNoise(renderer, scene, camera);
+                if (window.MTLX_PERF_LOG) {
+                    console.log('[mtlx-perf] GL compile: '
+                        + (performance.now() - __compilePerfStart).toFixed(1) + 'ms (target: ' + label + ')');
+                }
                 const badProg = (renderer.info.programs || []).find(
                     (p) => p.diagnostics && p.diagnostics.runnable === false
                 );
@@ -1560,6 +2035,10 @@ const createMtlxRenderView = async ({
                 };
                 animate();
 
+                if (window.MTLX_PERF_LOG) {
+                    console.log('[mtlx-perf] createMtlxRenderView total: '
+                        + (performance.now() - __totalPerfStart).toFixed(1) + 'ms (target: ' + label + ')');
+                }
         return {
             uniforms, introspected, vs, fs, controls, renderer,
             // Live auto-orbit toggle (no regen needed).
@@ -1730,7 +2209,7 @@ Object.assign(window, {
     prepGeometry, normalizeGeometry, buildPreviewGeometry,
     COLOR_VIEWABLE, resolveNodeKind,
     makeEnvTexture, getEnvironment, COLORSPACES,
-    createMtlxRenderView,
+    createMtlxRenderView, tryRefreshRenderView,
     fullscreenElement, toggleFullscreen, watchFullscreen,
     MtlxIcon, MTLX_ICON_PATHS,
 });

--- a/js/node-preview.jsx
+++ b/js/node-preview.jsx
@@ -816,6 +816,10 @@
                             const inputName = inp.getName();
                             const type = inp.getType();
                             const label = attrOf(inp, 'uiname') || inputName;
+                            // Collapsible parameter group this input belongs to
+                            // (item F2.3) — null/absent means "ungrouped",
+                            // rendered at the top of the panel same as before.
+                            const uifolder = attrOf(inp, 'uifolder');
                             let valueStr = null;
                             try { valueStr = inp.getValueString ? inp.getValueString() : null; } catch (e) { /* none */ }
                             const enumAttr = attrOf(inp, 'enum');
@@ -828,14 +832,14 @@
                                 const options = enumAttr ? enumAttr.split(',').map((e2) => e2.trim()).filter(Boolean) : null;
                                 const def = (valueStr != null ? valueStr : (options && options[0])) || '';
                                 return { uniform: 'in::' + inputName, input: inputName, label, type: 'string',
-                                    def, options, regen: true, live: false };
+                                    def, options, regen: true, live: false, uifolder };
                             }
 
                             // FILENAME — needs a live sampler uniform to preview.
                             if (type === 'filename') {
                                 if (!u || !uniforms[u.name]) return null;
                                 return { uniform: u.name, input: inputName, label, type: 'filename', def: null,
-                                    colorspace: attrOf(inp, 'colorspace'), live: true };
+                                    colorspace: attrOf(inp, 'colorspace'), live: true, uifolder };
                             }
 
                             // NUMERIC / VECTOR / COLOR / BOOLEAN.
@@ -846,7 +850,7 @@
                                 // ONLY of them (pbrlib add/mix/multiply):
                                 // show them as read-only connections.
                                 return { uniform: 'in::' + inputName, input: inputName, label, type,
-                                    def: '(connection)', readonly: true, live: false };
+                                    def: '(connection)', readonly: true, live: false, uifolder };
                             }
                             // Numeric enum (name→value) → existing select control.
                             let enumNames = null, enumValues = null;
@@ -867,7 +871,7 @@
                                     if (max <= min) max = min + 1;
                                 }
                                 return { uniform: u.name, input: inputName, label, type, def, min, max,
-                                    enumNames, enumValues, live: true };
+                                    enumNames, enumValues, live: true, uifolder };
                             }
 
                             // No uniform (e.g. an input with a geometric default
@@ -879,7 +883,7 @@
                             const parsed = parseDefault(type, valueStr);
                             return { uniform: 'in::' + inputName, input: inputName, label, type,
                                 def: parsed === undefined ? (valueStr || '(geometry)') : parsed,
-                                readonly: true, live: false };
+                                readonly: true, live: false, uifolder };
                         };
 
                         // Enumerate the node's inputs. Prefer the nodedef whose
@@ -1162,13 +1166,11 @@
                     const chan = p.type === 'color4' ? 'RGBA' : 'RGB';
                     return (
                         <div className="flex items-center gap-1">
-                            <input
-                                type="color"
+                            <ColorSwatch
+                                rgb={rgb}
                                 className="h-7 w-10 bg-transparent border border-gray-600 rounded cursor-pointer flex-none"
                                 title="Linear RGB — hex bytes map 1:1 onto the 0-1 values to the right"
-                                value={rgbToHex(rgb)}
-                                onChange={(e) => {
-                                    const nv = hexToRgb(e.target.value);
+                                onChange={(nv) => {
                                     onParamChange(p, p.type === 'color4' ? nv.concat([cur[3]]) : nv);
                                 }}
                             />
@@ -1205,6 +1207,32 @@
                     </div>
                 );
             };
+
+            // Group params by uifolder (item F2.3): un-foldered params
+            // render first, ungrouped, exactly as before; foldered ones are
+            // bucketed under a collapsible header, preserving the FIRST
+            // appearance order of each folder name. A node with no
+            // uifolder attrs anywhere yields an empty `folders` array, so
+            // the render below falls back to the old flat list untouched.
+            const paramGroups = React.useMemo(() => {
+                const ungrouped = [];
+                const folderOrder = [];
+                const byFolder = new Map();
+                for (const p of params) {
+                    const folder = p.uifolder;
+                    if (!folder) { ungrouped.push(p); continue; }
+                    if (!byFolder.has(folder)) { byFolder.set(folder, []); folderOrder.push(folder); }
+                    byFolder.get(folder).push(p);
+                }
+                return { ungrouped, folders: folderOrder.map((name) => ({ name, params: byFolder.get(name) })) };
+            }, [params]);
+            // Open/closed state per folder name, default expanded (a name
+            // absent from this map reads as open — see `!== false` below).
+            // Reset whenever the selected node/signature changes, same as
+            // resetNonce, so a folder collapsed on one node doesn't leak
+            // its state onto an unrelated one that happens to reuse a name.
+            const [paramFoldersOpen, setParamFoldersOpen] = React.useState({});
+            React.useEffect(() => { setParamFoldersOpen({}); }, [identKey]);
 
             // Desktop (lg+): panel sits to the RIGHT of the preview.
             // Mobile: flex-col stacks it BELOW.
@@ -1275,7 +1303,7 @@
                                 </div>
                             </div>
                             <div className="overflow-y-auto p-3 space-y-3 flex-1 custom-scrollbar">
-                                {params.map((p) => (
+                                {paramGroups.ungrouped.map((p) => (
                                     // Key includes nodeName: different nodes often
                                     // expose SAME-named inputs (image/hextiledimage
                                     // both have `file`), and a reused DOM file
@@ -1288,6 +1316,33 @@
                                         {renderControl(p)}
                                     </div>
                                 ))}
+                                {paramGroups.folders.map((f) => {
+                                    const open = paramFoldersOpen[f.name] !== false;
+                                    return (
+                                        <div key={'folder:' + f.name} className="border-t border-gray-700/70 mt-2 pt-2">
+                                            <button
+                                                type="button"
+                                                onClick={() => setParamFoldersOpen((prev) => Object.assign({}, prev, { [f.name]: !open }))}
+                                                className="w-full flex items-center gap-1.5 text-xs text-gray-400 hover:text-gray-200"
+                                            >
+                                                <MtlxIcon name={open ? 'chevron-down' : 'chevron-right'} className="flex-none w-3.5 h-3.5" />
+                                                <span className="truncate">{f.name}</span>
+                                            </button>
+                                            {open && (
+                                                <div className="mt-2 space-y-3">
+                                                    {f.params.map((p) => (
+                                                        <div key={identKey + ':' + p.uniform + ':' + resetNonce}>
+                                                            <label className="block text-xs text-gray-400 mb-1">
+                                                                {p.label} <span className="text-gray-600">({p.type})</span>
+                                                            </label>
+                                                            {renderControl(p)}
+                                                        </div>
+                                                    ))}
+                                                </div>
+                                            )}
+                                        </div>
+                                    );
+                                })}
                             </div>
                         </div>
                     )}

--- a/js/shared/mtlx-ui.jsx
+++ b/js/shared/mtlx-ui.jsx
@@ -95,6 +95,17 @@ const openInGraphEditor = ({ xml, name, files }) => {
     window.location.hash = '#!graph';
 };
 
+// Hand a document off to the material viewer — the graph editor's "Send to
+// Viewer" counterpart (item F2.2) to openInGraphEditor above. Same shape,
+// mirrored in reverse: stash it (plus any loose files) where
+// js/viewer-app.jsx's 'mtlx-view-document' listener expects it, fire that
+// event, then hash-route over to the viewer.
+const openInViewer = ({ xml, name, files }) => {
+    window.__mtlxPendingViewerImport = { xml, name, files: files || null };
+    window.dispatchEvent(new CustomEvent('mtlx-view-document', { detail: window.__mtlxPendingViewerImport }));
+    window.location.hash = '#!viewer';
+};
+
 // Page-wide drag & drop: files can be dropped ANYWHERE on the page, not
 // just a dedicated drop zone. Registers window-level dragenter/dragover/
 // dragleave/drop listeners exactly once (callbacks are read through refs
@@ -246,8 +257,213 @@ const ViewportControls = ({
     </div>
 );
 
+// Custom color picker swatch — replaces the two native `<input
+// type="color">` uses in the app (js/graph/panels.jsx's color3/color4 row,
+// js/node-preview.jsx's identical param control). Native color inputs open
+// the OS/browser's own picker, which can't be styled or themed and behaves
+// inconsistently across platforms; this popover keeps color editing fully
+// inside the app's own chrome. Speaks the SAME linear-RGB convention as
+// both callers: `rgb` is always `[r, g, b]` floats 0-1, and rgbToHex/
+// hexToRgb (js/mtlx-engine.js — a plain byte<->float mapping, no sRGB
+// transfer) are reused here so the hex field agrees with them exactly.
+// The `position: fixed` popover is portaled onto document.body via
+// ReactDOM.createPortal — a plain in-place sibling would be repositioned
+// by any `backdrop-filter`/`transform` ancestor (see the containing-block
+// explanation on the `popover` variable below).
+const ColorSwatch = ({ rgb, onChange, title, className }) => {
+    const [open, setOpen] = React.useState(false);
+    const [pos, setPos] = React.useState(null); // { left, top } or { left, bottom }
+    // Source of truth WHILE the popover is open. Initialized from `rgb`
+    // only at open time — NOT kept in sync afterward — so dragging
+    // saturation/value at s=0 or v=0 (where hue can't be recovered from
+    // rgb alone) doesn't cause the hue to jump around underneath the user.
+    const [hsv, setHsv] = React.useState({ h: 0, s: 0, v: 0 });
+    const [hexDraft, setHexDraft] = React.useState('');
+    const btnRef = React.useRef(null);
+    const popRef = React.useRef(null);
+    const svRef = React.useRef(null);
+    const hueRef = React.useRef(null);
+
+    // Standard HSV<->RGB formulas, deliberately with NO gamma/sRGB step —
+    // rgb here is already the linear 0-1 value MaterialX stores, and it
+    // should round-trip through hue/sat/value exactly as given.
+    const rgbToHsv = ([r, g, b]) => {
+        const max = Math.max(r, g, b), min = Math.min(r, g, b);
+        const d = max - min;
+        let h = 0;
+        if (d !== 0) {
+            if (max === r) h = 60 * (((g - b) / d) % 6);
+            else if (max === g) h = 60 * ((b - r) / d + 2);
+            else h = 60 * ((r - g) / d + 4);
+            if (h < 0) h += 360;
+        }
+        const s = max === 0 ? 0 : d / max;
+        return { h, s, v: max };
+    };
+    const hsvToRgb = ({ h, s, v }) => {
+        const c = v * s;
+        const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+        const m = v - c;
+        let rp = 0, gp = 0, bp = 0;
+        if (h < 60) { rp = c; gp = x; bp = 0; }
+        else if (h < 120) { rp = x; gp = c; bp = 0; }
+        else if (h < 180) { rp = 0; gp = c; bp = x; }
+        else if (h < 240) { rp = 0; gp = x; bp = c; }
+        else if (h < 300) { rp = x; gp = 0; bp = c; }
+        else { rp = c; gp = 0; bp = x; }
+        return [rp + m, gp + m, bp + m];
+    };
+
+    const POP_W = 176, POP_H = 210; // approx footprint, used only for the flip-above check
+
+    const openPopover = () => {
+        setHsv(rgbToHsv(rgb));
+        setHexDraft(rgbToHex(rgb));
+        const rect = btnRef.current ? btnRef.current.getBoundingClientRect() : null;
+        if (rect) {
+            const flip = rect.bottom + POP_H > window.innerHeight;
+            setPos(flip
+                ? { left: rect.left, bottom: window.innerHeight - rect.top + 4 }
+                : { left: rect.left, top: rect.bottom + 4 });
+        }
+        setOpen(true);
+    };
+
+    useEscapeToClose(() => setOpen(false), open);
+
+    // Close on pointerdown anywhere outside the popover/swatch. The
+    // popover itself stops propagation on its own pointerdown (below), so
+    // this only ever sees genuinely-outside events — the swatch button is
+    // still checked via ref for the rare case a future change removes that.
+    React.useEffect(() => {
+        if (!open) return undefined;
+        const onDown = (e) => {
+            if (popRef.current && popRef.current.contains(e.target)) return;
+            if (btnRef.current && btnRef.current.contains(e.target)) return;
+            setOpen(false);
+        };
+        window.addEventListener('pointerdown', onDown);
+        return () => window.removeEventListener('pointerdown', onDown);
+    }, [open]);
+
+    const setFromHsv = (nextHsv) => {
+        setHsv(nextHsv);
+        onChange(hsvToRgb(nextHsv));
+    };
+
+    const dragSv = (e) => {
+        const el = svRef.current;
+        if (!el) return;
+        const rect = el.getBoundingClientRect();
+        const s = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width));
+        const v = 1 - Math.max(0, Math.min(1, (e.clientY - rect.top) / rect.height));
+        setFromHsv({ h: hsv.h, s, v });
+    };
+    const dragHue = (e) => {
+        const el = hueRef.current;
+        if (!el) return;
+        const rect = el.getBoundingClientRect();
+        const h = Math.max(0, Math.min(360, ((e.clientX - rect.left) / rect.width) * 360));
+        setFromHsv({ h, s: hsv.s, v: hsv.v });
+    };
+
+    const commitHex = () => {
+        let h = hexDraft.trim();
+        if (!h) { setHexDraft(rgbToHex(rgb)); return; }
+        if (h[0] !== '#') h = '#' + h;
+        if (!/^#[0-9a-fA-F]{6}$/.test(h)) { setHexDraft(rgbToHex(rgb)); return; }
+        const nv = hexToRgb(h);
+        setHsv(rgbToHsv(nv));
+        onChange(nv);
+    };
+
+    const swatchCls = className || 'h-7 w-10 bg-transparent border border-gray-600 rounded cursor-pointer flex-none';
+
+    // The popover itself is portaled straight onto <body> via
+    // ReactDOM.createPortal (the UMD build already loaded by index.html —
+    // no dedicated portal infra needed for this one call) instead of being
+    // rendered as a plain DOM sibling. `position: fixed` alone isn't
+    // enough: several dialogs/panels in this app (including the parameter
+    // panel this swatch usually sits in) use Tailwind's `backdrop-blur`
+    // (backdrop-filter), which — like `transform`/`filter`/`will-change:
+    // transform` — establishes a NEW containing block for fixed-position
+    // descendants in Chromium. A fixed popover nested inside one of those
+    // ends up positioned relative to that ancestor's box, not the
+    // viewport, silently landing hundreds of pixels off target. Portaling
+    // to `document.body` sidesteps the whole containing-block question.
+    const popover = open ? (
+        <div
+            ref={popRef}
+            onPointerDown={(e) => e.stopPropagation()}
+            style={Object.assign({ position: 'fixed', zIndex: 9999, width: POP_W }, pos || {})}
+            className="bg-gray-800/95 backdrop-blur border border-gray-600 rounded-lg shadow-2xl p-2.5 space-y-2"
+        >
+            <div
+                ref={svRef}
+                onPointerDown={(e) => { e.currentTarget.setPointerCapture(e.pointerId); dragSv(e); }}
+                onPointerMove={(e) => { if (e.buttons === 1) dragSv(e); }}
+                className="relative w-full h-28 rounded cursor-crosshair"
+                style={{
+                    backgroundColor: 'hsl(' + hsv.h + ', 100%, 50%)',
+                    backgroundImage: 'linear-gradient(to right, #fff, rgba(255,255,255,0)), linear-gradient(to top, #000, rgba(0,0,0,0))',
+                }}
+            >
+                <div
+                    className="absolute w-3 h-3 -ml-1.5 -mt-1.5 rounded-full border-2 border-white shadow pointer-events-none"
+                    style={{ left: (hsv.s * 100) + '%', top: ((1 - hsv.v) * 100) + '%' }}
+                />
+            </div>
+            <div
+                ref={hueRef}
+                onPointerDown={(e) => { e.currentTarget.setPointerCapture(e.pointerId); dragHue(e); }}
+                onPointerMove={(e) => { if (e.buttons === 1) dragHue(e); }}
+                className="relative w-full h-3 rounded cursor-pointer"
+                style={{ background: 'linear-gradient(to right, #f00, #ff0, #0f0, #0ff, #00f, #f0f, #f00)' }}
+            >
+                <div
+                    className="absolute top-1/2 w-1.5 h-4 -ml-[3px] -mt-2 rounded-sm border border-white shadow pointer-events-none"
+                    style={{ left: (hsv.h / 360 * 100) + '%' }}
+                />
+            </div>
+            <div className="flex items-center gap-1.5">
+                <div
+                    className="h-6 w-6 flex-none rounded border border-gray-600"
+                    style={{ background: rgbToHex(rgb) }}
+                />
+                <input
+                    type="text"
+                    value={hexDraft}
+                    onChange={(e) => setHexDraft(e.target.value)}
+                    onBlur={commitHex}
+                    onKeyDown={(e) => {
+                        if (e.key === 'Enter') { commitHex(); e.target.blur(); }
+                        if (e.key === 'Escape') { setHexDraft(rgbToHex(rgb)); e.target.blur(); }
+                    }}
+                    spellCheck={false}
+                    className="flex-1 min-w-0 bg-gray-900 border border-gray-600 rounded px-1.5 py-0.5 text-[11px] font-mono text-gray-200"
+                />
+            </div>
+        </div>
+    ) : null;
+
+    return (
+        <React.Fragment>
+            <button
+                type="button"
+                ref={btnRef}
+                title={title}
+                onClick={() => (open ? setOpen(false) : openPopover())}
+                className={swatchCls}
+                style={{ background: rgbToHex(rgb) }}
+            />
+            {popover && ReactDOM.createPortal(popover, document.body)}
+        </React.Fragment>
+    );
+};
+
 Object.assign(window, {
     useEscapeToClose, useFullscreen, useViewToggle,
-    downloadSnapshot, downloadXml, openInGraphEditor,
+    downloadSnapshot, downloadXml, openInGraphEditor, openInViewer,
     useWindowFileDrop, LoadingOverlay, ViewportControls,
+    ColorSwatch,
 });

--- a/js/site-header.js
+++ b/js/site-header.js
@@ -255,13 +255,20 @@
     }
 
     // Version badge: the engine (mtlx-engine.js) sets window.__mtlxVersion and
-    // dispatches 'mtlx-version' once the WASM reports itself.
+    // dispatches 'mtlx-version' once the WASM reports itself. The home view
+    // never triggers getMxEnv(), though, so window.__mtlxVersion stays unset
+    // there and the badge would otherwise be blank until docs/viewer/graph
+    // loads the WASM. Fall back to the vendored build's known version —
+    // matches the vendored WASM build (see the pinned v1.39.5 spec URL
+    // above); update this when re-vendoring. The live 'mtlx-version' event
+    // still overrides it if they ever differ.
+    var MTLX_VERSION_FALLBACK = '1.39.5';
     var setVer = function (v) {
         if (!v) return;
         var els = document.querySelectorAll('#mtlx-header-version [data-role="ver"], #mtlx-header-version-mobile [data-role="ver"]');
         for (var i = 0; i < els.length; i++) { els[i].textContent = 'v' + v; }
     };
-    if (window.__mtlxVersion) setVer(window.__mtlxVersion);
+    setVer(window.__mtlxVersion || MTLX_VERSION_FALLBACK);
     window.addEventListener('mtlx-version', function (e) { setVer(e.detail || window.__mtlxVersion); });
 
     // ---- Shared footer --------------------------------------------------

--- a/js/vendor/EXRLoader.js
+++ b/js/vendor/EXRLoader.js
@@ -1,0 +1,2189 @@
+/**
+ * Vendored, patched copy of three.js's legacy examples/js UMD EXRLoader.
+ *
+ * Base: three@0.147.0 examples/js/loaders/EXRLoader.js, taken verbatim
+ * (https://unpkg.com/three@0.147.0/examples/js/loaders/EXRLoader.js).
+ * three.js is MIT licensed (https://github.com/mrdoob/three.js/blob/dev/LICENSE);
+ * this file additionally embeds the OpenEXR/TinyEXR notices reproduced below,
+ * unchanged from the upstream file.
+ *
+ * Patch: the DWA decode path in uncompressDWA()/lossyDctDecode() crashed with
+ * "Cannot read properties of undefined (reading 'width') at lossyDctDecode"
+ * on real-world .exr files whose channels are layer-prefixed (e.g. "RGBA.R",
+ * the default naming used by Blender/Nuke exporters). r147's channel-rule
+ * matching used naive `cd.name == rule.name` equality, which never matches a
+ * prefixed name, so lossyDctDecode() ran with an unset cscSet slot. The fix
+ * was ported from three's current ES-module loader,
+ * examples/jsm/loaders/EXRLoader.js, pulled 2026-07-14 from
+ * https://unpkg.com/three@0.185.1/examples/jsm/loaders/EXRLoader.js (the
+ * `latest` tag at fetch time), which contains PRs mrdoob/three.js#27982
+ * (mixed/non-RGB LOSSY_DCT channel decode via lossyDctChannelDecode),
+ * #30709, and #33216 (suffix+type-aware channel-rule matching, and a guard
+ * before calling lossyDctDecode()). Changed vs. r147:
+ *   - the channel-rule matching loop inside uncompressDWA() now compares the
+ *     channel-name suffix after the last '.' plus pixel type, instead of
+ *     the whole name;
+ *   - the call to lossyDctDecode() is now guarded on a complete RGB CSC
+ *     triplet being present;
+ *   - a new lossyDctChannelDecode() function (ported verbatim — it only
+ *     touches its own parameters, not the `info`/EXRDecoder object, so no
+ *     UMD-specific adaptation was needed) decodes LOSSY_DCT channels that
+ *     fall outside that triplet, replacing the previous
+ *     `case LOSSY_DCT: // skip` fallthrough into `throw`.
+ * lossyDctDecode() itself and all other DWA helpers (unRleAC, unZigZag,
+ * dctInverse, csc709Inverse, convertToHalf, toLinear, hufUncompress,
+ * applyLut, predictor, interleaveScalar) were diffed against the same jsm
+ * source and found logic-identical to r147 (formatting/message-text only),
+ * so they were left untouched. No `import`/`export` statements or bare
+ * (non-`THREE.`-prefixed) three.js enum identifiers were introduced by the
+ * port. Date of this patch: 2026-07-14.
+ *
+ * Consumed by js/mtlx-engine.js's loadExrTexture() via
+ * `new THREE.EXRLoader().setDataType( THREE.FloatType ).parse( buf )` —
+ * requires the global `THREE` and `fflate` (loaded first, see index.html)
+ * exactly as the upstream r147 file does.
+ */
+( function () {
+
+	/**
+ * OpenEXR loader currently supports uncompressed, ZIP(S), RLE, PIZ and DWA/B compression.
+ * Supports reading as UnsignedByte, HalfFloat and Float type data texture.
+ *
+ * Referred to the original Industrial Light & Magic OpenEXR implementation and the TinyEXR / Syoyo Fujita
+ * implementation, so I have preserved their copyright notices.
+ */
+
+	// /*
+	// Copyright (c) 2014 - 2017, Syoyo Fujita
+	// All rights reserved.
+
+	// Redistribution and use in source and binary forms, with or without
+	// modification, are permitted provided that the following conditions are met:
+	//     * Redistributions of source code must retain the above copyright
+	//       notice, this list of conditions and the following disclaimer.
+	//     * Redistributions in binary form must reproduce the above copyright
+	//       notice, this list of conditions and the following disclaimer in the
+	//       documentation and/or other materials provided with the distribution.
+	//     * Neither the name of the Syoyo Fujita nor the
+	//       names of its contributors may be used to endorse or promote products
+	//       derived from this software without specific prior written permission.
+
+	// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+	// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+	// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+	// DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+	// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+	// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+	// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+	// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+	// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+	// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+	// */
+
+	// // TinyEXR contains some OpenEXR code, which is licensed under ------------
+
+	// ///////////////////////////////////////////////////////////////////////////
+	// //
+	// // Copyright (c) 2002, Industrial Light & Magic, a division of Lucas
+	// // Digital Ltd. LLC
+	// //
+	// // All rights reserved.
+	// //
+	// // Redistribution and use in source and binary forms, with or without
+	// // modification, are permitted provided that the following conditions are
+	// // met:
+	// // *       Redistributions of source code must retain the above copyright
+	// // notice, this list of conditions and the following disclaimer.
+	// // *       Redistributions in binary form must reproduce the above
+	// // copyright notice, this list of conditions and the following disclaimer
+	// // in the documentation and/or other materials provided with the
+	// // distribution.
+	// // *       Neither the name of Industrial Light & Magic nor the names of
+	// // its contributors may be used to endorse or promote products derived
+	// // from this software without specific prior written permission.
+	// //
+	// // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+	// // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+	// // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+	// // A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+	// // OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+	// // SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+	// // LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+	// // DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+	// // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+	// // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+	// // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+	// //
+	// ///////////////////////////////////////////////////////////////////////////
+
+	// // End of OpenEXR license -------------------------------------------------
+
+	class EXRLoader extends THREE.DataTextureLoader {
+
+		constructor( manager ) {
+
+			super( manager );
+			this.type = THREE.HalfFloatType;
+
+		}
+		parse( buffer ) {
+
+			const USHORT_RANGE = 1 << 16;
+			const BITMAP_SIZE = USHORT_RANGE >> 3;
+			const HUF_ENCBITS = 16; // literal (value) bit length
+			const HUF_DECBITS = 14; // decoding bit size (>= 8)
+
+			const HUF_ENCSIZE = ( 1 << HUF_ENCBITS ) + 1; // encoding table size
+			const HUF_DECSIZE = 1 << HUF_DECBITS; // decoding table size
+			const HUF_DECMASK = HUF_DECSIZE - 1;
+			const NBITS = 16;
+			const A_OFFSET = 1 << NBITS - 1;
+			const MOD_MASK = ( 1 << NBITS ) - 1;
+			const SHORT_ZEROCODE_RUN = 59;
+			const LONG_ZEROCODE_RUN = 63;
+			const SHORTEST_LONG_RUN = 2 + LONG_ZEROCODE_RUN - SHORT_ZEROCODE_RUN;
+			const ULONG_SIZE = 8;
+			const FLOAT32_SIZE = 4;
+			const INT32_SIZE = 4;
+			const INT16_SIZE = 2;
+			const INT8_SIZE = 1;
+			const STATIC_HUFFMAN = 0;
+			const DEFLATE = 1;
+			const UNKNOWN = 0;
+			const LOSSY_DCT = 1;
+			const RLE = 2;
+			const logBase = Math.pow( 2.7182818, 2.2 );
+			function reverseLutFromBitmap( bitmap, lut ) {
+
+				let k = 0;
+				for ( let i = 0; i < USHORT_RANGE; ++ i ) {
+
+					if ( i == 0 || bitmap[ i >> 3 ] & 1 << ( i & 7 ) ) {
+
+						lut[ k ++ ] = i;
+
+					}
+
+				}
+
+				const n = k - 1;
+				while ( k < USHORT_RANGE ) lut[ k ++ ] = 0;
+				return n;
+
+			}
+
+			function hufClearDecTable( hdec ) {
+
+				for ( let i = 0; i < HUF_DECSIZE; i ++ ) {
+
+					hdec[ i ] = {};
+					hdec[ i ].len = 0;
+					hdec[ i ].lit = 0;
+					hdec[ i ].p = null;
+
+				}
+
+			}
+
+			const getBitsReturn = {
+				l: 0,
+				c: 0,
+				lc: 0
+			};
+			function getBits( nBits, c, lc, uInt8Array, inOffset ) {
+
+				while ( lc < nBits ) {
+
+					c = c << 8 | parseUint8Array( uInt8Array, inOffset );
+					lc += 8;
+
+				}
+
+				lc -= nBits;
+				getBitsReturn.l = c >> lc & ( 1 << nBits ) - 1;
+				getBitsReturn.c = c;
+				getBitsReturn.lc = lc;
+
+			}
+
+			const hufTableBuffer = new Array( 59 );
+			function hufCanonicalCodeTable( hcode ) {
+
+				for ( let i = 0; i <= 58; ++ i ) hufTableBuffer[ i ] = 0;
+				for ( let i = 0; i < HUF_ENCSIZE; ++ i ) hufTableBuffer[ hcode[ i ] ] += 1;
+				let c = 0;
+				for ( let i = 58; i > 0; -- i ) {
+
+					const nc = c + hufTableBuffer[ i ] >> 1;
+					hufTableBuffer[ i ] = c;
+					c = nc;
+
+				}
+
+				for ( let i = 0; i < HUF_ENCSIZE; ++ i ) {
+
+					const l = hcode[ i ];
+					if ( l > 0 ) hcode[ i ] = l | hufTableBuffer[ l ] ++ << 6;
+
+				}
+
+			}
+
+			function hufUnpackEncTable( uInt8Array, inOffset, ni, im, iM, hcode ) {
+
+				const p = inOffset;
+				let c = 0;
+				let lc = 0;
+				for ( ; im <= iM; im ++ ) {
+
+					if ( p.value - inOffset.value > ni ) return false;
+					getBits( 6, c, lc, uInt8Array, p );
+					const l = getBitsReturn.l;
+					c = getBitsReturn.c;
+					lc = getBitsReturn.lc;
+					hcode[ im ] = l;
+					if ( l == LONG_ZEROCODE_RUN ) {
+
+						if ( p.value - inOffset.value > ni ) {
+
+							throw new Error( 'Something wrong with hufUnpackEncTable' );
+
+						}
+
+						getBits( 8, c, lc, uInt8Array, p );
+						let zerun = getBitsReturn.l + SHORTEST_LONG_RUN;
+						c = getBitsReturn.c;
+						lc = getBitsReturn.lc;
+						if ( im + zerun > iM + 1 ) {
+
+							throw new Error( 'Something wrong with hufUnpackEncTable' );
+
+						}
+
+						while ( zerun -- ) hcode[ im ++ ] = 0;
+						im --;
+
+					} else if ( l >= SHORT_ZEROCODE_RUN ) {
+
+						let zerun = l - SHORT_ZEROCODE_RUN + 2;
+						if ( im + zerun > iM + 1 ) {
+
+							throw new Error( 'Something wrong with hufUnpackEncTable' );
+
+						}
+
+						while ( zerun -- ) hcode[ im ++ ] = 0;
+						im --;
+
+					}
+
+				}
+
+				hufCanonicalCodeTable( hcode );
+
+			}
+
+			function hufLength( code ) {
+
+				return code & 63;
+
+			}
+
+			function hufCode( code ) {
+
+				return code >> 6;
+
+			}
+
+			function hufBuildDecTable( hcode, im, iM, hdecod ) {
+
+				for ( ; im <= iM; im ++ ) {
+
+					const c = hufCode( hcode[ im ] );
+					const l = hufLength( hcode[ im ] );
+					if ( c >> l ) {
+
+						throw new Error( 'Invalid table entry' );
+
+					}
+
+					if ( l > HUF_DECBITS ) {
+
+						const pl = hdecod[ c >> l - HUF_DECBITS ];
+						if ( pl.len ) {
+
+							throw new Error( 'Invalid table entry' );
+
+						}
+
+						pl.lit ++;
+						if ( pl.p ) {
+
+							const p = pl.p;
+							pl.p = new Array( pl.lit );
+							for ( let i = 0; i < pl.lit - 1; ++ i ) {
+
+								pl.p[ i ] = p[ i ];
+
+							}
+
+						} else {
+
+							pl.p = new Array( 1 );
+
+						}
+
+						pl.p[ pl.lit - 1 ] = im;
+
+					} else if ( l ) {
+
+						let plOffset = 0;
+						for ( let i = 1 << HUF_DECBITS - l; i > 0; i -- ) {
+
+							const pl = hdecod[ ( c << HUF_DECBITS - l ) + plOffset ];
+							if ( pl.len || pl.p ) {
+
+								throw new Error( 'Invalid table entry' );
+
+							}
+
+							pl.len = l;
+							pl.lit = im;
+							plOffset ++;
+
+						}
+
+					}
+
+				}
+
+				return true;
+
+			}
+
+			const getCharReturn = {
+				c: 0,
+				lc: 0
+			};
+			function getChar( c, lc, uInt8Array, inOffset ) {
+
+				c = c << 8 | parseUint8Array( uInt8Array, inOffset );
+				lc += 8;
+				getCharReturn.c = c;
+				getCharReturn.lc = lc;
+
+			}
+
+			const getCodeReturn = {
+				c: 0,
+				lc: 0
+			};
+			function getCode( po, rlc, c, lc, uInt8Array, inOffset, outBuffer, outBufferOffset, outBufferEndOffset ) {
+
+				if ( po == rlc ) {
+
+					if ( lc < 8 ) {
+
+						getChar( c, lc, uInt8Array, inOffset );
+						c = getCharReturn.c;
+						lc = getCharReturn.lc;
+
+					}
+
+					lc -= 8;
+					let cs = c >> lc;
+					cs = new Uint8Array( [ cs ] )[ 0 ];
+					if ( outBufferOffset.value + cs > outBufferEndOffset ) {
+
+						return false;
+
+					}
+
+					const s = outBuffer[ outBufferOffset.value - 1 ];
+					while ( cs -- > 0 ) {
+
+						outBuffer[ outBufferOffset.value ++ ] = s;
+
+					}
+
+				} else if ( outBufferOffset.value < outBufferEndOffset ) {
+
+					outBuffer[ outBufferOffset.value ++ ] = po;
+
+				} else {
+
+					return false;
+
+				}
+
+				getCodeReturn.c = c;
+				getCodeReturn.lc = lc;
+
+			}
+
+			function UInt16( value ) {
+
+				return value & 0xFFFF;
+
+			}
+
+			function Int16( value ) {
+
+				const ref = UInt16( value );
+				return ref > 0x7FFF ? ref - 0x10000 : ref;
+
+			}
+
+			const wdec14Return = {
+				a: 0,
+				b: 0
+			};
+			function wdec14( l, h ) {
+
+				const ls = Int16( l );
+				const hs = Int16( h );
+				const hi = hs;
+				const ai = ls + ( hi & 1 ) + ( hi >> 1 );
+				const as = ai;
+				const bs = ai - hi;
+				wdec14Return.a = as;
+				wdec14Return.b = bs;
+
+			}
+
+			function wdec16( l, h ) {
+
+				const m = UInt16( l );
+				const d = UInt16( h );
+				const bb = m - ( d >> 1 ) & MOD_MASK;
+				const aa = d + bb - A_OFFSET & MOD_MASK;
+				wdec14Return.a = aa;
+				wdec14Return.b = bb;
+
+			}
+
+			function wav2Decode( buffer, j, nx, ox, ny, oy, mx ) {
+
+				const w14 = mx < 1 << 14;
+				const n = nx > ny ? ny : nx;
+				let p = 1;
+				let p2;
+				let py;
+				while ( p <= n ) p <<= 1;
+				p >>= 1;
+				p2 = p;
+				p >>= 1;
+				while ( p >= 1 ) {
+
+					py = 0;
+					const ey = py + oy * ( ny - p2 );
+					const oy1 = oy * p;
+					const oy2 = oy * p2;
+					const ox1 = ox * p;
+					const ox2 = ox * p2;
+					let i00, i01, i10, i11;
+					for ( ; py <= ey; py += oy2 ) {
+
+						let px = py;
+						const ex = py + ox * ( nx - p2 );
+						for ( ; px <= ex; px += ox2 ) {
+
+							const p01 = px + ox1;
+							const p10 = px + oy1;
+							const p11 = p10 + ox1;
+							if ( w14 ) {
+
+								wdec14( buffer[ px + j ], buffer[ p10 + j ] );
+								i00 = wdec14Return.a;
+								i10 = wdec14Return.b;
+								wdec14( buffer[ p01 + j ], buffer[ p11 + j ] );
+								i01 = wdec14Return.a;
+								i11 = wdec14Return.b;
+								wdec14( i00, i01 );
+								buffer[ px + j ] = wdec14Return.a;
+								buffer[ p01 + j ] = wdec14Return.b;
+								wdec14( i10, i11 );
+								buffer[ p10 + j ] = wdec14Return.a;
+								buffer[ p11 + j ] = wdec14Return.b;
+
+							} else {
+
+								wdec16( buffer[ px + j ], buffer[ p10 + j ] );
+								i00 = wdec14Return.a;
+								i10 = wdec14Return.b;
+								wdec16( buffer[ p01 + j ], buffer[ p11 + j ] );
+								i01 = wdec14Return.a;
+								i11 = wdec14Return.b;
+								wdec16( i00, i01 );
+								buffer[ px + j ] = wdec14Return.a;
+								buffer[ p01 + j ] = wdec14Return.b;
+								wdec16( i10, i11 );
+								buffer[ p10 + j ] = wdec14Return.a;
+								buffer[ p11 + j ] = wdec14Return.b;
+
+							}
+
+						}
+
+						if ( nx & p ) {
+
+							const p10 = px + oy1;
+							if ( w14 ) wdec14( buffer[ px + j ], buffer[ p10 + j ] ); else wdec16( buffer[ px + j ], buffer[ p10 + j ] );
+							i00 = wdec14Return.a;
+							buffer[ p10 + j ] = wdec14Return.b;
+							buffer[ px + j ] = i00;
+
+						}
+
+					}
+
+					if ( ny & p ) {
+
+						let px = py;
+						const ex = py + ox * ( nx - p2 );
+						for ( ; px <= ex; px += ox2 ) {
+
+							const p01 = px + ox1;
+							if ( w14 ) wdec14( buffer[ px + j ], buffer[ p01 + j ] ); else wdec16( buffer[ px + j ], buffer[ p01 + j ] );
+							i00 = wdec14Return.a;
+							buffer[ p01 + j ] = wdec14Return.b;
+							buffer[ px + j ] = i00;
+
+						}
+
+					}
+
+					p2 = p;
+					p >>= 1;
+
+				}
+
+				return py;
+
+			}
+
+			function hufDecode( encodingTable, decodingTable, uInt8Array, inOffset, ni, rlc, no, outBuffer, outOffset ) {
+
+				let c = 0;
+				let lc = 0;
+				const outBufferEndOffset = no;
+				const inOffsetEnd = Math.trunc( inOffset.value + ( ni + 7 ) / 8 );
+				while ( inOffset.value < inOffsetEnd ) {
+
+					getChar( c, lc, uInt8Array, inOffset );
+					c = getCharReturn.c;
+					lc = getCharReturn.lc;
+					while ( lc >= HUF_DECBITS ) {
+
+						const index = c >> lc - HUF_DECBITS & HUF_DECMASK;
+						const pl = decodingTable[ index ];
+						if ( pl.len ) {
+
+							lc -= pl.len;
+							getCode( pl.lit, rlc, c, lc, uInt8Array, inOffset, outBuffer, outOffset, outBufferEndOffset );
+							c = getCodeReturn.c;
+							lc = getCodeReturn.lc;
+
+						} else {
+
+							if ( ! pl.p ) {
+
+								throw new Error( 'hufDecode issues' );
+
+							}
+
+							let j;
+							for ( j = 0; j < pl.lit; j ++ ) {
+
+								const l = hufLength( encodingTable[ pl.p[ j ] ] );
+								while ( lc < l && inOffset.value < inOffsetEnd ) {
+
+									getChar( c, lc, uInt8Array, inOffset );
+									c = getCharReturn.c;
+									lc = getCharReturn.lc;
+
+								}
+
+								if ( lc >= l ) {
+
+									if ( hufCode( encodingTable[ pl.p[ j ] ] ) == ( c >> lc - l & ( 1 << l ) - 1 ) ) {
+
+										lc -= l;
+										getCode( pl.p[ j ], rlc, c, lc, uInt8Array, inOffset, outBuffer, outOffset, outBufferEndOffset );
+										c = getCodeReturn.c;
+										lc = getCodeReturn.lc;
+										break;
+
+									}
+
+								}
+
+							}
+
+							if ( j == pl.lit ) {
+
+								throw new Error( 'hufDecode issues' );
+
+							}
+
+						}
+
+					}
+
+				}
+
+				const i = 8 - ni & 7;
+				c >>= i;
+				lc -= i;
+				while ( lc > 0 ) {
+
+					const pl = decodingTable[ c << HUF_DECBITS - lc & HUF_DECMASK ];
+					if ( pl.len ) {
+
+						lc -= pl.len;
+						getCode( pl.lit, rlc, c, lc, uInt8Array, inOffset, outBuffer, outOffset, outBufferEndOffset );
+						c = getCodeReturn.c;
+						lc = getCodeReturn.lc;
+
+					} else {
+
+						throw new Error( 'hufDecode issues' );
+
+					}
+
+				}
+
+				return true;
+
+			}
+
+			function hufUncompress( uInt8Array, inDataView, inOffset, nCompressed, outBuffer, nRaw ) {
+
+				const outOffset = {
+					value: 0
+				};
+				const initialInOffset = inOffset.value;
+				const im = parseUint32( inDataView, inOffset );
+				const iM = parseUint32( inDataView, inOffset );
+				inOffset.value += 4;
+				const nBits = parseUint32( inDataView, inOffset );
+				inOffset.value += 4;
+				if ( im < 0 || im >= HUF_ENCSIZE || iM < 0 || iM >= HUF_ENCSIZE ) {
+
+					throw new Error( 'Something wrong with HUF_ENCSIZE' );
+
+				}
+
+				const freq = new Array( HUF_ENCSIZE );
+				const hdec = new Array( HUF_DECSIZE );
+				hufClearDecTable( hdec );
+				const ni = nCompressed - ( inOffset.value - initialInOffset );
+				hufUnpackEncTable( uInt8Array, inOffset, ni, im, iM, freq );
+				if ( nBits > 8 * ( nCompressed - ( inOffset.value - initialInOffset ) ) ) {
+
+					throw new Error( 'Something wrong with hufUncompress' );
+
+				}
+
+				hufBuildDecTable( freq, im, iM, hdec );
+				hufDecode( freq, hdec, uInt8Array, inOffset, nBits, iM, nRaw, outBuffer, outOffset );
+
+			}
+
+			function applyLut( lut, data, nData ) {
+
+				for ( let i = 0; i < nData; ++ i ) {
+
+					data[ i ] = lut[ data[ i ] ];
+
+				}
+
+			}
+
+			function predictor( source ) {
+
+				for ( let t = 1; t < source.length; t ++ ) {
+
+					const d = source[ t - 1 ] + source[ t ] - 128;
+					source[ t ] = d;
+
+				}
+
+			}
+
+			function interleaveScalar( source, out ) {
+
+				let t1 = 0;
+				let t2 = Math.floor( ( source.length + 1 ) / 2 );
+				let s = 0;
+				const stop = source.length - 1;
+				while ( true ) {
+
+					if ( s > stop ) break;
+					out[ s ++ ] = source[ t1 ++ ];
+					if ( s > stop ) break;
+					out[ s ++ ] = source[ t2 ++ ];
+
+				}
+
+			}
+
+			function decodeRunLength( source ) {
+
+				let size = source.byteLength;
+				const out = new Array();
+				let p = 0;
+				const reader = new DataView( source );
+				while ( size > 0 ) {
+
+					const l = reader.getInt8( p ++ );
+					if ( l < 0 ) {
+
+						const count = - l;
+						size -= count + 1;
+						for ( let i = 0; i < count; i ++ ) {
+
+							out.push( reader.getUint8( p ++ ) );
+
+						}
+
+					} else {
+
+						const count = l;
+						size -= 2;
+						const value = reader.getUint8( p ++ );
+						for ( let i = 0; i < count + 1; i ++ ) {
+
+							out.push( value );
+
+						}
+
+					}
+
+				}
+
+				return out;
+
+			}
+
+			function lossyDctDecode( cscSet, rowPtrs, channelData, acBuffer, dcBuffer, outBuffer ) {
+
+				let dataView = new DataView( outBuffer.buffer );
+				const width = channelData[ cscSet.idx[ 0 ] ].width;
+				const height = channelData[ cscSet.idx[ 0 ] ].height;
+				const numComp = 3;
+				const numFullBlocksX = Math.floor( width / 8.0 );
+				const numBlocksX = Math.ceil( width / 8.0 );
+				const numBlocksY = Math.ceil( height / 8.0 );
+				const leftoverX = width - ( numBlocksX - 1 ) * 8;
+				const leftoverY = height - ( numBlocksY - 1 ) * 8;
+				const currAcComp = {
+					value: 0
+				};
+				const currDcComp = new Array( numComp );
+				const dctData = new Array( numComp );
+				const halfZigBlock = new Array( numComp );
+				const rowBlock = new Array( numComp );
+				const rowOffsets = new Array( numComp );
+				for ( let comp = 0; comp < numComp; ++ comp ) {
+
+					rowOffsets[ comp ] = rowPtrs[ cscSet.idx[ comp ] ];
+					currDcComp[ comp ] = comp < 1 ? 0 : currDcComp[ comp - 1 ] + numBlocksX * numBlocksY;
+					dctData[ comp ] = new Float32Array( 64 );
+					halfZigBlock[ comp ] = new Uint16Array( 64 );
+					rowBlock[ comp ] = new Uint16Array( numBlocksX * 64 );
+
+				}
+
+				for ( let blocky = 0; blocky < numBlocksY; ++ blocky ) {
+
+					let maxY = 8;
+					if ( blocky == numBlocksY - 1 ) maxY = leftoverY;
+					let maxX = 8;
+					for ( let blockx = 0; blockx < numBlocksX; ++ blockx ) {
+
+						if ( blockx == numBlocksX - 1 ) maxX = leftoverX;
+						for ( let comp = 0; comp < numComp; ++ comp ) {
+
+							halfZigBlock[ comp ].fill( 0 );
+
+							// set block DC component
+							halfZigBlock[ comp ][ 0 ] = dcBuffer[ currDcComp[ comp ] ++ ];
+							// set block AC components
+							unRleAC( currAcComp, acBuffer, halfZigBlock[ comp ] );
+
+							// UnZigZag block to float
+							unZigZag( halfZigBlock[ comp ], dctData[ comp ] );
+							// decode float dct
+							dctInverse( dctData[ comp ] );
+
+						}
+
+						if ( numComp == 3 ) {
+
+							csc709Inverse( dctData );
+
+						}
+
+						for ( let comp = 0; comp < numComp; ++ comp ) {
+
+							convertToHalf( dctData[ comp ], rowBlock[ comp ], blockx * 64 );
+
+						}
+
+					} // blockx
+
+					let offset = 0;
+					for ( let comp = 0; comp < numComp; ++ comp ) {
+
+						const type = channelData[ cscSet.idx[ comp ] ].type;
+						for ( let y = 8 * blocky; y < 8 * blocky + maxY; ++ y ) {
+
+							offset = rowOffsets[ comp ][ y ];
+							for ( let blockx = 0; blockx < numFullBlocksX; ++ blockx ) {
+
+								const src = blockx * 64 + ( y & 0x7 ) * 8;
+								dataView.setUint16( offset + 0 * INT16_SIZE * type, rowBlock[ comp ][ src + 0 ], true );
+								dataView.setUint16( offset + 1 * INT16_SIZE * type, rowBlock[ comp ][ src + 1 ], true );
+								dataView.setUint16( offset + 2 * INT16_SIZE * type, rowBlock[ comp ][ src + 2 ], true );
+								dataView.setUint16( offset + 3 * INT16_SIZE * type, rowBlock[ comp ][ src + 3 ], true );
+								dataView.setUint16( offset + 4 * INT16_SIZE * type, rowBlock[ comp ][ src + 4 ], true );
+								dataView.setUint16( offset + 5 * INT16_SIZE * type, rowBlock[ comp ][ src + 5 ], true );
+								dataView.setUint16( offset + 6 * INT16_SIZE * type, rowBlock[ comp ][ src + 6 ], true );
+								dataView.setUint16( offset + 7 * INT16_SIZE * type, rowBlock[ comp ][ src + 7 ], true );
+								offset += 8 * INT16_SIZE * type;
+
+							}
+
+						}
+
+						// handle partial X blocks
+						if ( numFullBlocksX != numBlocksX ) {
+
+							for ( let y = 8 * blocky; y < 8 * blocky + maxY; ++ y ) {
+
+								const offset = rowOffsets[ comp ][ y ] + 8 * numFullBlocksX * INT16_SIZE * type;
+								const src = numFullBlocksX * 64 + ( y & 0x7 ) * 8;
+								for ( let x = 0; x < maxX; ++ x ) {
+
+									dataView.setUint16( offset + x * INT16_SIZE * type, rowBlock[ comp ][ src + x ], true );
+
+								}
+
+							}
+
+						}
+
+					} // comp
+
+				} // blocky
+
+				const halfRow = new Uint16Array( width );
+				dataView = new DataView( outBuffer.buffer );
+
+				// convert channels back to float, if needed
+				for ( let comp = 0; comp < numComp; ++ comp ) {
+
+					channelData[ cscSet.idx[ comp ] ].decoded = true;
+					const type = channelData[ cscSet.idx[ comp ] ].type;
+					if ( channelData[ comp ].type != 2 ) continue;
+					for ( let y = 0; y < height; ++ y ) {
+
+						const offset = rowOffsets[ comp ][ y ];
+						for ( let x = 0; x < width; ++ x ) {
+
+							halfRow[ x ] = dataView.getUint16( offset + x * INT16_SIZE * type, true );
+
+						}
+
+						for ( let x = 0; x < width; ++ x ) {
+
+							dataView.setFloat32( offset + x * INT16_SIZE * type, decodeFloat16( halfRow[ x ] ), true );
+
+						}
+
+					}
+
+				}
+
+			}
+
+			// Decodes a single LOSSY_DCT channel that isn't part of an RGB CSC
+			// triplet (e.g. a standalone "A" or "Y" channel, or any channel in a
+			// file with layer-prefixed names where only one channel matched a
+			// given rule). Companion to lossyDctDecode() above, which only
+			// handles the 3-channel RGB case. Ported verbatim from three.js
+			// examples/jsm/loaders/EXRLoader.js (PR #27982); this function does
+			// not reference the `info` object so no field-name adaptation was
+			// needed to fit this UMD build's EXRDecoder shape.
+			function lossyDctChannelDecode( channelIndex, rowPtrs, channelData, acBuffer, dcBuffer, outBuffer ) {
+
+				const dataView = new DataView( outBuffer.buffer );
+				const cd = channelData[ channelIndex ];
+				const width = cd.width;
+				const height = cd.height;
+
+				const numBlocksX = Math.ceil( width / 8.0 );
+				const numBlocksY = Math.ceil( height / 8.0 );
+				const numFullBlocksX = Math.floor( width / 8.0 );
+				const leftoverX = width - ( numBlocksX - 1 ) * 8;
+				const leftoverY = height - ( numBlocksY - 1 ) * 8;
+
+				const currAcComp = { value: 0 };
+				let currDcComp = 0;
+				const dctData = new Float32Array( 64 );
+				const halfZigBlock = new Uint16Array( 64 );
+				const rowBlock = new Uint16Array( numBlocksX * 64 );
+
+				for ( let blocky = 0; blocky < numBlocksY; ++ blocky ) {
+
+					let maxY = 8;
+					if ( blocky == numBlocksY - 1 ) maxY = leftoverY;
+
+					for ( let blockx = 0; blockx < numBlocksX; ++ blockx ) {
+
+						halfZigBlock.fill( 0 );
+						halfZigBlock[ 0 ] = dcBuffer[ currDcComp ++ ];
+						unRleAC( currAcComp, acBuffer, halfZigBlock );
+						unZigZag( halfZigBlock, dctData );
+						dctInverse( dctData );
+						convertToHalf( dctData, rowBlock, blockx * 64 );
+
+					}
+
+					// Write decoded data to output buffer
+					for ( let y = 8 * blocky; y < 8 * blocky + maxY; ++ y ) {
+
+						let offset = rowPtrs[ channelIndex ][ y ];
+
+						for ( let blockx = 0; blockx < numFullBlocksX; ++ blockx ) {
+
+							const src = blockx * 64 + ( ( y & 0x7 ) * 8 );
+
+							for ( let x = 0; x < 8; ++ x ) {
+
+								dataView.setUint16( offset + x * INT16_SIZE * cd.type, rowBlock[ src + x ], true );
+
+							}
+
+							offset += 8 * INT16_SIZE * cd.type;
+
+						}
+
+						if ( numBlocksX != numFullBlocksX ) {
+
+							const src = numFullBlocksX * 64 + ( ( y & 0x7 ) * 8 );
+
+							for ( let x = 0; x < leftoverX; ++ x ) {
+
+								dataView.setUint16( offset + x * INT16_SIZE * cd.type, rowBlock[ src + x ], true );
+
+							}
+
+						}
+
+					}
+
+				}
+
+				cd.decoded = true;
+
+			}
+
+			function unRleAC( currAcComp, acBuffer, halfZigBlock ) {
+
+				let acValue;
+				let dctComp = 1;
+				while ( dctComp < 64 ) {
+
+					acValue = acBuffer[ currAcComp.value ];
+					if ( acValue == 0xff00 ) {
+
+						dctComp = 64;
+
+					} else if ( acValue >> 8 == 0xff ) {
+
+						dctComp += acValue & 0xff;
+
+					} else {
+
+						halfZigBlock[ dctComp ] = acValue;
+						dctComp ++;
+
+					}
+
+					currAcComp.value ++;
+
+				}
+
+			}
+
+			function unZigZag( src, dst ) {
+
+				dst[ 0 ] = decodeFloat16( src[ 0 ] );
+				dst[ 1 ] = decodeFloat16( src[ 1 ] );
+				dst[ 2 ] = decodeFloat16( src[ 5 ] );
+				dst[ 3 ] = decodeFloat16( src[ 6 ] );
+				dst[ 4 ] = decodeFloat16( src[ 14 ] );
+				dst[ 5 ] = decodeFloat16( src[ 15 ] );
+				dst[ 6 ] = decodeFloat16( src[ 27 ] );
+				dst[ 7 ] = decodeFloat16( src[ 28 ] );
+				dst[ 8 ] = decodeFloat16( src[ 2 ] );
+				dst[ 9 ] = decodeFloat16( src[ 4 ] );
+				dst[ 10 ] = decodeFloat16( src[ 7 ] );
+				dst[ 11 ] = decodeFloat16( src[ 13 ] );
+				dst[ 12 ] = decodeFloat16( src[ 16 ] );
+				dst[ 13 ] = decodeFloat16( src[ 26 ] );
+				dst[ 14 ] = decodeFloat16( src[ 29 ] );
+				dst[ 15 ] = decodeFloat16( src[ 42 ] );
+				dst[ 16 ] = decodeFloat16( src[ 3 ] );
+				dst[ 17 ] = decodeFloat16( src[ 8 ] );
+				dst[ 18 ] = decodeFloat16( src[ 12 ] );
+				dst[ 19 ] = decodeFloat16( src[ 17 ] );
+				dst[ 20 ] = decodeFloat16( src[ 25 ] );
+				dst[ 21 ] = decodeFloat16( src[ 30 ] );
+				dst[ 22 ] = decodeFloat16( src[ 41 ] );
+				dst[ 23 ] = decodeFloat16( src[ 43 ] );
+				dst[ 24 ] = decodeFloat16( src[ 9 ] );
+				dst[ 25 ] = decodeFloat16( src[ 11 ] );
+				dst[ 26 ] = decodeFloat16( src[ 18 ] );
+				dst[ 27 ] = decodeFloat16( src[ 24 ] );
+				dst[ 28 ] = decodeFloat16( src[ 31 ] );
+				dst[ 29 ] = decodeFloat16( src[ 40 ] );
+				dst[ 30 ] = decodeFloat16( src[ 44 ] );
+				dst[ 31 ] = decodeFloat16( src[ 53 ] );
+				dst[ 32 ] = decodeFloat16( src[ 10 ] );
+				dst[ 33 ] = decodeFloat16( src[ 19 ] );
+				dst[ 34 ] = decodeFloat16( src[ 23 ] );
+				dst[ 35 ] = decodeFloat16( src[ 32 ] );
+				dst[ 36 ] = decodeFloat16( src[ 39 ] );
+				dst[ 37 ] = decodeFloat16( src[ 45 ] );
+				dst[ 38 ] = decodeFloat16( src[ 52 ] );
+				dst[ 39 ] = decodeFloat16( src[ 54 ] );
+				dst[ 40 ] = decodeFloat16( src[ 20 ] );
+				dst[ 41 ] = decodeFloat16( src[ 22 ] );
+				dst[ 42 ] = decodeFloat16( src[ 33 ] );
+				dst[ 43 ] = decodeFloat16( src[ 38 ] );
+				dst[ 44 ] = decodeFloat16( src[ 46 ] );
+				dst[ 45 ] = decodeFloat16( src[ 51 ] );
+				dst[ 46 ] = decodeFloat16( src[ 55 ] );
+				dst[ 47 ] = decodeFloat16( src[ 60 ] );
+				dst[ 48 ] = decodeFloat16( src[ 21 ] );
+				dst[ 49 ] = decodeFloat16( src[ 34 ] );
+				dst[ 50 ] = decodeFloat16( src[ 37 ] );
+				dst[ 51 ] = decodeFloat16( src[ 47 ] );
+				dst[ 52 ] = decodeFloat16( src[ 50 ] );
+				dst[ 53 ] = decodeFloat16( src[ 56 ] );
+				dst[ 54 ] = decodeFloat16( src[ 59 ] );
+				dst[ 55 ] = decodeFloat16( src[ 61 ] );
+				dst[ 56 ] = decodeFloat16( src[ 35 ] );
+				dst[ 57 ] = decodeFloat16( src[ 36 ] );
+				dst[ 58 ] = decodeFloat16( src[ 48 ] );
+				dst[ 59 ] = decodeFloat16( src[ 49 ] );
+				dst[ 60 ] = decodeFloat16( src[ 57 ] );
+				dst[ 61 ] = decodeFloat16( src[ 58 ] );
+				dst[ 62 ] = decodeFloat16( src[ 62 ] );
+				dst[ 63 ] = decodeFloat16( src[ 63 ] );
+
+			}
+
+			function dctInverse( data ) {
+
+				const a = 0.5 * Math.cos( 3.14159 / 4.0 );
+				const b = 0.5 * Math.cos( 3.14159 / 16.0 );
+				const c = 0.5 * Math.cos( 3.14159 / 8.0 );
+				const d = 0.5 * Math.cos( 3.0 * 3.14159 / 16.0 );
+				const e = 0.5 * Math.cos( 5.0 * 3.14159 / 16.0 );
+				const f = 0.5 * Math.cos( 3.0 * 3.14159 / 8.0 );
+				const g = 0.5 * Math.cos( 7.0 * 3.14159 / 16.0 );
+				const alpha = new Array( 4 );
+				const beta = new Array( 4 );
+				const theta = new Array( 4 );
+				const gamma = new Array( 4 );
+				for ( let row = 0; row < 8; ++ row ) {
+
+					const rowPtr = row * 8;
+					alpha[ 0 ] = c * data[ rowPtr + 2 ];
+					alpha[ 1 ] = f * data[ rowPtr + 2 ];
+					alpha[ 2 ] = c * data[ rowPtr + 6 ];
+					alpha[ 3 ] = f * data[ rowPtr + 6 ];
+					beta[ 0 ] = b * data[ rowPtr + 1 ] + d * data[ rowPtr + 3 ] + e * data[ rowPtr + 5 ] + g * data[ rowPtr + 7 ];
+					beta[ 1 ] = d * data[ rowPtr + 1 ] - g * data[ rowPtr + 3 ] - b * data[ rowPtr + 5 ] - e * data[ rowPtr + 7 ];
+					beta[ 2 ] = e * data[ rowPtr + 1 ] - b * data[ rowPtr + 3 ] + g * data[ rowPtr + 5 ] + d * data[ rowPtr + 7 ];
+					beta[ 3 ] = g * data[ rowPtr + 1 ] - e * data[ rowPtr + 3 ] + d * data[ rowPtr + 5 ] - b * data[ rowPtr + 7 ];
+					theta[ 0 ] = a * ( data[ rowPtr + 0 ] + data[ rowPtr + 4 ] );
+					theta[ 3 ] = a * ( data[ rowPtr + 0 ] - data[ rowPtr + 4 ] );
+					theta[ 1 ] = alpha[ 0 ] + alpha[ 3 ];
+					theta[ 2 ] = alpha[ 1 ] - alpha[ 2 ];
+					gamma[ 0 ] = theta[ 0 ] + theta[ 1 ];
+					gamma[ 1 ] = theta[ 3 ] + theta[ 2 ];
+					gamma[ 2 ] = theta[ 3 ] - theta[ 2 ];
+					gamma[ 3 ] = theta[ 0 ] - theta[ 1 ];
+					data[ rowPtr + 0 ] = gamma[ 0 ] + beta[ 0 ];
+					data[ rowPtr + 1 ] = gamma[ 1 ] + beta[ 1 ];
+					data[ rowPtr + 2 ] = gamma[ 2 ] + beta[ 2 ];
+					data[ rowPtr + 3 ] = gamma[ 3 ] + beta[ 3 ];
+					data[ rowPtr + 4 ] = gamma[ 3 ] - beta[ 3 ];
+					data[ rowPtr + 5 ] = gamma[ 2 ] - beta[ 2 ];
+					data[ rowPtr + 6 ] = gamma[ 1 ] - beta[ 1 ];
+					data[ rowPtr + 7 ] = gamma[ 0 ] - beta[ 0 ];
+
+				}
+
+				for ( let column = 0; column < 8; ++ column ) {
+
+					alpha[ 0 ] = c * data[ 16 + column ];
+					alpha[ 1 ] = f * data[ 16 + column ];
+					alpha[ 2 ] = c * data[ 48 + column ];
+					alpha[ 3 ] = f * data[ 48 + column ];
+					beta[ 0 ] = b * data[ 8 + column ] + d * data[ 24 + column ] + e * data[ 40 + column ] + g * data[ 56 + column ];
+					beta[ 1 ] = d * data[ 8 + column ] - g * data[ 24 + column ] - b * data[ 40 + column ] - e * data[ 56 + column ];
+					beta[ 2 ] = e * data[ 8 + column ] - b * data[ 24 + column ] + g * data[ 40 + column ] + d * data[ 56 + column ];
+					beta[ 3 ] = g * data[ 8 + column ] - e * data[ 24 + column ] + d * data[ 40 + column ] - b * data[ 56 + column ];
+					theta[ 0 ] = a * ( data[ column ] + data[ 32 + column ] );
+					theta[ 3 ] = a * ( data[ column ] - data[ 32 + column ] );
+					theta[ 1 ] = alpha[ 0 ] + alpha[ 3 ];
+					theta[ 2 ] = alpha[ 1 ] - alpha[ 2 ];
+					gamma[ 0 ] = theta[ 0 ] + theta[ 1 ];
+					gamma[ 1 ] = theta[ 3 ] + theta[ 2 ];
+					gamma[ 2 ] = theta[ 3 ] - theta[ 2 ];
+					gamma[ 3 ] = theta[ 0 ] - theta[ 1 ];
+					data[ 0 + column ] = gamma[ 0 ] + beta[ 0 ];
+					data[ 8 + column ] = gamma[ 1 ] + beta[ 1 ];
+					data[ 16 + column ] = gamma[ 2 ] + beta[ 2 ];
+					data[ 24 + column ] = gamma[ 3 ] + beta[ 3 ];
+					data[ 32 + column ] = gamma[ 3 ] - beta[ 3 ];
+					data[ 40 + column ] = gamma[ 2 ] - beta[ 2 ];
+					data[ 48 + column ] = gamma[ 1 ] - beta[ 1 ];
+					data[ 56 + column ] = gamma[ 0 ] - beta[ 0 ];
+
+				}
+
+			}
+
+			function csc709Inverse( data ) {
+
+				for ( let i = 0; i < 64; ++ i ) {
+
+					const y = data[ 0 ][ i ];
+					const cb = data[ 1 ][ i ];
+					const cr = data[ 2 ][ i ];
+					data[ 0 ][ i ] = y + 1.5747 * cr;
+					data[ 1 ][ i ] = y - 0.1873 * cb - 0.4682 * cr;
+					data[ 2 ][ i ] = y + 1.8556 * cb;
+
+				}
+
+			}
+
+			function convertToHalf( src, dst, idx ) {
+
+				for ( let i = 0; i < 64; ++ i ) {
+
+					dst[ idx + i ] = THREE.DataUtils.toHalfFloat( toLinear( src[ i ] ) );
+
+				}
+
+			}
+
+			function toLinear( float ) {
+
+				if ( float <= 1 ) {
+
+					return Math.sign( float ) * Math.pow( Math.abs( float ), 2.2 );
+
+				} else {
+
+					return Math.sign( float ) * Math.pow( logBase, Math.abs( float ) - 1.0 );
+
+				}
+
+			}
+
+			function uncompressRAW( info ) {
+
+				return new DataView( info.array.buffer, info.offset.value, info.size );
+
+			}
+
+			function uncompressRLE( info ) {
+
+				const compressed = info.viewer.buffer.slice( info.offset.value, info.offset.value + info.size );
+				const rawBuffer = new Uint8Array( decodeRunLength( compressed ) );
+				const tmpBuffer = new Uint8Array( rawBuffer.length );
+				predictor( rawBuffer ); // revert predictor
+
+				interleaveScalar( rawBuffer, tmpBuffer ); // interleave pixels
+
+				return new DataView( tmpBuffer.buffer );
+
+			}
+
+			function uncompressZIP( info ) {
+
+				const compressed = info.array.slice( info.offset.value, info.offset.value + info.size );
+				if ( typeof fflate === 'undefined' ) {
+
+					console.error( 'THREE.EXRLoader: External library fflate.min.js required.' );
+
+				}
+
+				const rawBuffer = fflate.unzlibSync( compressed ); // eslint-disable-line no-undef
+				const tmpBuffer = new Uint8Array( rawBuffer.length );
+				predictor( rawBuffer ); // revert predictor
+
+				interleaveScalar( rawBuffer, tmpBuffer ); // interleave pixels
+
+				return new DataView( tmpBuffer.buffer );
+
+			}
+
+			function uncompressPIZ( info ) {
+
+				const inDataView = info.viewer;
+				const inOffset = {
+					value: info.offset.value
+				};
+				const outBuffer = new Uint16Array( info.width * info.scanlineBlockSize * ( info.channels * info.type ) );
+				const bitmap = new Uint8Array( BITMAP_SIZE );
+
+				// Setup channel info
+				let outBufferEnd = 0;
+				const pizChannelData = new Array( info.channels );
+				for ( let i = 0; i < info.channels; i ++ ) {
+
+					pizChannelData[ i ] = {};
+					pizChannelData[ i ][ 'start' ] = outBufferEnd;
+					pizChannelData[ i ][ 'end' ] = pizChannelData[ i ][ 'start' ];
+					pizChannelData[ i ][ 'nx' ] = info.width;
+					pizChannelData[ i ][ 'ny' ] = info.lines;
+					pizChannelData[ i ][ 'size' ] = info.type;
+					outBufferEnd += pizChannelData[ i ].nx * pizChannelData[ i ].ny * pizChannelData[ i ].size;
+
+				}
+
+				// Read range compression data
+
+				const minNonZero = parseUint16( inDataView, inOffset );
+				const maxNonZero = parseUint16( inDataView, inOffset );
+				if ( maxNonZero >= BITMAP_SIZE ) {
+
+					throw new Error( 'Something is wrong with PIZ_COMPRESSION BITMAP_SIZE' );
+
+				}
+
+				if ( minNonZero <= maxNonZero ) {
+
+					for ( let i = 0; i < maxNonZero - minNonZero + 1; i ++ ) {
+
+						bitmap[ i + minNonZero ] = parseUint8( inDataView, inOffset );
+
+					}
+
+				}
+
+				// Reverse LUT
+				const lut = new Uint16Array( USHORT_RANGE );
+				const maxValue = reverseLutFromBitmap( bitmap, lut );
+				const length = parseUint32( inDataView, inOffset );
+
+				// Huffman decoding
+				hufUncompress( info.array, inDataView, inOffset, length, outBuffer, outBufferEnd );
+
+				// Wavelet decoding
+				for ( let i = 0; i < info.channels; ++ i ) {
+
+					const cd = pizChannelData[ i ];
+					for ( let j = 0; j < pizChannelData[ i ].size; ++ j ) {
+
+						wav2Decode( outBuffer, cd.start + j, cd.nx, cd.size, cd.ny, cd.nx * cd.size, maxValue );
+
+					}
+
+				}
+
+				// Expand the pixel data to their original range
+				applyLut( lut, outBuffer, outBufferEnd );
+
+				// Rearrange the pixel data into the format expected by the caller.
+				let tmpOffset = 0;
+				const tmpBuffer = new Uint8Array( outBuffer.buffer.byteLength );
+				for ( let y = 0; y < info.lines; y ++ ) {
+
+					for ( let c = 0; c < info.channels; c ++ ) {
+
+						const cd = pizChannelData[ c ];
+						const n = cd.nx * cd.size;
+						const cp = new Uint8Array( outBuffer.buffer, cd.end * INT16_SIZE, n * INT16_SIZE );
+						tmpBuffer.set( cp, tmpOffset );
+						tmpOffset += n * INT16_SIZE;
+						cd.end += n;
+
+					}
+
+				}
+
+				return new DataView( tmpBuffer.buffer );
+
+			}
+
+			function uncompressPXR( info ) {
+
+				const compressed = info.array.slice( info.offset.value, info.offset.value + info.size );
+				if ( typeof fflate === 'undefined' ) {
+
+					console.error( 'THREE.EXRLoader: External library fflate.min.js required.' );
+
+				}
+
+				const rawBuffer = fflate.unzlibSync( compressed ); // eslint-disable-line no-undef
+
+				const sz = info.lines * info.channels * info.width;
+				const tmpBuffer = info.type == 1 ? new Uint16Array( sz ) : new Uint32Array( sz );
+				let tmpBufferEnd = 0;
+				let writePtr = 0;
+				const ptr = new Array( 4 );
+				for ( let y = 0; y < info.lines; y ++ ) {
+
+					for ( let c = 0; c < info.channels; c ++ ) {
+
+						let pixel = 0;
+						switch ( info.type ) {
+
+							case 1:
+								ptr[ 0 ] = tmpBufferEnd;
+								ptr[ 1 ] = ptr[ 0 ] + info.width;
+								tmpBufferEnd = ptr[ 1 ] + info.width;
+								for ( let j = 0; j < info.width; ++ j ) {
+
+									const diff = rawBuffer[ ptr[ 0 ] ++ ] << 8 | rawBuffer[ ptr[ 1 ] ++ ];
+									pixel += diff;
+									tmpBuffer[ writePtr ] = pixel;
+									writePtr ++;
+
+								}
+
+								break;
+							case 2:
+								ptr[ 0 ] = tmpBufferEnd;
+								ptr[ 1 ] = ptr[ 0 ] + info.width;
+								ptr[ 2 ] = ptr[ 1 ] + info.width;
+								tmpBufferEnd = ptr[ 2 ] + info.width;
+								for ( let j = 0; j < info.width; ++ j ) {
+
+									const diff = rawBuffer[ ptr[ 0 ] ++ ] << 24 | rawBuffer[ ptr[ 1 ] ++ ] << 16 | rawBuffer[ ptr[ 2 ] ++ ] << 8;
+									pixel += diff;
+									tmpBuffer[ writePtr ] = pixel;
+									writePtr ++;
+
+								}
+
+								break;
+
+						}
+
+					}
+
+				}
+
+				return new DataView( tmpBuffer.buffer );
+
+			}
+
+			function uncompressDWA( info ) {
+
+				const inDataView = info.viewer;
+				const inOffset = {
+					value: info.offset.value
+				};
+				const outBuffer = new Uint8Array( info.width * info.lines * ( info.channels * info.type * INT16_SIZE ) );
+
+				// Read compression header information
+				const dwaHeader = {
+					version: parseInt64( inDataView, inOffset ),
+					unknownUncompressedSize: parseInt64( inDataView, inOffset ),
+					unknownCompressedSize: parseInt64( inDataView, inOffset ),
+					acCompressedSize: parseInt64( inDataView, inOffset ),
+					dcCompressedSize: parseInt64( inDataView, inOffset ),
+					rleCompressedSize: parseInt64( inDataView, inOffset ),
+					rleUncompressedSize: parseInt64( inDataView, inOffset ),
+					rleRawSize: parseInt64( inDataView, inOffset ),
+					totalAcUncompressedCount: parseInt64( inDataView, inOffset ),
+					totalDcUncompressedCount: parseInt64( inDataView, inOffset ),
+					acCompression: parseInt64( inDataView, inOffset )
+				};
+				if ( dwaHeader.version < 2 ) throw new Error( 'EXRLoader.parse: ' + EXRHeader.compression + ' version ' + dwaHeader.version + ' is unsupported' );
+
+				// Read channel ruleset information
+				const channelRules = new Array();
+				let ruleSize = parseUint16( inDataView, inOffset ) - INT16_SIZE;
+				while ( ruleSize > 0 ) {
+
+					const name = parseNullTerminatedString( inDataView.buffer, inOffset );
+					const value = parseUint8( inDataView, inOffset );
+					const compression = value >> 2 & 3;
+					const csc = ( value >> 4 ) - 1;
+					const index = new Int8Array( [ csc ] )[ 0 ];
+					const type = parseUint8( inDataView, inOffset );
+					channelRules.push( {
+						name: name,
+						index: index,
+						type: type,
+						compression: compression
+					} );
+					ruleSize -= name.length + 3;
+
+				}
+
+				// Classify channels
+				const channels = EXRHeader.channels;
+				const channelData = new Array( info.channels );
+				for ( let i = 0; i < info.channels; ++ i ) {
+
+					const cd = channelData[ i ] = {};
+					const channel = channels[ i ];
+					cd.name = channel.name;
+					cd.compression = UNKNOWN;
+					cd.decoded = false;
+					cd.type = channel.pixelType;
+					cd.pLinear = channel.pLinear;
+					cd.width = info.width;
+					cd.height = info.lines;
+
+				}
+
+				const cscSet = {
+					idx: new Array( 3 )
+				};
+				for ( let offset = 0; offset < info.channels; ++ offset ) {
+
+					const cd = channelData[ offset ];
+					// Match channel rules by suffix (text after the last '.') and pixel
+					// type, not raw name equality: layer-prefixed channel names (e.g.
+					// "RGBA.R" from Blender/Nuke) never equal a bare rule name like "R",
+					// so the naive `cd.name == rule.name` check left cscSet.idx slots
+					// unset and cd.compression stuck at UNKNOWN, which crashed
+					// lossyDctDecode() (undefined.width) once it ran unconditionally.
+					// Ported from three.js examples/jsm/loaders/EXRLoader.js (PR #33216).
+					const dotIndex = cd.name.lastIndexOf( '.' );
+					const suffix = dotIndex >= 0 ? cd.name.substring( dotIndex + 1 ) : cd.name;
+					for ( let i = 0; i < channelRules.length; ++ i ) {
+
+						const rule = channelRules[ i ];
+						if ( suffix === rule.name && cd.type === rule.type ) {
+
+							cd.compression = rule.compression;
+							if ( rule.index >= 0 ) {
+
+								cscSet.idx[ rule.index ] = offset;
+
+							}
+
+							cd.offset = offset;
+
+						}
+
+					}
+
+				}
+
+				let acBuffer, dcBuffer, rleBuffer;
+
+				// Read DCT - AC component data
+				if ( dwaHeader.acCompressedSize > 0 ) {
+
+					switch ( dwaHeader.acCompression ) {
+
+						case STATIC_HUFFMAN:
+							acBuffer = new Uint16Array( dwaHeader.totalAcUncompressedCount );
+							hufUncompress( info.array, inDataView, inOffset, dwaHeader.acCompressedSize, acBuffer, dwaHeader.totalAcUncompressedCount );
+							break;
+						case DEFLATE:
+							const compressed = info.array.slice( inOffset.value, inOffset.value + dwaHeader.totalAcUncompressedCount );
+							const data = fflate.unzlibSync( compressed ); // eslint-disable-line no-undef
+							acBuffer = new Uint16Array( data.buffer );
+							inOffset.value += dwaHeader.totalAcUncompressedCount;
+							break;
+
+					}
+
+				}
+
+				// Read DCT - DC component data
+				if ( dwaHeader.dcCompressedSize > 0 ) {
+
+					const zlibInfo = {
+						array: info.array,
+						offset: inOffset,
+						size: dwaHeader.dcCompressedSize
+					};
+					dcBuffer = new Uint16Array( uncompressZIP( zlibInfo ).buffer );
+					inOffset.value += dwaHeader.dcCompressedSize;
+
+				}
+
+				// Read RLE compressed data
+				if ( dwaHeader.rleRawSize > 0 ) {
+
+					const compressed = info.array.slice( inOffset.value, inOffset.value + dwaHeader.rleCompressedSize );
+					const data = fflate.unzlibSync( compressed ); // eslint-disable-line no-undef
+					rleBuffer = decodeRunLength( data.buffer );
+					inOffset.value += dwaHeader.rleCompressedSize;
+
+				}
+
+				// Prepare outbuffer data offset
+				let outBufferEnd = 0;
+				const rowOffsets = new Array( channelData.length );
+				for ( let i = 0; i < rowOffsets.length; ++ i ) {
+
+					rowOffsets[ i ] = new Array();
+
+				}
+
+				for ( let y = 0; y < info.lines; ++ y ) {
+
+					for ( let chan = 0; chan < channelData.length; ++ chan ) {
+
+						rowOffsets[ chan ].push( outBufferEnd );
+						outBufferEnd += channelData[ chan ].width * info.type * INT16_SIZE;
+
+					}
+
+				}
+
+				// Lossy DCT decode RGB channels. Guarded (previously unconditional):
+				// a file with no complete RGB CSC triplet — e.g. only a "Z" or "A"
+				// channel classified as LOSSY_DCT — left cscSet.idx[0] undefined, and
+				// calling lossyDctDecode() unconditionally then read
+				// channelData[undefined].width and crashed. Ported from three.js
+				// examples/jsm/loaders/EXRLoader.js (PR #33216).
+				if ( cscSet.idx[ 0 ] !== undefined && channelData[ cscSet.idx[ 0 ] ] ) {
+
+					lossyDctDecode( cscSet, rowOffsets, channelData, acBuffer, dcBuffer, outBuffer );
+
+				}
+
+				// Decode other channels
+				for ( let i = 0; i < channelData.length; ++ i ) {
+
+					const cd = channelData[ i ];
+					if ( cd.decoded ) continue;
+					switch ( cd.compression ) {
+
+						case RLE:
+							let row = 0;
+							let rleOffset = 0;
+							for ( let y = 0; y < info.lines; ++ y ) {
+
+								let rowOffsetBytes = rowOffsets[ i ][ row ];
+								for ( let x = 0; x < cd.width; ++ x ) {
+
+									for ( let byte = 0; byte < INT16_SIZE * cd.type; ++ byte ) {
+
+										outBuffer[ rowOffsetBytes ++ ] = rleBuffer[ rleOffset + byte * cd.width * cd.height ];
+
+									}
+
+									rleOffset ++;
+
+								}
+
+								row ++;
+
+							}
+
+							break;
+						// LOSSY_DCT channels that aren't part of the RGB CSC triplet
+						// above (e.g. a standalone "A" or "Y" channel) are decoded
+						// individually here instead of being skipped/thrown. Ported
+						// from three.js examples/jsm/loaders/EXRLoader.js (PR #27982).
+						case LOSSY_DCT:
+							lossyDctChannelDecode( i, rowOffsets, channelData, acBuffer, dcBuffer, outBuffer );
+							break;
+						default:
+							throw new Error( 'EXRLoader.parse: unsupported channel compression' );
+
+					}
+
+				}
+
+				return new DataView( outBuffer.buffer );
+
+			}
+
+			function parseNullTerminatedString( buffer, offset ) {
+
+				const uintBuffer = new Uint8Array( buffer );
+				let endOffset = 0;
+				while ( uintBuffer[ offset.value + endOffset ] != 0 ) {
+
+					endOffset += 1;
+
+				}
+
+				const stringValue = new TextDecoder().decode( uintBuffer.slice( offset.value, offset.value + endOffset ) );
+				offset.value = offset.value + endOffset + 1;
+				return stringValue;
+
+			}
+
+			function parseFixedLengthString( buffer, offset, size ) {
+
+				const stringValue = new TextDecoder().decode( new Uint8Array( buffer ).slice( offset.value, offset.value + size ) );
+				offset.value = offset.value + size;
+				return stringValue;
+
+			}
+
+			function parseRational( dataView, offset ) {
+
+				const x = parseInt32( dataView, offset );
+				const y = parseUint32( dataView, offset );
+				return [ x, y ];
+
+			}
+
+			function parseTimecode( dataView, offset ) {
+
+				const x = parseUint32( dataView, offset );
+				const y = parseUint32( dataView, offset );
+				return [ x, y ];
+
+			}
+
+			function parseInt32( dataView, offset ) {
+
+				const Int32 = dataView.getInt32( offset.value, true );
+				offset.value = offset.value + INT32_SIZE;
+				return Int32;
+
+			}
+
+			function parseUint32( dataView, offset ) {
+
+				const Uint32 = dataView.getUint32( offset.value, true );
+				offset.value = offset.value + INT32_SIZE;
+				return Uint32;
+
+			}
+
+			function parseUint8Array( uInt8Array, offset ) {
+
+				const Uint8 = uInt8Array[ offset.value ];
+				offset.value = offset.value + INT8_SIZE;
+				return Uint8;
+
+			}
+
+			function parseUint8( dataView, offset ) {
+
+				const Uint8 = dataView.getUint8( offset.value );
+				offset.value = offset.value + INT8_SIZE;
+				return Uint8;
+
+			}
+
+			const parseInt64 = function ( dataView, offset ) {
+
+				const Int64 = Number( dataView.getBigInt64( offset.value, true ) );
+				offset.value += ULONG_SIZE;
+				return Int64;
+
+			};
+
+			function parseFloat32( dataView, offset ) {
+
+				const float = dataView.getFloat32( offset.value, true );
+				offset.value += FLOAT32_SIZE;
+				return float;
+
+			}
+
+			function decodeFloat32( dataView, offset ) {
+
+				return THREE.DataUtils.toHalfFloat( parseFloat32( dataView, offset ) );
+
+			}
+
+			// https://stackoverflow.com/questions/5678432/decompressing-half-precision-floats-in-javascript
+			function decodeFloat16( binary ) {
+
+				const exponent = ( binary & 0x7C00 ) >> 10,
+					fraction = binary & 0x03FF;
+				return ( binary >> 15 ? - 1 : 1 ) * ( exponent ? exponent === 0x1F ? fraction ? NaN : Infinity : Math.pow( 2, exponent - 15 ) * ( 1 + fraction / 0x400 ) : 6.103515625e-5 * ( fraction / 0x400 ) );
+
+			}
+
+			function parseUint16( dataView, offset ) {
+
+				const Uint16 = dataView.getUint16( offset.value, true );
+				offset.value += INT16_SIZE;
+				return Uint16;
+
+			}
+
+			function parseFloat16( buffer, offset ) {
+
+				return decodeFloat16( parseUint16( buffer, offset ) );
+
+			}
+
+			function parseChlist( dataView, buffer, offset, size ) {
+
+				const startOffset = offset.value;
+				const channels = [];
+				while ( offset.value < startOffset + size - 1 ) {
+
+					const name = parseNullTerminatedString( buffer, offset );
+					const pixelType = parseInt32( dataView, offset );
+					const pLinear = parseUint8( dataView, offset );
+					offset.value += 3; // reserved, three chars
+					const xSampling = parseInt32( dataView, offset );
+					const ySampling = parseInt32( dataView, offset );
+					channels.push( {
+						name: name,
+						pixelType: pixelType,
+						pLinear: pLinear,
+						xSampling: xSampling,
+						ySampling: ySampling
+					} );
+
+				}
+
+				offset.value += 1;
+				return channels;
+
+			}
+
+			function parseChromaticities( dataView, offset ) {
+
+				const redX = parseFloat32( dataView, offset );
+				const redY = parseFloat32( dataView, offset );
+				const greenX = parseFloat32( dataView, offset );
+				const greenY = parseFloat32( dataView, offset );
+				const blueX = parseFloat32( dataView, offset );
+				const blueY = parseFloat32( dataView, offset );
+				const whiteX = parseFloat32( dataView, offset );
+				const whiteY = parseFloat32( dataView, offset );
+				return {
+					redX: redX,
+					redY: redY,
+					greenX: greenX,
+					greenY: greenY,
+					blueX: blueX,
+					blueY: blueY,
+					whiteX: whiteX,
+					whiteY: whiteY
+				};
+
+			}
+
+			function parseCompression( dataView, offset ) {
+
+				const compressionCodes = [ 'NO_COMPRESSION', 'RLE_COMPRESSION', 'ZIPS_COMPRESSION', 'ZIP_COMPRESSION', 'PIZ_COMPRESSION', 'PXR24_COMPRESSION', 'B44_COMPRESSION', 'B44A_COMPRESSION', 'DWAA_COMPRESSION', 'DWAB_COMPRESSION' ];
+				const compression = parseUint8( dataView, offset );
+				return compressionCodes[ compression ];
+
+			}
+
+			function parseBox2i( dataView, offset ) {
+
+				const xMin = parseUint32( dataView, offset );
+				const yMin = parseUint32( dataView, offset );
+				const xMax = parseUint32( dataView, offset );
+				const yMax = parseUint32( dataView, offset );
+				return {
+					xMin: xMin,
+					yMin: yMin,
+					xMax: xMax,
+					yMax: yMax
+				};
+
+			}
+
+			function parseLineOrder( dataView, offset ) {
+
+				const lineOrders = [ 'INCREASING_Y' ];
+				const lineOrder = parseUint8( dataView, offset );
+				return lineOrders[ lineOrder ];
+
+			}
+
+			function parseV2f( dataView, offset ) {
+
+				const x = parseFloat32( dataView, offset );
+				const y = parseFloat32( dataView, offset );
+				return [ x, y ];
+
+			}
+
+			function parseV3f( dataView, offset ) {
+
+				const x = parseFloat32( dataView, offset );
+				const y = parseFloat32( dataView, offset );
+				const z = parseFloat32( dataView, offset );
+				return [ x, y, z ];
+
+			}
+
+			function parseValue( dataView, buffer, offset, type, size ) {
+
+				if ( type === 'string' || type === 'stringvector' || type === 'iccProfile' ) {
+
+					return parseFixedLengthString( buffer, offset, size );
+
+				} else if ( type === 'chlist' ) {
+
+					return parseChlist( dataView, buffer, offset, size );
+
+				} else if ( type === 'chromaticities' ) {
+
+					return parseChromaticities( dataView, offset );
+
+				} else if ( type === 'compression' ) {
+
+					return parseCompression( dataView, offset );
+
+				} else if ( type === 'box2i' ) {
+
+					return parseBox2i( dataView, offset );
+
+				} else if ( type === 'lineOrder' ) {
+
+					return parseLineOrder( dataView, offset );
+
+				} else if ( type === 'float' ) {
+
+					return parseFloat32( dataView, offset );
+
+				} else if ( type === 'v2f' ) {
+
+					return parseV2f( dataView, offset );
+
+				} else if ( type === 'v3f' ) {
+
+					return parseV3f( dataView, offset );
+
+				} else if ( type === 'int' ) {
+
+					return parseInt32( dataView, offset );
+
+				} else if ( type === 'rational' ) {
+
+					return parseRational( dataView, offset );
+
+				} else if ( type === 'timecode' ) {
+
+					return parseTimecode( dataView, offset );
+
+				} else if ( type === 'preview' ) {
+
+					offset.value += size;
+					return 'skipped';
+
+				} else {
+
+					offset.value += size;
+					return undefined;
+
+				}
+
+			}
+
+			function parseHeader( dataView, buffer, offset ) {
+
+				const EXRHeader = {};
+				if ( dataView.getUint32( 0, true ) != 20000630 ) {
+
+					// magic
+
+					throw new Error( 'THREE.EXRLoader: provided file doesn\'t appear to be in OpenEXR format.' );
+
+				}
+
+				EXRHeader.version = dataView.getUint8( 4 );
+				const spec = dataView.getUint8( 5 ); // fullMask
+
+				EXRHeader.spec = {
+					singleTile: !! ( spec & 2 ),
+					longName: !! ( spec & 4 ),
+					deepFormat: !! ( spec & 8 ),
+					multiPart: !! ( spec & 16 )
+				};
+
+				// start of header
+
+				offset.value = 8; // start at 8 - after pre-amble
+
+				let keepReading = true;
+				while ( keepReading ) {
+
+					const attributeName = parseNullTerminatedString( buffer, offset );
+					if ( attributeName == 0 ) {
+
+						keepReading = false;
+
+					} else {
+
+						const attributeType = parseNullTerminatedString( buffer, offset );
+						const attributeSize = parseUint32( dataView, offset );
+						const attributeValue = parseValue( dataView, buffer, offset, attributeType, attributeSize );
+						if ( attributeValue === undefined ) {
+
+							console.warn( `EXRLoader.parse: skipped unknown header attribute type \'${attributeType}\'.` );
+
+						} else {
+
+							EXRHeader[ attributeName ] = attributeValue;
+
+						}
+
+					}
+
+				}
+
+				if ( ( spec & ~ 0x04 ) != 0 ) {
+
+					// unsupported tiled, deep-image, multi-part
+
+					console.error( 'EXRHeader:', EXRHeader );
+					throw new Error( 'THREE.EXRLoader: provided file is currently unsupported.' );
+
+				}
+
+				return EXRHeader;
+
+			}
+
+			function setupDecoder( EXRHeader, dataView, uInt8Array, offset, outputType ) {
+
+				const EXRDecoder = {
+					size: 0,
+					viewer: dataView,
+					array: uInt8Array,
+					offset: offset,
+					width: EXRHeader.dataWindow.xMax - EXRHeader.dataWindow.xMin + 1,
+					height: EXRHeader.dataWindow.yMax - EXRHeader.dataWindow.yMin + 1,
+					channels: EXRHeader.channels.length,
+					bytesPerLine: null,
+					lines: null,
+					inputSize: null,
+					type: EXRHeader.channels[ 0 ].pixelType,
+					uncompress: null,
+					getter: null,
+					format: null,
+					encoding: null
+				};
+				switch ( EXRHeader.compression ) {
+
+					case 'NO_COMPRESSION':
+						EXRDecoder.lines = 1;
+						EXRDecoder.uncompress = uncompressRAW;
+						break;
+					case 'RLE_COMPRESSION':
+						EXRDecoder.lines = 1;
+						EXRDecoder.uncompress = uncompressRLE;
+						break;
+					case 'ZIPS_COMPRESSION':
+						EXRDecoder.lines = 1;
+						EXRDecoder.uncompress = uncompressZIP;
+						break;
+					case 'ZIP_COMPRESSION':
+						EXRDecoder.lines = 16;
+						EXRDecoder.uncompress = uncompressZIP;
+						break;
+					case 'PIZ_COMPRESSION':
+						EXRDecoder.lines = 32;
+						EXRDecoder.uncompress = uncompressPIZ;
+						break;
+					case 'PXR24_COMPRESSION':
+						EXRDecoder.lines = 16;
+						EXRDecoder.uncompress = uncompressPXR;
+						break;
+					case 'DWAA_COMPRESSION':
+						EXRDecoder.lines = 32;
+						EXRDecoder.uncompress = uncompressDWA;
+						break;
+					case 'DWAB_COMPRESSION':
+						EXRDecoder.lines = 256;
+						EXRDecoder.uncompress = uncompressDWA;
+						break;
+					default:
+						throw new Error( 'EXRLoader.parse: ' + EXRHeader.compression + ' is unsupported' );
+
+				}
+
+				EXRDecoder.scanlineBlockSize = EXRDecoder.lines;
+				if ( EXRDecoder.type == 1 ) {
+
+					// half
+					switch ( outputType ) {
+
+						case THREE.FloatType:
+							EXRDecoder.getter = parseFloat16;
+							EXRDecoder.inputSize = INT16_SIZE;
+							break;
+						case THREE.HalfFloatType:
+							EXRDecoder.getter = parseUint16;
+							EXRDecoder.inputSize = INT16_SIZE;
+							break;
+
+					}
+
+				} else if ( EXRDecoder.type == 2 ) {
+
+					// float
+					switch ( outputType ) {
+
+						case THREE.FloatType:
+							EXRDecoder.getter = parseFloat32;
+							EXRDecoder.inputSize = FLOAT32_SIZE;
+							break;
+						case THREE.HalfFloatType:
+							EXRDecoder.getter = decodeFloat32;
+							EXRDecoder.inputSize = FLOAT32_SIZE;
+
+					}
+
+				} else {
+
+					throw new Error( 'EXRLoader.parse: unsupported pixelType ' + EXRDecoder.type + ' for ' + EXRHeader.compression + '.' );
+
+				}
+
+				EXRDecoder.blockCount = ( EXRHeader.dataWindow.yMax + 1 ) / EXRDecoder.scanlineBlockSize;
+				for ( let i = 0; i < EXRDecoder.blockCount; i ++ ) parseInt64( dataView, offset ); // scanlineOffset
+
+				// we should be passed the scanline offset table, ready to start reading pixel data.
+
+				// RGB images will be converted to RGBA format, preventing software emulation in select devices.
+				EXRDecoder.outputChannels = EXRDecoder.channels == 3 ? 4 : EXRDecoder.channels;
+				const size = EXRDecoder.width * EXRDecoder.height * EXRDecoder.outputChannels;
+				switch ( outputType ) {
+
+					case THREE.FloatType:
+						EXRDecoder.byteArray = new Float32Array( size );
+
+						// Fill initially with 1s for the alpha value if the texture is not RGBA, RGB values will be overwritten
+						if ( EXRDecoder.channels < EXRDecoder.outputChannels ) EXRDecoder.byteArray.fill( 1, 0, size );
+						break;
+					case THREE.HalfFloatType:
+						EXRDecoder.byteArray = new Uint16Array( size );
+						if ( EXRDecoder.channels < EXRDecoder.outputChannels ) EXRDecoder.byteArray.fill( 0x3C00, 0, size ); // Uint16Array holds half float data, 0x3C00 is 1
+
+						break;
+					default:
+						console.error( 'THREE.EXRLoader: unsupported type: ', outputType );
+						break;
+
+				}
+
+				EXRDecoder.bytesPerLine = EXRDecoder.width * EXRDecoder.inputSize * EXRDecoder.channels;
+				if ( EXRDecoder.outputChannels == 4 ) {
+
+					EXRDecoder.format = THREE.RGBAFormat;
+					EXRDecoder.encoding = THREE.LinearEncoding;
+
+				} else {
+
+					EXRDecoder.format = THREE.RedFormat;
+					EXRDecoder.encoding = THREE.LinearEncoding;
+
+				}
+
+				return EXRDecoder;
+
+			}
+
+			// start parsing file [START]
+
+			const bufferDataView = new DataView( buffer );
+			const uInt8Array = new Uint8Array( buffer );
+			const offset = {
+				value: 0
+			};
+
+			// get header information and validate format.
+			const EXRHeader = parseHeader( bufferDataView, buffer, offset );
+
+			// get input compression information and prepare decoding.
+			const EXRDecoder = setupDecoder( EXRHeader, bufferDataView, uInt8Array, offset, this.type );
+			const tmpOffset = {
+				value: 0
+			};
+			const channelOffsets = {
+				R: 0,
+				G: 1,
+				B: 2,
+				A: 3,
+				Y: 0
+			};
+			for ( let scanlineBlockIdx = 0; scanlineBlockIdx < EXRDecoder.height / EXRDecoder.scanlineBlockSize; scanlineBlockIdx ++ ) {
+
+				const line = parseUint32( bufferDataView, offset ); // line_no
+				EXRDecoder.size = parseUint32( bufferDataView, offset ); // data_len
+				EXRDecoder.lines = line + EXRDecoder.scanlineBlockSize > EXRDecoder.height ? EXRDecoder.height - line : EXRDecoder.scanlineBlockSize;
+				const isCompressed = EXRDecoder.size < EXRDecoder.lines * EXRDecoder.bytesPerLine;
+				const viewer = isCompressed ? EXRDecoder.uncompress( EXRDecoder ) : uncompressRAW( EXRDecoder );
+				offset.value += EXRDecoder.size;
+				for ( let line_y = 0; line_y < EXRDecoder.scanlineBlockSize; line_y ++ ) {
+
+					const true_y = line_y + scanlineBlockIdx * EXRDecoder.scanlineBlockSize;
+					if ( true_y >= EXRDecoder.height ) break;
+					for ( let channelID = 0; channelID < EXRDecoder.channels; channelID ++ ) {
+
+						const cOff = channelOffsets[ EXRHeader.channels[ channelID ].name ];
+						for ( let x = 0; x < EXRDecoder.width; x ++ ) {
+
+							tmpOffset.value = ( line_y * ( EXRDecoder.channels * EXRDecoder.width ) + channelID * EXRDecoder.width + x ) * EXRDecoder.inputSize;
+							const outIndex = ( EXRDecoder.height - 1 - true_y ) * ( EXRDecoder.width * EXRDecoder.outputChannels ) + x * EXRDecoder.outputChannels + cOff;
+							EXRDecoder.byteArray[ outIndex ] = EXRDecoder.getter( viewer, tmpOffset );
+
+						}
+
+					}
+
+				}
+
+			}
+
+			return {
+				header: EXRHeader,
+				width: EXRDecoder.width,
+				height: EXRDecoder.height,
+				data: EXRDecoder.byteArray,
+				format: EXRDecoder.format,
+				encoding: EXRDecoder.encoding,
+				type: this.type
+			};
+
+		}
+		setDataType( value ) {
+
+			this.type = value;
+			return this;
+
+		}
+		load( url, onLoad, onProgress, onError ) {
+
+			function onLoadCallback( texture, texData ) {
+
+				texture.encoding = texData.encoding;
+				texture.minFilter = THREE.LinearFilter;
+				texture.magFilter = THREE.LinearFilter;
+				texture.generateMipmaps = false;
+				texture.flipY = false;
+				if ( onLoad ) onLoad( texture, texData );
+
+			}
+
+			return super.load( url, onLoadCallback, onProgress, onError );
+
+		}
+
+	}
+
+	THREE.EXRLoader = EXRLoader;
+
+} )();

--- a/js/viewer-app.jsx
+++ b/js/viewer-app.jsx
@@ -249,6 +249,43 @@
                 onDragState: setDragOver,
             });
 
+            // ---- Receive a material handed off from the node graph editor
+            // (item F2.2's counterpart to the "Send to Editor" button below:
+            // js/graph-app.jsx's "Send to Viewer" button stashes the payload
+            // on window.__mtlxPendingViewerImport, dispatches
+            // 'mtlx-view-document', and jumps the hash to #!viewer). On
+            // arrival here there may already be a pending payload (checked
+            // once on mount) and/or more may arrive later while this tab
+            // stays open (the event). Routed through ingestRef, exactly like
+            // the drag-drop handler above — a .mtlx in the map already
+            // replaces the current session per ingest()'s own semantics, so
+            // no extra confirm dialog is needed here (unlike the graph
+            // editor's guardedIngest, which guards against losing unsaved
+            // graph edits — the viewer has no such concept).
+            React.useEffect(() => {
+                const handleImport = (payload) => {
+                    if (!payload) return;
+                    const safeName = (payload.name || 'material').replace(/[^a-z0-9_\-]+/gi, '_') || 'material';
+                    const map = Object.assign({}, payload.files || {}, {
+                        [safeName + '.mtlx']: new Blob([payload.xml], { type: 'application/xml' }),
+                    });
+                    ingestRef.current(map);
+                };
+                if (window.__mtlxPendingViewerImport) {
+                    const payload = window.__mtlxPendingViewerImport;
+                    window.__mtlxPendingViewerImport = null;
+                    handleImport(payload);
+                }
+                const onViewDoc = (e) => {
+                    const payload = e.detail;
+                    if (!payload) return;
+                    window.__mtlxPendingViewerImport = null;
+                    handleImport(payload);
+                };
+                window.addEventListener('mtlx-view-document', onViewDoc);
+                return () => window.removeEventListener('mtlx-view-document', onViewDoc);
+            }, []);
+
             // Warm the MaterialX WASM + environment map on mount, instead of
             // paying for them on the first drop. Also resolves the version
             // badge in the shared header right away.


### PR DESCRIPTION
- Fix edge drags misfiring the add-node search; drop-on-node opens a filterable
  port picker; port dblclick places nodes beside the origin; disconnected ports
  stay visible; entering a nodegraph selects its output (unless pinned)
- Preview panel: viewport control strip (geometry, turntable, env, PNG,
  fullscreen, Send to Viewer), readable loading overlay, collapsible uifolder
  parameter groups in nodedef order (graph panel + docs previewer)
- Preview perf: skip GL recompiles when the regenerated shader source is
  unchanged (in-place uniform refresh); background compile pre-warm on a hidden
  GL context keeps the UI responsive during ~3s driver compiles; coalesced
  rebuilds cancel stale builds
- Presets dialog with 18 curated MaterialX examples (xi:include + fileprefix
  texture resolution); EXR/HDR texture drops via vendored patched EXRLoader