### PR TITLE
Add specDocs.js and validator.js for MaterialX extraction and diagnostics

### DIFF
--- a/js/docs-app.jsx
+++ b/js/docs-app.jsx
@@ -15,6 +15,52 @@
 // js/docs/sidebar.jsx — App owns all their state/derived data and passes
 // it down as props (see the {jsonData && (...)} block below).
 
+        // Given nodeVersionGroups (see groupDefVersions, js/docs/port-
+        // tables.jsx) and a parsed sig hint ({out, ins}, from a VS Code
+        // hover deep link's `?sig=` suffix — see js/docs/doc-links.jsx's
+        // parseSigHint), returns the INDEX of the group to pre-select in
+        // the Signature dropdown, or -1 when nothing matches (leave the
+        // dropdown's own default alone).
+        //
+        // Matching is deliberately permissive: hint.out is matched
+        // exactly against each group's resolved output type first, then
+        // retried lowercased (a hand-typed/legacy hash could differ only
+        // in case) — a SINGLE candidate (or a hint with no typed inputs
+        // to disambiguate with) wins outright. With MULTIPLE candidates
+        // sharing that output type (e.g. fractal3d's several float-
+        // output signatures), hint.ins — the hovered element's typed
+        // <input> children — disambiguates: the first candidate whose
+        // DEFAULT version's inputTypes satisfies EVERY hinted name->type
+        // pair wins; if none do, fall back to the first candidate rather
+        // than showing nothing.
+        const matchSigHintToGroups = (groups, hint) => {
+            if (!groups || !groups.length || !hint || !hint.out) return -1;
+
+            let candidates = [];
+            for (let i = 0; i < groups.length; i++) {
+                if (groups[i].type === hint.out) candidates.push(i);
+            }
+            if (!candidates.length) {
+                const wantLower = hint.out.toLowerCase();
+                for (let i = 0; i < groups.length; i++) {
+                    if ((groups[i].type || '').toLowerCase() === wantLower) candidates.push(i);
+                }
+            }
+            if (!candidates.length) return -1;
+            if (candidates.length === 1 || !hint.ins || !hint.ins.length) return candidates[0];
+
+            for (const idx of candidates) {
+                const group = groups[idx];
+                const defaultVersion = group.versions && group.versions[0];
+                if (!defaultVersion) continue;
+                const inputTypes = defaultVersion.inputTypes || {};
+                const satisfiesAll = hint.ins.every((inp) =>
+                    Object.prototype.hasOwnProperty.call(inputTypes, inp.name) && inputTypes[inp.name] === inp.type);
+                if (satisfiesAll) return idx;
+            }
+            return candidates[0];
+        };
+
         function App({ active = true, inline = false, initialHash } = {}) {
             // Embed mode: focused single-node view, iframed by the graph
             // editor (index.html?embed=1#/<lib>/<group>/<name>) — flag is
@@ -42,12 +88,34 @@
             // load can race with the user switching shell views (which rewrites
             // location.hash to a '#!' route and would lose a docs deep link).
             const initialHashRef = React.useRef(window.location.hash);
+            // A signature hint (`{name, hint}`, hint from hashToSel's
+            // sel.sigHint) waiting to be applied to the Signature
+            // dropdown once nodeVersionGroups has loaded for the node it
+            // targets — set at the two hash-driven selection sites below
+            // (applyData's fromHash branch, onNav), consumed at most once
+            // by the effect right after the nodeVersionGroups effect
+            // further down. A ref, not state: it's read/written across
+            // renders but never itself drives one.
+            const pendingSigRef = React.useRef(null);
             const [jsonData, setJsonData] = React.useState(null);
             const [selectedNode, setSelectedNode] = React.useState(null);
             // Which signature (port table) of the selected node is shown —
             // and previewed. Reset on every selection change.
             const [sigIndex, setSigIndex] = React.useState(0);
-            React.useEffect(() => { setSigIndex(0); }, [selectedNode]);
+            React.useEffect(() => {
+                setSigIndex(0);
+                // A pending sig hint targets ONE specific node by name.
+                // If the selection driving this effect is for a
+                // DIFFERENT node than the pending hint's — e.g. the hint
+                // was set by a hash navigation, then something else (a
+                // sidebar click, browser back) changed the selection
+                // again before the consumer effect below ever got a
+                // chance to run — the hint is stale for this node and
+                // must not be applied to it.
+                if (pendingSigRef.current && selectedNode && pendingSigRef.current.name !== selectedNode.name) {
+                    pendingSigRef.current = null;
+                }
+            }, [selectedNode]);
             const [copied, setCopied] = React.useState(false);
             // Auto-generated port tables (from the nodedef) for undocumented
             // nodes: { name, status: 'loading'|'ready'|'unavailable', tables }.
@@ -148,6 +216,13 @@
                 if (fromHash) {
                     setExpandedLibs({ [fromHash.lib]: true });
                     setExpandedGroups({ [`${fromHash.lib}-${fromHash.group}`]: true });
+                    // A `?sig=` hint on this hash (VS Code hover deep
+                    // link only — see doc-links.jsx's parseSigHint) is
+                    // queued for the new-effect consumer below; set
+                    // right before setSelectedNode so the sigIndex-reset
+                    // effect above sees a pending hint whose name already
+                    // matches this selection.
+                    pendingSigRef.current = fromHash.sigHint ? { name: fromHash.name, hint: fromHash.sigHint } : null;
                     setSelectedNode(fromHash);
                     return;
                 }
@@ -219,6 +294,9 @@
                     if (sel) {
                         setExpandedLibs((p) => Object.assign({}, p, { [sel.lib]: true }));
                         setExpandedGroups((p) => Object.assign({}, p, { [`${sel.lib}-${sel.group}`]: true }));
+                        // Same pending-hint queuing as applyData's
+                        // fromHash branch above — see its comment.
+                        pendingSigRef.current = sel.sigHint ? { name: sel.name, hint: sel.sigHint } : null;
                         setSelectedNode(sel);
                     }
                 };
@@ -328,6 +406,24 @@
                     .catch(() => { if (alive) setNodeVersionGroups(null); });
                 return () => { alive = false; };
             }, [selectedNode]);
+            // Consumes a pending sig hint (queued at the two hash-driven
+            // selection sites above) exactly once nodeVersionGroups has
+            // actually loaded for the CURRENTLY selected node — matching
+            // needs live group/version data (matchSigHintToGroups reads
+            // each candidate group's default version's inputTypes),
+            // which only exists once the nodeVersionGroups effect above
+            // resolves. The hint is consumed (pendingSigRef.current
+            // nulled) even on a no-match/idx<=0 result, not just a
+            // successful one, so it's applied at most once and never
+            // leaks into a later, unrelated selection.
+            React.useEffect(() => {
+                const pending = pendingSigRef.current;
+                if (!pending || !selectedNode || pending.name !== selectedNode.name) return;
+                if (!nodeVersionGroups) return; // groups not loaded yet — wait for the next run
+                pendingSigRef.current = null;
+                const idx = matchSigHintToGroups(nodeVersionGroups, pending.hint);
+                if (idx > 0) setSigIndex(idx);
+            }, [nodeVersionGroups, selectedNode]);
             // Which VERSION is selected within the currently resolved
             // signature group — reset whenever the selection or signature
             // changes (a different signature may resolve to a different

--- a/js/docs/doc-links.jsx
+++ b/js/docs/doc-links.jsx
@@ -23,18 +23,72 @@
         // 'stdlib' winning ties so ambiguous names resolve deterministically.
         const selToHash = (sel) =>
             sel ? '#/' + [sel.lib, sel.group, sel.name].map(encodeURIComponent).join('/') : '';
+
+        // Parses a `?sig=<token>` query suffix — a VS Code hover deep
+        // link only (see vscode_extension/src/extension.js's openDocs
+        // command and its SIG_TOKEN_RE; selToHash above never emits one)
+        // — into { out, ins: [{name, type}] }, or null when absent/
+        // malformed. Token shape mirrors vscode_extension/src/
+        // nodeSignature.js's buildSigToken output exactly: `<outType>`
+        // optionally followed by `(<name>:<type>,...)`. extension.js
+        // already shape-validated the token before ever building the
+        // hash, but this parse is independently defensive — a hand-
+        // typed/pasted/bookmarked hash is untrusted input too.
+        const SIG_HINT_RE = /^([\w.\-:]+)(?:\(([^)]*)\))?$/;
+        const parseSigHint = (query) => {
+            if (!query) return null;
+            let sigRaw = null;
+            for (const pair of query.split('&')) {
+                if (pair.slice(0, 4) === 'sig=') { sigRaw = pair.slice(4); break; }
+            }
+            if (!sigRaw) return null;
+            let sig;
+            try { sig = decodeURIComponent(sigRaw); } catch (e) { return null; }
+            const m = SIG_HINT_RE.exec(sig);
+            if (!m) return null;
+            const ins = [];
+            if (m[2]) {
+                for (const pair of m[2].split(',')) {
+                    const idx = pair.indexOf(':');
+                    if (idx === -1) continue; // malformed pair — skip, not fatal
+                    const name = pair.slice(0, idx);
+                    const type = pair.slice(idx + 1);
+                    if (name && type) ins.push({ name, type });
+                }
+            }
+            return { out: m[1], ins };
+        };
+
         const hashToSel = (data, hash) => {
             if (!data || !hash) return null;
-            const body = hash.replace(/^#\/?/, '');
+            let body = hash.replace(/^#\/?/, '');
             if (!body) return null;
+
+            // Strip a `?sig=...` suffix BEFORE splitting into lib/group/
+            // name segments — it's not part of the addressing scheme,
+            // just an optional hint for which signature to pre-select
+            // once the node itself resolves. `q === -1` (no '?' at all —
+            // every permalink the site itself ever writes) leaves body/
+            // sigHint exactly as they were before this feature existed,
+            // so existing permalinks resolve identically.
+            const q = body.indexOf('?');
+            const sigHint = q === -1 ? null : parseSigHint(body.slice(q + 1));
+            if (q !== -1) body = body.slice(0, q);
+
             const parts = body.split('/').map((s) => { try { return decodeURIComponent(s); } catch (e) { return s; } });
+            // Attaches sigHint (when one was parsed) onto an otherwise-
+            // resolved selection, on every successful return path below.
+            const withSig = (sel) => {
+                if (sel && sigHint) sel.sigHint = sigHint;
+                return sel;
+            };
 
             // Canonical form: #/lib/group/name (what this page itself writes).
             if (parts.length >= 3) {
                 const name = parts.slice(2).join('/'); // names shouldn't contain '/', but be safe
                 const [lib, group] = parts;
                 if (data[lib] && data[lib][group] && data[lib][group][name]) {
-                    return { lib, group, name, info: data[lib][group][name] };
+                    return withSig({ lib, group, name, info: data[lib][group][name] });
                 }
                 return null;
             }
@@ -51,7 +105,7 @@
             for (const lib of libs) {
                 for (const group of Object.keys(data[lib]).sort()) {
                     const nodes = data[lib][group];
-                    if (nodes[want]) return { lib, group, name: want, info: nodes[want] };
+                    if (nodes[want]) return withSig({ lib, group, name: want, info: nodes[want] });
                     if (!fuzzy) {
                         for (const name of Object.keys(nodes)) {
                             if (squash(name) === wantKey) { fuzzy = { lib, group, name, info: nodes[name] }; break; }
@@ -59,7 +113,7 @@
                     }
                 }
             }
-            return fuzzy;
+            return withSig(fuzzy);
         };
 
         // ---- Official spec deep-links ----

--- a/js/graph-app.jsx
+++ b/js/graph-app.jsx
@@ -219,15 +219,20 @@
             // once when the dialog opens (not on every render) and held here.
             const [xmlDialogOpen, setXmlDialogOpen] = React.useState(false);
             const [xmlDialogXml, setXmlDialogXml] = React.useState('');
-            // Validate popup: result is recomputed fresh each time the
-            // dialog opens (see the useEffect gated on validateOpen below).
+            // Validate popup + toolbar button: validateStatus is now a
+            // BACKGROUND status (see the docXmlRev-gated effect below),
+            // not a one-shot computed-on-open result — it's what colors
+            // the toolbar Validate button even before it's ever clicked.
+            // Opening the dialog (validateOpen) additionally forces an
+            // immediate, non-debounced refresh (see that effect too) so
+            // it never shows a stale pre-edit result.
             const [validateOpen, setValidateOpen] = React.useState(false);
-            const [validateResult, setValidateResult] = React.useState(null);
+            const [validateStatus, setValidateStatus] = React.useState(null);
             // Export dialog (toolbar "Export" button, item B1): holds
             // { defaultName, textures } computed once when the dialog is
             // opened (openExportDialog below), or null while closed — same
             // "computed once by the caller, not on every render" contract
-            // as xmlDialogXml/validateResult above.
+            // as xmlDialogXml above.
             const [exportDialog, setExportDialog] = React.useState(null);
             // Presets dialog (toolbar "Presets" button, item F3.2): a
             // curated list of official MaterialX example documents (see
@@ -245,6 +250,23 @@
             // Bumped on every committed edit that reached the MaterialX
             // document — the material preview regenerates from the live doc.
             const [docRev, setDocRev] = React.useState(0);
+            // Validate source-of-truth: the exact XML TEXT the Validate
+            // button/dialog checks — deliberately NOT `parsed`/parsedRef.
+            // Written in exactly two places: the raw as-opened text at
+            // ingest (loadDocument below), and the canonical serialized
+            // XML flushUndoSnapshot (above the undo stack further down)
+            // just handed to window.__mtlxNotifyEdit. Never the live doc
+            // itself, because serializeDocXml heals connected-input
+            // faults IN PLACE on every snapshot — validating parsed.doc
+            // would silently mask exactly the faults this feature exists
+            // to surface (see validateMtlxXml, js/graph/model.jsx). `rev`
+            // is a cheap monotonic counter so an in-flight background
+            // validation that's since been superseded by a newer edit can
+            // detect it's stale and drop its result instead of clobbering
+            // a fresher one; docXmlRev is its render-triggering twin (a
+            // plain ref write doesn't cause an effect to re-run).
+            const docXmlRef = React.useRef({ xml: null, rev: 0 });
+            const [docXmlRev, setDocXmlRev] = React.useState(0);
             // Unsaved-changes tracking, deliberately SEPARATE from docRev:
             // docRev only bumps for edits that need a preview recompile, but
             // a dragged node's xpos/ypos or a freshly-added-but-unconnected
@@ -358,6 +380,13 @@
             const UNDO_CAP = 50;
             const UNDO_DEBOUNCE_MS = 350;
             const UNDO_RETRY_MAX = 10;
+            // Background document-text validation's own debounce (see the
+            // docXmlRev-gated effect further down) — slightly longer than
+            // UNDO_DEBOUNCE_MS since validating is the least urgent of the
+            // two and a burst of edits (each bumping docXmlRev right
+            // alongside an undo snapshot) shouldn't run doc.validate()
+            // once per settle either.
+            const VALIDATE_DEBOUNCE_MS = 500;
 
             // Flush a pending debounced snapshot immediately (synchronous
             // body shared by the timer callback and undoDoc, so Ctrl+Z right
@@ -389,6 +418,15 @@
                 // reusing this function's existing debounce/coalescing
                 // instead of re-implementing it on the extension side.
                 if (typeof window.__mtlxNotifyEdit === 'function') window.__mtlxNotifyEdit(xml);
+                // Keep the Validate source-of-truth (docXmlRef, declared
+                // above near docRev) in lockstep with whatever XML just
+                // got handed to the VS Code bridge (or would have, in the
+                // standalone browser) — same `xml` value, so it's cheap
+                // (no serialization of our own; serializeDocXml already
+                // ran above). This is the second of the two write sites —
+                // see docXmlRef's comment for the first (loadDocument).
+                docXmlRef.current = { xml, rev: docXmlRef.current.rev + 1 };
+                setDocXmlRev((r) => r + 1);
                 const u = undoStateRef.current;
                 u.stack.length = u.index + 1; // drop any redo branch
                 if (u.savedIndex > u.index) u.savedIndex = -1;
@@ -667,6 +705,21 @@
                 setStatus('Parsing ' + path + ' \u2026');
                 try {
                     let xml = await map[path].text();
+                    // Validate source-of-truth write site #1 (see
+                    // docXmlRef's declaration near docRev above): the RAW,
+                    // as-opened text of the picked file — captured BEFORE
+                    // xi:include resolution splices in other files'
+                    // content below, and well before parseMtlxDocument or
+                    // any healing ever touches it. This is exactly what
+                    // the VS Code extension's own tier-2 validator
+                    // (vscode_extension/src/mtlxNode.js's
+                    // validateSemantic) validates too — it readFromXmlString's
+                    // the raw buffer text verbatim, xi:include and all —
+                    // so capturing the resolved/merged text here instead
+                    // would let the graph's Validate button diverge from
+                    // what VS Code shows for any document using includes.
+                    docXmlRef.current = { xml, rev: docXmlRef.current.rev + 1 };
+                    setDocXmlRev((r) => r + 1);
                     if (/<xi:include\b/.test(xml)) {
                         const dir = path.indexOf('/') >= 0 ? path.slice(0, path.lastIndexOf('/')) : '';
                         xml = await resolveIncludes(xml, map, dir);
@@ -2059,46 +2112,55 @@
                 setXmlDialogOpen(true);
             };
 
-            // Validation popup (item 9's "Validate" button): recomputed
-            // fresh every time the dialog opens. The WASM binding's
-            // validate() is boolean-only in this build (see NodePreview's
-            // identical defensive call above — the only other caller), so
-            // a false result is paired with a cheap best-effort scan for
-            // dangling nodename/nodegraph references on top-level nodes
-            // rather than a real diagnostic list. Wrapped in `safe` end to
-            // end so any WASM quirk degrades to the boolean-only view.
+            // Background document-text validation (item 9's "Validate"
+            // button/dialog, now source-of-truth-driven): recomputes
+            // validateStatus from docXmlRef's cached TEXT (declared near
+            // docRev above) whenever that text changes — NOT gated on the
+            // dialog being open, so the toolbar button itself can show a
+            // live green/red badge before Validate is ever clicked. Runs
+            // through validateMtlxXml (js/graph/model.jsx), which builds
+            // a THROWAWAY document from the raw XML instead of calling
+            // parsed.doc.validate() directly — the live doc gets healed
+            // (stripValuesFromConnectedInputs) by every serializeDocXml
+            // call, so validating it would mask exactly the faults this
+            // feature exists to surface. Debounced on the same idea as
+            // flushUndoSnapshot's own undo-snapshot debounce, just on a
+            // slightly longer cadence (VALIDATE_DEBOUNCE_MS) since a rapid
+            // burst of edits (each bumping docXmlRev) shouldn't run
+            // doc.validate() once per settle.
+            React.useEffect(() => {
+                const { xml, rev } = docXmlRef.current;
+                if (!xml) { setValidateStatus(null); return; } // nothing loaded yet — don't spam validation attempts
+                const t = setTimeout(() => {
+                    validateMtlxXml(xml).then((res) => {
+                        // Stale guard: a newer edit landed (docXmlRef.current.rev
+                        // bumped again) while this validation was in flight —
+                        // drop this result; the effect run it superseded
+                        // will produce (and apply) its own.
+                        if (docXmlRef.current.rev !== rev) return;
+                        setValidateStatus(res);
+                    });
+                }, VALIDATE_DEBOUNCE_MS);
+                return () => clearTimeout(t);
+            }, [docXmlRev]);
+
+            // Validation popup (item 9's "Validate" button): consumes the
+            // background validateStatus above, but ALSO forces an
+            // immediate (non-debounced) validation pass right when the
+            // dialog opens — otherwise a dialog opened mid-debounce would
+            // show whatever the last SETTLED result was (or nothing, on
+            // the very first-ever open) for up to VALIDATE_DEBOUNCE_MS.
+            // Same staleness guard as the background effect above, so an
+            // edit landing mid-flight can't clobber a fresher result.
             React.useEffect(() => {
                 if (!validateOpen) return;
-                setValidateResult(null);
-                setValidateResult(mxSafe(() => {
-                    if (!parsed || !parsed.doc || typeof parsed.doc.validate !== 'function') {
-                        return { kind: 'unavailable' };
-                    }
-                    let ok;
-                    try {
-                        ok = parsed.doc.validate();
-                    } catch (e) {
-                        return { kind: 'unavailable' };
-                    }
-                    if (ok) return { kind: 'valid' };
-                    const issues = [];
-                    const nodes = vecToArray(mxSafe(() => parsed.doc.getNodes(), []));
-                    for (const n of nodes) {
-                        const nm = mxElName(n);
-                        for (const inp of vecToArray(mxSafe(() => n.getInputs(), []))) {
-                            const nn = mxElAttr(inp, 'nodename');
-                            if (nn && !mxSafe(() => parsed.doc.getNode(nn), null)) {
-                                issues.push(nm + '.' + mxElName(inp) + ' references missing node "' + nn + '"');
-                            }
-                            const ng = mxElAttr(inp, 'nodegraph');
-                            if (ng && !mxSafe(() => parsed.doc.getNodeGraph(ng), null)) {
-                                issues.push(nm + '.' + mxElName(inp) + ' references missing nodegraph "' + ng + '"');
-                            }
-                        }
-                    }
-                    return { kind: 'invalid', issues };
-                }, { kind: 'unavailable' }));
-            }, [validateOpen, parsed]);
+                const { xml, rev } = docXmlRef.current;
+                if (!xml) { setValidateStatus(null); return; }
+                validateMtlxXml(xml).then((res) => {
+                    if (docXmlRef.current.rev !== rev) return;
+                    setValidateStatus(res);
+                });
+            }, [validateOpen]);
 
             // ---- Graph editing: connect / disconnect / delete ------------
             // Same contract as applyParamEdit: every edit is written into
@@ -3511,9 +3573,15 @@
                         if (inp.nodename && nameMap[inp.nodename]) {
                             mxSafe(() => { target.setAttribute('nodename', nameMap[inp.nodename]); return true; }, false);
                             if (inp.output) mxSafe(() => { target.setAttribute('output', inp.output); return true; }, false);
+                            // Item 9: ensureTypedInput above may have copied the
+                            // nodedef default VALUE onto this freshly-created
+                            // input — a connected input must not also carry one.
+                            mxSafe(() => { target.removeAttribute('value'); return true; }, false);
                         } else if (inp.nodegraph && nameMap[inp.nodegraph]) {
                             mxSafe(() => { target.setAttribute('nodegraph', nameMap[inp.nodegraph]); return true; }, false);
                             if (inp.output) mxSafe(() => { target.setAttribute('output', inp.output); return true; }, false);
+                            // Item 9: same as the nodename branch above.
+                            mxSafe(() => { target.removeAttribute('value'); return true; }, false);
                         } else if (inp.value !== '') {
                             mxSafe(() => { mxWriteValue(target, inp.value, inp.type); return true; }, false);
                         }
@@ -3670,6 +3738,11 @@
                                 if (!target) continue;
                                 mxSafe(() => { target.setAttribute('nodename', inp.nodename); return true; }, false);
                                 if (inp.output) mxSafe(() => { target.setAttribute('output', inp.output); return true; }, false);
+                                // Item 9: ensureTypedInput may have copied the
+                                // nodedef default VALUE onto this input — strip
+                                // it now that it's connected (matches the
+                                // external branch below, which already does this).
+                                mxSafe(() => { target.removeAttribute('value'); return true; }, false);
                                 continue;
                             }
                             const external = inp.nodename || inp.nodegraph || inp.interfacename;
@@ -5170,9 +5243,16 @@
                             <button
                                 onClick={() => setValidateOpen(true)}
                                 title="Run the MaterialX library's document validation"
-                                className="h-7 inline-flex items-center gap-1 text-[11px] px-2 rounded border bg-gray-800/80 backdrop-blur border-gray-600 text-gray-300 hover:bg-gray-700/80 transition-colors"
+                                className={'h-7 inline-flex items-center gap-1 text-[11px] px-2 rounded border bg-gray-800/80 backdrop-blur hover:bg-gray-700/80 transition-colors '
+                                    + (validateStatus && validateStatus.kind === 'valid'
+                                        ? 'border-green-500/60 text-green-300'
+                                        : validateStatus && validateStatus.kind === 'invalid'
+                                            ? 'border-red-500/60 text-red-300'
+                                            : 'border-gray-600 text-gray-300')}
                             >
-                                <MtlxIcon name="copy-check" className="w-3.5 h-3.5" />
+                                <MtlxIcon name={validateStatus && validateStatus.kind === 'valid' ? 'check'
+                                    : validateStatus && validateStatus.kind === 'invalid' ? 'x' : 'copy-check'}
+                                    className="w-3.5 h-3.5" />
                                 <span>Validate</span>
                             </button>
                         )}
@@ -5210,7 +5290,7 @@
 
                     {/* Validation popup ("Validate" button, item 9). */}
                     {validateOpen && (
-                        <ValidateDialog result={validateResult} open={validateOpen} onClose={() => setValidateOpen(false)} />
+                        <ValidateDialog status={validateStatus} open={validateOpen} onClose={() => setValidateOpen(false)} />
                     )}
 
                     {/* Export dialog ("Export" button, item B1). */}
@@ -5572,7 +5652,10 @@
                             ><MtlxIcon name="zoom-in-area" className="w-3.5 h-3.5" /></button>
                         </div>
                         {legendOpen ? (
-                            <div className="bg-gray-800/90 backdrop-blur border border-gray-700 rounded-lg p-3 w-60">
+                            // w-80 (not w-60): the longest type name (displacementshader,
+                            // ~133px at this legend's text-[11px] font-mono) doesn't fit
+                            // in a grid-cols-2 column at the old width.
+                            <div className="bg-gray-800/90 backdrop-blur border border-gray-700 rounded-lg p-3 w-80">
                                 <div className="flex items-center justify-between mb-2">
                                     <span className="text-xs font-semibold text-gray-400 uppercase tracking-wider">Types</span>
                                     <div className="flex items-center -mr-1">

--- a/js/graph/dialogs.jsx
+++ b/js/graph/dialogs.jsx
@@ -233,12 +233,20 @@
             );
         }
 
-        // Validation popup (item 9's "Validate" button): a defensive,
-        // best-effort check over the CURRENT document. `result` is computed
-        // by the caller (in a useEffect gated on validateOpen) so it stays
-        // fresh across re-opens without recomputing on every render; this
-        // component only renders whatever it was handed.
-        function ValidateDialog({ result, open, onClose }) {
+        // Validation popup (item 9's "Validate" button): renders the
+        // shared `status` — { kind: 'valid' | 'invalid' | 'unavailable',
+        // issues? } — computed in js/graph-app.jsx by validateMtlxXml
+        // (js/graph/model.jsx) against the document's raw TEXT (docXmlRef),
+        // not the live in-memory doc. Unlike the old per-open computation
+        // this replaced, `status` is now a BACKGROUND value that also
+        // drives the toolbar Validate button's own green/red coloring, so
+        // it can already be non-null the moment this dialog mounts;
+        // opening the dialog additionally forces one immediate refresh
+        // (see graph-app.jsx's validateOpen-gated effect) so a stale
+        // pre-edit result never lingers. Issues are shown VERBATIM — no
+        // truncation, no reformatting — this component only renders
+        // whatever it was handed.
+        function ValidateDialog({ status, open, onClose }) {
             useEscapeToClose(onClose, open);
             if (!open) return null;
             return (
@@ -251,21 +259,21 @@
                             <button onClick={onClose} title="Close" className="text-gray-400 hover:text-gray-200 leading-none text-lg px-1">{'×'}</button>
                         </div>
                         <div className="overflow-y-auto custom-scrollbar px-4 py-3 text-[12px]">
-                            {!result && <div className="text-gray-400 animate-pulse">Validating{'…'}</div>}
-                            {result && result.kind === 'valid' && (
+                            {!status && <div className="text-gray-400 animate-pulse">Validating{'…'}</div>}
+                            {status && status.kind === 'valid' && (
                                 <div className="text-green-400 font-bold">{'✓ Document is valid'}</div>
                             )}
-                            {result && result.kind === 'invalid' && (
+                            {status && status.kind === 'invalid' && (
                                 <div>
                                     <div className="text-red-400 font-bold mb-2">{'✗ Validation failed'}</div>
-                                    {result.issues && result.issues.length > 0 && (
+                                    {status.issues && status.issues.length > 0 && (
                                         <ul className="list-disc list-inside space-y-1 text-gray-300 font-mono text-[11px]">
-                                            {result.issues.map((s, i) => <li key={i}>{s}</li>)}
+                                            {status.issues.map((s, i) => <li key={i}>{s}</li>)}
                                         </ul>
                                     )}
                                 </div>
                             )}
-                            {result && result.kind === 'unavailable' && (
+                            {status && status.kind === 'unavailable' && (
                                 <div className="text-gray-400">Validation is not available in this build.</div>
                             )}
                         </div>
@@ -293,9 +301,12 @@
             useEscapeToClose(onClose, open && !busy);
 
             // Reset to the caller's latest defaults each time the dialog is
-            // (re)opened — mirrors XmlDialog/ValidateDialog's "computed once
-            // per open by the caller" contract, just applied to local state
-            // instead of a prop that's recomputed from scratch.
+            // (re)opened — mirrors XmlDialog's "computed once per open by
+            // the caller" contract, just applied to local state instead of
+            // a prop that's recomputed from scratch. (ValidateDialog's own
+            // `status` used to follow this same contract too, but is now a
+            // background value refreshed independently of any one open —
+            // see its effect in js/graph-app.jsx.)
             const wasOpen = React.useRef(false);
             React.useEffect(() => {
                 if (open && !wasOpen.current) {

--- a/js/graph/model.jsx
+++ b/js/graph/model.jsx
@@ -86,6 +86,82 @@
             return { mx, doc, nodegraphs, implGraphNames };
         };
 
+        // Validate a document's TEXT AS AUTHORED — deliberately NOT the
+        // live in-memory graph doc (parsed.doc). serializeDocXml (below)
+        // calls stripValuesFromConnectedInputs on the doc IN PLACE before
+        // every write (Export, undo/redo snapshots, AND the VS Code
+        // text-sync path), which silently heals faults like "an input
+        // carries both a value and a connection" — so validating
+        // parsed.doc directly would show a document opened WITH real
+        // faults as perfectly clean the moment any snapshot fires (undo
+        // snapshots alone fire ~350ms after every edit). Building a
+        // fresh, throwaway document straight from the raw XML string
+        // instead means the graph editor's Validate button/dialog always
+        // reports on exactly the same text the VS Code extension's own
+        // validator (vscode_extension/src/validator.js's tier-2 path,
+        // mtlxNode.js's validateSemantic — which likewise just
+        // readFromXmlString's the raw buffer text, xi:include and all)
+        // would report — the actual on-disk/in-buffer document, at every
+        // moment, not "the document as the graph editor has quietly
+        // fixed it so far".
+        //
+        // Returns one of:
+        //   { kind: 'valid' }
+        //   { kind: 'invalid', issues: [ ...verbatim diagnostic lines ] }
+        //   { kind: 'unavailable' } — wasm not ready, no validate()
+        //                             binding in this build, or any other
+        //                             unexpected throw
+        const validateMtlxXml = async (xml) => {
+            if (!xml) return { kind: 'unavailable' };
+            try {
+                const { mx, stdlib } = await getMxEnv();
+                if (typeof mx.createDocument !== 'function' || typeof mx.readFromXmlString !== 'function') {
+                    return { kind: 'unavailable' };
+                }
+                const doc = mx.createDocument();
+                try {
+                    await mx.readFromXmlString(doc, xml);
+                } catch (e) {
+                    // A document that doesn't even parse is certainly not
+                    // valid — report the parse error itself as the sole
+                    // issue, the same way VS Code's tier-1 XML scanner
+                    // (validator.js's scanXml) reports a malformed file
+                    // before tier 2 (this same wasm validate path) ever runs.
+                    return { kind: 'invalid', issues: [mxErr(mx, e)] };
+                }
+                if (typeof doc.setDataLibrary === 'function') {
+                    doc.setDataLibrary(stdlib);
+                }
+                if (typeof doc.validate !== 'function') return { kind: 'unavailable' };
+                const holder = {};
+                let ok;
+                try {
+                    ok = doc.validate(holder);
+                } catch (e) {
+                    return { kind: 'unavailable' };
+                }
+                if (ok) return { kind: 'valid' };
+                // The WASM binding's validate() has an overloadTable
+                // {'0','1'} — the 1-arg overload fills holder.message with
+                // the FULL newline-separated MaterialX diagnostic list on
+                // failure. Shown VERBATIM (no reformatting) — same
+                // contract the old validateOpen-gated effect in
+                // js/graph-app.jsx used to follow.
+                const issues = String(holder.message || '')
+                    .split(/\r\n|\r|\n/)
+                    .map((s) => s.trim())
+                    .filter(Boolean);
+                // holder.message empty despite a false result (build
+                // variance, or a failure validate() itself can't
+                // attribute to any single line) -> a single generic
+                // fallback issue, never an empty "invalid" dialog.
+                if (!issues.length) issues.push('The document failed validation.');
+                return { kind: 'invalid', issues };
+            } catch (e) {
+                return { kind: 'unavailable' };
+            }
+        };
+
         // Serialize a parsed document to XML — shared by Export and the
         // undo/redo snapshot capture. Transient '__pv_*' preview wrappers
         // only exist inside an in-flight generation; if one is caught
@@ -100,6 +176,14 @@
                 err.transient = true;
                 throw err;
             }
+            // Item 9 belt-and-suspenders: strip any input that carries both
+            // a value and a connection before every write. This is the ONE
+            // choke point every caller of serializeDocXml goes through
+            // (Export dialog, undo/redo snapshots via flushUndoSnapshot,
+            // AND the VS Code text-sync path), so it also self-heals
+            // documents that predate this fix or were authored outside the
+            // graph editor, right on the next serialize.
+            mxSafe(() => stripValuesFromConnectedInputs(parsed.doc), 0);
             return parsed.mx.writeToXmlString(parsed.doc);
         };
 
@@ -477,7 +561,7 @@
         };
 
 Object.assign(window, {
-    DEFAULT_GRAPH_URL, parseMtlxDocument, serializeDocXml, kindOfNode,
+    DEFAULT_GRAPH_URL, parseMtlxDocument, validateMtlxXml, serializeDocXml, kindOfNode,
     resolveVersionedNodeDef, signatureInputTypes, CLOSURE_TYPES, isClosureModifier,
     collectPorts, storedPos, buildScope, MTLX_PERF_LOG,
 });

--- a/js/graph/preview.jsx
+++ b/js/graph/preview.jsx
@@ -844,6 +844,11 @@
                         isFullscreen={isFullscreen}
                         onToggleFullscreen={toggleFullscreenView}
                         trailingChildren={trailingChildren}
+                        // This panel is docked at the screen's right edge, so open
+                        // the env dialog toward the graph canvas (left) instead of
+                        // the default below/right placement, which would cover the
+                        // 3D preview itself.
+                        envDialogPlacement="left"
                         containerClassName="flex items-center justify-end gap-1 px-2 py-1 border-b border-gray-700 bg-gray-900/70 flex-none"
                     />
                     <div

--- a/js/mtlx-engine.js
+++ b/js/mtlx-engine.js
@@ -1197,10 +1197,12 @@ const makeEnvTexture = (w, h, blurred) => {
         }
     }
     const tex = new THREE.DataTexture(data, w, h, THREE.RGBAFormat);
-    // Equirect mapping: irrelevant for the IBL sampler uniforms;
-    // the visible background uses a flipY=true copy of this texture
-    // (makeBackgroundTexture) — three's background convention is
-    // mirrored vertically from MaterialX's latlong lookup.
+    // Equirect mapping: irrelevant for the IBL sampler uniforms; the
+    // visible skybox mesh (bgMesh, see createMtlxRenderView) uses a
+    // flipY=true copy of this texture (makeBackgroundTexture) — see
+    // that function's header comment for why flipY=true is correct
+    // for the mirrored-sphere backdrop (not merely a scene.background
+    // leftover — scene.background is gone entirely, see bgMesh).
     tex.mapping = THREE.EquirectangularReflectionMapping;
     tex.wrapS = THREE.RepeatWrapping;
     tex.wrapT = THREE.ClampToEdgeWrapping;
@@ -1284,24 +1286,29 @@ const prepareEnv = (tex) => {
     t.needsUpdate = true;
     return t;
 };
-// Build the texture used as the VISIBLE scene.background from a
-// prepared radiance texture. It must be a SEPARATE texture from the
-// IBL sampler, because the two consumers disagree on V orientation:
+// Build the texture used as the shell-owned skybox mesh's visible
+// backdrop (bgMesh, see createMtlxRenderView) from a prepared radiance
+// texture. It must be a SEPARATE texture from the IBL sampler, because
+// the two consumers disagree on V orientation:
 //   - MaterialX's mx_latlong_map_lookup maps "up" to v = 0, i.e. it
 //     wants the .hdr's first scanline at v = 0 → flipY = FALSE
 //     (what a fresh DataTexture gives us — reflections are correct).
-//   - three's background path (equirectUv in the equirect→cubemap
-//     conversion) maps "up" to v = 1 → it needs flipY = TRUE, which
-//     is what RGBELoader sets on the textures it loads.
-// The official viewer gets this for free: prepareEnvTexture rebuilds
-// a flipY=false DataTexture for the IBL uniforms, but the background
-// is the ORIGINAL loader texture (flipY=true). Reusing the IBL
-// texture as scene.background mirrors the environment vertically.
+//   - The skybox mesh samples this texture through three's own
+//     SphereGeometry UVs (uv.y = 1 - v, so uv.y = 1 sits at the +Y
+//     pole — see BG_BASE/BG_SIGN's derivation comment above
+//     createMtlxRenderView for the full walk-through), which wants the
+//     .hdr's first scanline at v = 1 → flipY = TRUE.
+// This is NOT a stale leftover from the old scene.background design —
+// it was re-derived independently for the mirrored-sphere mesh above
+// and lands on the SAME flag value, because three's own classic
+// equirect-panorama recipe (webgl_panorama_equirectangular: a plain
+// image texture, default flipY=true, on `SphereGeometry(...).scale(
+// -1,1,1)`) makes the identical assumption on the identical geometry.
 // Shares the pixel data; only the upload orientation differs.
 const makeBackgroundTexture = (src) => {
     const img = src.image;
     const bg = new THREE.DataTexture(img.data, img.width, img.height, src.format, src.type);
-    bg.flipY = true; // three's equirect background convention
+    bg.flipY = true; // correct for the mirrored skybox sphere — see header comment above
     bg.mapping = THREE.EquirectangularReflectionMapping;
     bg.wrapS = THREE.RepeatWrapping;
     bg.wrapT = THREE.ClampToEdgeWrapping;
@@ -1559,9 +1566,9 @@ const getEnvironment = () => {
             const irradiance = irrSrc ? prepareEnv(irrSrc) : radiance;
             const img = radiance.image;
             const mips = Math.trunc(Math.log2(Math.max(img.width, img.height))) + 1;
-            // Correctly-oriented copy for scene.background (see
-            // makeBackgroundTexture — the IBL texture is mirrored
-            // vertically from three's background convention).
+            // Correctly-oriented copy for the visible skybox mesh (see
+            // makeBackgroundTexture — the IBL texture's flipY=false
+            // doesn't match the mirrored-sphere backdrop's sampling).
             const background = makeBackgroundTexture(radiance);
             return { radiance, irradiance, mips, background, prefilteredIrr: !!irrRaw };
         });
@@ -2218,6 +2225,67 @@ const tryRefreshRenderView = async ({ view, mx, gen, genContext, renderable, lab
 // isMounted() went false mid-way through THIS build (already cleaned
 // up). Throws Error with a decoded MaterialX/GLSL message on failure.
 // ------------------------------------------------------------------
+// Skybox backdrop rotation calibration — read by createMtlxRenderView's
+// shell init (applies the persisted envRotationRad to bgMesh before the
+// first frame) and its setEnvRotation(rad) handle method, so a single
+// constant pair keeps both call sites in lockstep.
+//
+// Derivation (this is the load-bearing part of F1 — re-derive rather
+// than guess if the backdrop ever looks wrong; BG_SIGN is the more
+// likely one to need flipping, BG_BASE the less likely):
+//
+// 1. The material's env lookup (see u_envMatrix in bindMaterialUniforms
+//    below) rotates the SAMPLE direction by RotationY(PI/2 + rad)
+//    before projecting it to latlong (u,v) via MaterialX's
+//    mx_latlong_map_projection (theta = acos(dy), phi = atan2(dz,dx);
+//    u = phi/2PI, v = theta/PI, v = 0 at the +Y pole — the same
+//    (sin(theta)cos(phi), cos(theta), sin(theta)sin(phi)) convention
+//    re-derived independently in the shIrradianceFromEquirect comment
+//    above). Rotating the QUERY direction forward by angle a, with
+//    world axes held fixed, reads identically to the ENVIRONMENT
+//    CONTENT having rotated backward by a — so the lighting behaves as
+//    if it had spun by -(PI/2 + rad) about Y.
+//
+// 2. bgMesh is `SphereGeometry(...).scale(-1,1,1)` (see its
+//    construction below). three's SphereGeometry sets uv.x = u =
+//    ix/widthSegments (phi = u*2PI; the x-mirror only negates
+//    vertex.x, not UVs) and uv.y = 1 - v where v = iy/heightSegments
+//    (theta = v*PI, so uv.y = 1 sits at the +Y pole, theta = 0). After
+//    the mirror, the vertex at (uv.x, uv.y) sits at object-space
+//    direction (cos(phi)sin(theta), cos(theta), sin(phi)sin(theta))
+//    with phi = uv.x*2PI, theta = (1 - uv.y)*PI — the SAME functional
+//    form as step 1's direction-from-(u,v), just parameterized by
+//    (uv.x, 1 - uv.y) instead of MaterialX's own (u,v).
+//
+// 3. makeBackgroundTexture sets flipY=true (see its header comment for
+//    why), so sampling bgMesh's texture at (uv.x, uv.y) actually reads
+//    the RAW .hdr data row/col at (uv.x, 1 - uv.y) — flipY flips which
+//    data row lands at a given GL v. Combined with step 2: a raw .hdr
+//    texel at MaterialX address (u,v) = (uv.x, 1 - uv.y) sits, at
+//    mesh.rotation.y = 0, at EXACTLY the object-space direction
+//    MaterialX's own (inverse) projection would place it at — the
+//    un-rotated skybox already matches MaterialX's un-rotated latlong
+//    convention texel-for-texel.
+//
+// 4. So rotating bgMesh by angle b moves every raw texel to
+//    (that texel's direction) rotated by RotationY(b) — i.e. (by the
+//    same phi-shifts-by-minus-the-angle rule used in step 1) the
+//    backdrop's visible content spins by -b in world space. Matching
+//    that to step 1's "-(PI/2 + rad)" lighting spin:
+//        -b = -(PI/2 + rad)  =>  b = -(PI/2 + rad)
+//    i.e. mesh.rotation.y = -(Math.PI / 2) + (-1) * rad — which is
+//    just the NEGATION of u_envMatrix's own (PI/2 + rad) angle, which
+//    makes sense given step 1's "query rotation forward = content
+//    rotation backward" equivalence.
+//
+// Verified analytically against r128's THREE.Matrix4.makeRotationY and
+// SphereGeometry source, NOT verified visually — the user's rotation-
+// slider check (see the plan) is the final word. If the backdrop
+// tracks the highlight but 180 degrees out of phase, adjust BG_BASE;
+// if it counter-rotates instead of co-rotating, flip BG_SIGN's -1.
+// ------------------------------------------------------------------
+const BG_BASE = -Math.PI / 2;
+const BG_SIGN = -1;
 const createMtlxRenderView = async ({
     canvas, mx, gen, genContext, renderable, lightData,
     label, needsLighting, geomName,
@@ -2257,10 +2325,29 @@ const createMtlxRenderView = async ({
     // each one individually.
     let mesh = null, material = null, geometry = null, uniforms = null;
     // The radiance texture, kept so the caller can toggle it as the
-    // visible scene background (setEnvBackground) — the IBL uniforms
-    // are bound regardless.
+    // visible backdrop (setEnvBackground) via bgMesh below — the IBL
+    // uniforms are bound regardless.
     let envBgTexture = null;
     let envRadSamplerName = null, envIrrSamplerName = null, envRotationRad = 0;
+    // Shell-owned skybox mesh — replaces scene.background entirely.
+    // Built once (below, in the needsLighting env-fetch block) when an
+    // env exists; stays null for unlit previews (needsLighting=false),
+    // so every bgMesh-touching line in this function guards with
+    // `if (bgMesh)` and is a safe no-op there.
+    //
+    // WHY not scene.background: envBgTexture has mapping =
+    // EquirectangularReflectionMapping, so r128's WebGLBackground
+    // module converts it ONCE into a cubemap and caches that cubemap
+    // in a WeakMap keyed by the source texture (invalidated only by
+    // texture.dispose()) — the cube-map background path it then draws
+    // completely ignores texture.offset/texture.matrix, so the old
+    // per-frame `envBgTexture.offset.x = ...` write (see git history)
+    // was a silent no-op: the lighting rotated but the backdrop never
+    // moved. three doesn't gain a rotatable scene.background
+    // (scene.backgroundRotation) until r163; this codebase targets
+    // r128. Owning the mesh ourselves sidesteps that cache entirely —
+    // rotating bgMesh.rotation.y is a normal, un-cached transform.
+    let bgMesh = null;
     // Shell-level env (IBL) state — fetched ONCE, below (see the
     // env-fetch block after the ResizeObserver setup), rather than
     // inside every material apply: the env textures never change
@@ -2296,6 +2383,21 @@ const createMtlxRenderView = async ({
         // live at final teardown).
         try { if (material) material.dispose(); } catch (e) { /* already disposed/invalid */ }
         try { if (geometry) geometry.dispose(); } catch (e) { /* ditto */ }
+        // bgMesh: dispose its OWN geometry (a SphereGeometry built
+        // fresh per shell, below — nobody else references it) and
+        // material (a MeshBasicMaterial, ditto), and drop it from the
+        // scene. Do NOT dispose bgMesh.material.map (envBgTexture) —
+        // env textures are shared/cached (getEnvironment()'s
+        // envPromise, setEnvOverride's broadcast env) across every
+        // live view; same non-disposal policy this function already
+        // applies to envRadiance/envIrradiance, never disposed here.
+        try {
+            if (bgMesh) {
+                scene.remove(bgMesh);
+                bgMesh.geometry.dispose();
+                bgMesh.material.dispose();
+            }
+        } catch (e) { /* already disposed/invalid, or scene never got this far */ }
         if (renderer) renderer.dispose();
     };
     // [mtlx-perf] whole-function total — everything below, from shader
@@ -2440,7 +2542,37 @@ const createMtlxRenderView = async ({
                         envBgTexture = makeBackgroundTexture(envRadiance);
                         envHasFile = false;
                     }
-                    if (envBackground) scene.background = envBgTexture;
+                    // Shell-owned skybox mesh — see bgMesh's
+                    // declaration above for the WHY-not-scene.
+                    // background rationale. SphereGeometry + the x-
+                    // mirror is the canonical r128 "camera inside a
+                    // sphere" panorama recipe. R=50 sits well inside
+                    // the camera's far=100 (see the PerspectiveCamera
+                    // constructed above) with plenty of margin.
+                    // MeshBasicMaterial is unlit (a backdrop, not a
+                    // lit surface) with depthWrite:false + a very low
+                    // renderOrder so it's drawn FIRST and every real
+                    // object simply paints over it — depthWrite:false
+                    // means it never touches the depth buffer, so draw
+                    // order (not depth testing) is what keeps it
+                    // behind everything, regardless of the actual
+                    // (large) sphere radius.
+                    // rotation.y is seeded from envRotationRad (not a
+                    // bare 0) so a persisted rotation is already
+                    // correct on the very first rendered frame — same
+                    // DELIBERATE TWEAK pattern u_envMatrix uses in
+                    // bindMaterialUniforms below. See BG_BASE/BG_SIGN's
+                    // derivation comment above createMtlxRenderView.
+                    const bgGeometry = new THREE.SphereGeometry(50, 64, 32);
+                    bgGeometry.scale(-1, 1, 1);
+                    bgMesh = new THREE.Mesh(
+                        bgGeometry,
+                        new THREE.MeshBasicMaterial({ map: envBgTexture, depthWrite: false })
+                    );
+                    bgMesh.renderOrder = -1000;
+                    bgMesh.rotation.y = BG_BASE + BG_SIGN * envRotationRad;
+                    bgMesh.visible = !!envBackground;
+                    scene.add(bgMesh);
                 }
 
                 // Selected preview geometry (sphere/cube/shaderball),
@@ -2751,10 +2883,11 @@ const createMtlxRenderView = async ({
                 fallbackSpin = !!on;
                 if (controls) controls.autoRotate = !!on;
             },
-            // Show/hide the environment map as the visible background.
-            // No-op when there is no env (unlit previews).
+            // Show/hide the environment map as the visible backdrop
+            // (bgMesh). No-op when there is no env (unlit previews —
+            // bgMesh is null, see its declaration above).
             setEnvBackground: (on) => {
-                scene.background = (on && envBgTexture) ? envBgTexture : null;
+                if (bgMesh) bgMesh.visible = !!on;
             },
             // Whether this view HAS an environment to show — lets the
             // UI hide the toggle for unlit previews instead of
@@ -2770,17 +2903,15 @@ const createMtlxRenderView = async ({
                     uniforms.u_envMatrix.value = new THREE.Matrix4().makeRotationY(Math.PI / 2 + rad);
                 }
                 envRotationRad = rad;
-                // Best-effort: also rotate the visible backdrop via the
-                // background texture's offset (wrapS is RepeatWrapping —
-                // see makeBackgroundTexture). r128's equirect background
-                // path may or may not actually sample through
-                // texture.offset; if it doesn't, the lighting rotates but
-                // the backdrop stays fixed (there's no
-                // scene.backgroundRotation before three r163) — harmless
-                // either way, and this keeps working for free if it does.
-                if (envBgTexture) {
-                    envBgTexture.offset.x = -rad / (2 * Math.PI);
-                }
+                // Rotate the visible backdrop mesh to match — see
+                // BG_BASE/BG_SIGN's derivation comment above
+                // createMtlxRenderView (this is a real geometry
+                // rotation, not a texture-offset hack: bgMesh's
+                // declaration above explains why the old offset.x
+                // write never worked on r128). bgMesh is null for
+                // previews with no env; guard so this stays a no-op
+                // there, mirroring hasEnvBackground()'s contract.
+                if (bgMesh) bgMesh.rotation.y = BG_BASE + BG_SIGN * rad;
             },
             // IBL-only exposure multiplier — direct lights are
             // unaffected, but IBL is the dominant light source in these
@@ -2797,11 +2928,11 @@ const createMtlxRenderView = async ({
             },
             // Live-swap the environment (radiance/irradiance/mips/
             // background) without a shader rebuild — used by the
-            // Environment dialog's Import.../Reset. Re-applies the
-            // current rotation offset to the new background texture, and
-            // only touches scene.background if it's currently shown (a
-            // hidden background — scene.background falsy — stays hidden).
-            // No-op (safely) on views with no lighting/env samplers.
+            // Environment dialog's Import.../Reset. Swaps bgMesh's
+            // texture in place (rotation/visibility are left exactly
+            // as they were — this only changes WHAT's shown, never
+            // WHETHER it's shown). No-op (safely) on views with no
+            // lighting/env samplers.
             setEnvironment: (env) => {
                 if (!env) return;
                 if (envRadSamplerName && uniforms[envRadSamplerName]) uniforms[envRadSamplerName].value = env.radiance;
@@ -2818,8 +2949,14 @@ const createMtlxRenderView = async ({
                 envIrradiance = env.irradiance;
                 envMips = env.mips;
                 envBgTexture = env.background;
-                if (envBgTexture) envBgTexture.offset.x = -envRotationRad / (2 * Math.PI);
-                if (scene.background) scene.background = envBgTexture;
+                // bgMesh is null for previews with no env — guard so
+                // an Import/Reset broadcast (setEnvOverride's
+                // LIVE_VIEWS loop, which also try/catches each call as
+                // a backstop) can't throw calling this standalone.
+                if (bgMesh) {
+                    bgMesh.material.map = envBgTexture;
+                    bgMesh.material.needsUpdate = true;
+                }
             },
             // Apply a newly-generated (or already-generated, via `srcs`)
             // material into this SAME shell — the persistent-shell

--- a/js/mtlx-engine.js
+++ b/js/mtlx-engine.js
@@ -349,6 +349,7 @@ const mxElCat = (el) => mxSafe(() => el.getCategory(), '');
 const mxElType = (el) => mxSafe(() => String(el.getType()), '');
 const mxElName = (el) => mxSafe(() => el.getName(), '');
 const mxElAttr = (el, name) => mxSafe(() => el.getAttribute(name), '');
+const mxElHasAttr = (el, name) => mxSafe(() => el.hasAttribute(name), false);
 
 // Shortest chain of `convert` hops fromType->toType using ONLY the
 // conversions the loaded library actually defines. This matters because
@@ -462,6 +463,56 @@ const ensureTypedInput = (doc, node, inputName, wantedType) => {
         console.warn('ensureTypedInput: "' + inputName + '" is "' + mxElType(inp) + '" (wanted "' + wantedType + '"), path=' + how);
     }
     return inp;
+};
+
+// Belt-and-suspenders sweep run immediately before every writeToXmlString
+// call site (graph/model.jsx serializeDocXml, node-preview.jsx
+// buildExportXml, viewer-app.jsx send-to-editor): strips any leftover
+// `value` attribute from an <input> that ALSO carries a connection
+// (nodename/nodegraph/interfacename). MaterialX forbids an input binding
+// both a value and a connection — doc.validate() reports it as "Node input
+// has too many bindings" — and every consumer (shadergen, the graph UI)
+// reads the connection and ignores the value on a connected input anyway,
+// so removing it is semantics-preserving, never a behavior change to a
+// valid document. Root cause of the stale value is ensureTypedInput()
+// above copying the nodedef's default VALUE onto a freshly-created input;
+// callers are expected to strip it themselves right after wiring a
+// connection (see graph-app.jsx's stashValueBeforeRemoval call sites), but
+// this sweep also self-heals documents authored elsewhere or loaded from
+// disk before this fix existed — a later export cleans them up even
+// though nothing in THIS session wrote the bad attribute.
+//
+// Recursive walk over doc.getChildren() (mxSafe-wrapped at every step, so
+// one hostile/unbound element can't abort the sweep); depth-capped at 10,
+// which is generous headroom for MaterialX's actual nesting (doc ->
+// nodegraph -> node -> input is 3 deep) rather than a real limit anyone
+// should hit. Returns the number of attributes stripped, for perf/debug
+// logging by callers that want it.
+const stripValuesFromConnectedInputs = (doc, maxDepth) => {
+    const cap = (typeof maxDepth === 'number') ? maxDepth : 10;
+    let stripped = 0;
+    const walk = (el, depth) => {
+        if (!el || depth > cap) return;
+        const children = vecToArray(mxSafe(() => el.getChildren(), []));
+        for (const child of children) {
+            if (mxElCat(child) === 'input') {
+                const connected = mxElAttr(child, 'nodename')
+                    || mxElAttr(child, 'nodegraph')
+                    || mxElAttr(child, 'interfacename');
+                // Presence, not truthiness: an empty value="" on a
+                // connected input is just as invalid ("too many
+                // bindings") as a non-empty one, and mxElAttr's ''
+                // fallback can't tell "absent" from "present but empty".
+                if (connected && mxElHasAttr(child, 'value')) {
+                    const removed = mxSafe(() => { child.removeAttribute('value'); return true; }, false);
+                    if (removed) stripped++;
+                }
+            }
+            walk(child, depth + 1);
+        }
+    };
+    walk(doc, 0);
+    return stripped;
 };
 
 // ------------------------------------------------------------------
@@ -3064,12 +3115,216 @@ const createMtlxRenderView = async ({
 // fill the viewport with !important rules, and the render view's
 // ResizeObserver picks up the canvas size change — so callers only
 // need to toggle and (optionally) restyle inner fixed-size elements.
+//
+// CSS-maximize fallback: some hosts never grant native fullscreen at
+// all. VS Code webviews report `document.fullscreenEnabled === false`
+// (the webview host doesn't wire up the platform fullscreen
+// transition) and reject any requestFullscreen() call outright; a
+// plain <iframe> embed without an `allowfullscreen` attribute is
+// blocked by the browser the same way. `nativeFullscreenAvailable()`
+// is checked at TOGGLE time rather than cached once at load, since a
+// host could in principle flip capability after this script runs.
+// When native isn't available, `toggleFullscreen` drives a hand-
+// rolled "CSS maximize" instead: the target element is pinned over
+// the viewport with `position:fixed` + inset 0 and an opaque
+// backdrop, any ancestor whose COMPUTED style would otherwise create
+// a new containing block or clip it (backdrop-filter, transform,
+// filter, perspective, will-change, contain — the graph editor's
+// right panel trips this via `backdrop-blur` + `overflow-hidden`, see
+// graph-app.jsx ~:4770-4778) is neutralized inline, and this module
+// synthesizes a 'fullscreenchange' event on `document` so
+// `watchFullscreen` below (left untouched) and every existing
+// consumer (useFullscreen in mtlx-ui.jsx, graph panel maximize,
+// viewer/node-preview/graph-preview fullscreen buttons) keep working
+// without any caller-side branching.
 // ------------------------------------------------------------------
+
+// True only when the platform will actually grant a requestFullscreen()
+// call. False in VS Code webviews and in iframes lacking allowfullscreen.
+const nativeFullscreenAvailable = () =>
+    !!(document.fullscreenEnabled || document.webkitFullscreenEnabled);
+
+// Module-level state for the CSS-maximize fallback. null means
+// "nothing is CSS-maximized right now"; only one element can be
+// maximized at a time (mirrors native fullscreen semantics, and keeps
+// exit() unambiguous — there's exactly one thing to tear down).
+// Shape: { el, savedStyle, savedNeutralized[], savedBodyOverflow,
+//          savedHtmlOverflow, keyHandler, domObserver }
+let cssMaxState = null;
+
+// Saves an element's literal `style` ATTRIBUTE — distinguishing "no
+// style attribute at all" from "style=''" — so enter/exit can restore
+// it exactly later even though el/ancestors may carry framework-
+// authored inline styles (e.g. React style props) we must not clobber.
+const cssMaxSaveStyleAttr = (node) => ({
+    node,
+    hadAttr: node.hasAttribute('style'),
+    value: node.getAttribute('style'),
+});
+const cssMaxRestoreStyleAttr = (rec) => {
+    try {
+        if (rec.hadAttr) rec.node.setAttribute('style', rec.value);
+        else rec.node.removeAttribute('style');
+    } catch (e) { /* node may have been removed from the DOM meanwhile */ }
+};
+
+// Whether `cs` (a getComputedStyle() result) would make its element a
+// containing block for — or otherwise clip — a `position:fixed`
+// descendant. Checked property-by-property per the CSS spec: any
+// non-'none' backdrop-filter/transform/filter/perspective, a
+// will-change listing transform/filter/perspective, or a contain
+// value including paint/layout/strict/content all qualify (contain's
+// `size`/`style` keywords alone do not, so they're intentionally not
+// matched here).
+const cssMaxComputedIsTrap = (cs) => {
+    try {
+        if (cs.backdropFilter && cs.backdropFilter !== 'none') return true;
+        if (cs.webkitBackdropFilter && cs.webkitBackdropFilter !== 'none') return true;
+        if (cs.transform && cs.transform !== 'none') return true;
+        if (cs.filter && cs.filter !== 'none') return true;
+        if (cs.perspective && cs.perspective !== 'none') return true;
+        if (/transform|filter|perspective/.test(cs.willChange || '')) return true;
+        if (/paint|layout|strict|content/.test(cs.contain || '')) return true;
+        return false;
+    } catch (e) { return false; }
+};
+
+// Exit the current CSS-maximize, restoring everything it touched.
+// Called both from toggleFullscreen (user-initiated exit) and from
+// the MutationObserver below (auto-exit when el is disconnected).
+const exitCssMaximize = () => {
+    const state = cssMaxState;
+    if (!state) return;
+    // Null the module state FIRST, before any teardown work below. The
+    // MutationObserver's callback (and, in principle, a rapid double
+    // toggle) can re-enter this function while teardown is still
+    // running; with the state already null that re-entrant call is a
+    // harmless no-op instead of double-restoring styles or throwing.
+    cssMaxState = null;
+    try { state.domObserver.disconnect(); } catch (e) { /* already gone */ }
+    try { document.removeEventListener('keydown', state.keyHandler); } catch (e) { /* ignore */ }
+    cssMaxRestoreStyleAttr(state.savedStyle);
+    for (const rec of state.savedNeutralized) cssMaxRestoreStyleAttr(rec);
+    try { document.body.style.overflow = state.savedBodyOverflow; } catch (e) { /* ignore */ }
+    try { document.documentElement.style.overflow = state.savedHtmlOverflow; } catch (e) { /* ignore */ }
+    // Same notification channel the native path uses, so watchFullscreen
+    // subscribers see this exit exactly like a native fullscreenchange.
+    try { document.dispatchEvent(new Event('fullscreenchange')); } catch (e) { /* ignore */ }
+};
+
+// Enter CSS-maximize on `el`. Caller (toggleFullscreen) guarantees
+// cssMaxState is currently null — only one element maximizes at a time.
+const enterCssMaximize = (el) => {
+    try {
+        const savedStyle = cssMaxSaveStyleAttr(el);
+
+        // Ancestor neutralization walk: anything between el and <body>
+        // (inclusive) that would trap a fixed-position descendant gets
+        // its trapping properties inlined away, with its own style
+        // attribute saved first so this is fully reversible.
+        const savedNeutralized = [];
+        for (let node = el.parentElement; node; node = node.parentElement) {
+            let trap = false;
+            try { trap = cssMaxComputedIsTrap(getComputedStyle(node)); } catch (e) { trap = false; }
+            if (!trap) continue;
+            savedNeutralized.push(cssMaxSaveStyleAttr(node));
+            try {
+                node.style.backdropFilter = 'none';
+                node.style.webkitBackdropFilter = 'none';
+                node.style.transform = 'none';
+                node.style.filter = 'none';
+                node.style.perspective = 'none';
+                node.style.willChange = 'auto';
+                node.style.contain = 'none';
+            } catch (e) { /* stay defensive even though inline writes rarely throw */ }
+            if (node === document.body) break;
+        }
+
+        // Pin el over the viewport. zIndex 9990 stays below the 9999
+        // used by body-portaled overlays (mtlx-ui.jsx EnvDialog/popovers)
+        // so those remain usable while maximized. backgroundColor is
+        // needed because the graph/viewer preview containers have no
+        // opaque background of their own — without it, whatever used to
+        // be behind el would show through the gaps during the transition.
+        // The box starts below the site header (js/site-header.js renders
+        // a sticky <header> inside #site-header, a sibling of #root at
+        // z-40) instead of at the very top, so the header stays visible
+        // and clickable rather than being covered by el's z-index 9990.
+        // When the header is absent/hidden (embed-mode iframes hide it),
+        // its rect bottom is 0 and this collapses back to full-viewport.
+        try {
+            const hdr = document.querySelector('#site-header header');
+            const topPx = hdr ? Math.max(0, hdr.getBoundingClientRect().bottom) : 0;
+            el.style.position = 'fixed';
+            el.style.top = topPx + 'px';
+            el.style.left = '0';
+            el.style.right = '0';
+            el.style.bottom = '0';
+            el.style.width = '100%';
+            // auto, not 100%: with top offset by topPx AND bottom pinned
+            // to 0, height:100% would overflow past the viewport bottom
+            // by topPx — auto lets top+bottom do the sizing instead.
+            el.style.height = 'auto';
+            el.style.maxWidth = 'none';
+            el.style.maxHeight = 'none';
+            el.style.margin = '0';
+            el.style.zIndex = '9990';
+            el.style.backgroundColor = '#111827';
+        } catch (e) {
+            // Couldn't style el at all — nothing was actually maximized,
+            // so undo the ancestor neutralization and bail rather than
+            // leaving cssMaxState pointing at a half-applied maximize.
+            for (const rec of savedNeutralized) cssMaxRestoreStyleAttr(rec);
+            return;
+        }
+
+        const savedBodyOverflow = document.body.style.overflow;
+        const savedHtmlOverflow = document.documentElement.style.overflow;
+        document.body.style.overflow = 'hidden';
+        document.documentElement.style.overflow = 'hidden';
+
+        // Esc parity with native fullscreen. Bubble phase + document
+        // target so it doesn't need to compete with per-widget handlers.
+        const keyHandler = (e) => { if (e.key === 'Escape') exitCssMaximize(); };
+        document.addEventListener('keydown', keyHandler);
+
+        // Native fullscreen auto-exits when the fullscreened element
+        // leaves the document; CSS-maximize has no such built-in, so a
+        // MutationObserver stands in for it. Without this, switching
+        // shell views (graph -> docs) while maximized would unmount el
+        // but leave body/html stuck at overflow:hidden forever.
+        const domObserver = new MutationObserver(() => {
+            if (!document.body.contains(el)) exitCssMaximize();
+        });
+        domObserver.observe(document.body, { childList: true, subtree: true });
+
+        cssMaxState = {
+            el, savedStyle, savedNeutralized,
+            savedBodyOverflow, savedHtmlOverflow,
+            keyHandler, domObserver,
+        };
+
+        try { document.dispatchEvent(new Event('fullscreenchange')); } catch (e) { /* ignore */ }
+    } catch (e) { /* CSS maximize is best-effort; never throw into the caller */ }
+};
+
 const fullscreenElement = () =>
-    document.fullscreenElement || document.webkitFullscreenElement || null;
+    document.fullscreenElement || document.webkitFullscreenElement ||
+    (cssMaxState ? cssMaxState.el : null);
 // Enter fullscreen on `el`, or exit if anything is fullscreen now.
 const toggleFullscreen = (el) => {
     try {
+        if (!nativeFullscreenAvailable()) {
+            // CSS-maximize fallback (VS Code webview / no-allowfullscreen
+            // iframe). Same "exit whatever's active, else enter on el"
+            // shape as the native branch below, just against cssMaxState
+            // instead of the browser's real fullscreen element — so a
+            // toggle while a DIFFERENT element is maximized exits it
+            // (native parity: it never swaps targets, just closes).
+            if (cssMaxState) exitCssMaximize();
+            else if (el) enterCssMaximize(el);
+            return;
+        }
         if (fullscreenElement()) {
             const exit = document.exitFullscreen || document.webkitExitFullscreen;
             if (exit) { const p = exit.call(document); if (p && p.catch) p.catch(() => {}); }
@@ -3123,6 +3378,7 @@ const MTLX_ICON_PATHS = {
     'chevron-right': { filled: false, inner: '<path d="M9 6l6 6l-6 6"/>' },
     'chevron-down': { filled: false, inner: '<path d="M6 9l6 6l6 -6"/>' },
     'check': { filled: false, inner: '<path d="M5 12l5 5l10 -10"/>' },
+    x: { filled: false, inner: '<path d="M18 6l-12 12"/><path d="M6 6l12 12"/>' },
 };
 
 // React component (plain createElement — this file stays JSX-free).
@@ -3185,7 +3441,7 @@ Object.assign(window, {
     parseUniforms, stripVersion, encodeDisplay,
     mxErr, mxWriteValue, vecToArray,
     mxSafe, mxElName, mxElCat, mxElType, mxElAttr,
-    findConvertChain, ensureTypedInput,
+    findConvertChain, ensureTypedInput, stripValuesFromConnectedInputs,
     normPath, readDroppedItems, expandZips, findFileForRef, resolveIncludes,
     TEXTURE_CACHE, textureCacheKey, bindDroppedTextures,
     collectMxUniforms, mxValueToThreeUniform,

--- a/js/node-preview.jsx
+++ b/js/node-preview.jsx
@@ -285,6 +285,13 @@
                 if (DEBUG_SHADERS) {
                     console.log('export input types (non-default only) →', typeReport.join(', ') || '(all at defaults)');
                 }
+                // Item 9 belt-and-suspenders: the wiring sites below (translation,
+                // convert.in x2, surface_unlit.emission_color) already strip the
+                // value themselves right after connecting, but this sweep also
+                // catches anything from an older build of this function or a
+                // loaded document that predates the fix — never export an input
+                // with both a value and a connection.
+                mxSafe(() => stripValuesFromConnectedInputs(ed.doc), 0);
                 // 2) Serialize the DOCUMENT itself — no options, no
                 //    predicate, no fallback. The standard library is attached
                 //    via setDataLibrary (referenced, not contained), so the
@@ -587,7 +594,12 @@
                             applyOverrides(previewInstance);
                             createdNodes.push(previewInstance);
                             renderable = doc.addNode('surface', 'preview_surface', 'surfaceshader');
-                            addTypedInput(renderable, 'bsdf', 'BSDF').setNodeName('preview_bsdf');
+                            const bsdfInp = addTypedInput(renderable, 'bsdf', 'BSDF');
+                            bsdfInp.setNodeName('preview_bsdf');
+                            // Item 9: addTypedInput may have copied the
+                            // nodedef default VALUE onto this fresh input —
+                            // strip it now that it's connected.
+                            mxSafe(() => { bsdfInp.removeAttribute('value'); return true; }, false);
                             createdNodes.push(renderable);
                             needsLighting = true;
                         } else if (kind === 'edf') {
@@ -596,7 +608,12 @@
                             applyOverrides(previewInstance);
                             createdNodes.push(previewInstance);
                             renderable = doc.addNode('surface', 'preview_surface', 'surfaceshader');
-                            addTypedInput(renderable, 'edf', 'EDF').setNodeName('preview_edf');
+                            const edfInp = addTypedInput(renderable, 'edf', 'EDF');
+                            edfInp.setNodeName('preview_edf');
+                            // Item 9: addTypedInput may have copied the
+                            // nodedef default VALUE onto this fresh input —
+                            // strip it now that it's connected.
+                            mxSafe(() => { edfInp.removeAttribute('value'); return true; }, false);
                             createdNodes.push(renderable);
                             needsLighting = true;
                         } else if (kind === 'translation') {
@@ -621,9 +638,18 @@
                                 const inp = addTypedInput(renderable, iName, oTypeStr);
                                 inp.setNodeName('preview_node');
                                 inp.setAttribute('output', oName);
+                                // Item 9: addTypedInput (ensureTypedInput) may have
+                                // copied the nodedef default VALUE onto this fresh
+                                // input — a connected input must not also carry one.
+                                mxSafe(() => { inp.removeAttribute('value'); return true; }, false);
                             }
                             const mat = doc.addNode('surfacematerial', 'preview_material', 'material');
-                            addTypedInput(mat, 'surfaceshader', 'surfaceshader').setNodeName('preview_surface');
+                            const matInp = addTypedInput(mat, 'surfaceshader', 'surfaceshader');
+                            matInp.setNodeName('preview_surface');
+                            // Item 9: addTypedInput may have copied the
+                            // nodedef default VALUE onto this fresh input —
+                            // strip it now that it's connected.
+                            mxSafe(() => { matInp.removeAttribute('value'); return true; }, false);
                             createdNodes.push(mat);
                             needsLighting = true;
                         } else if (kind === 'color') {
@@ -656,6 +682,10 @@
                                     const inp = addTypedInput(conv, 'in', prevType);
                                     if (srcIsPreviewNode) connectToPreview(inp, 'preview_node');
                                     else inp.setNodeName(srcName);
+                                    // Item 9: addTypedInput may have copied the
+                                    // nodedef default VALUE onto `inp` — strip it
+                                    // now that it's connected, either branch above.
+                                    mxSafe(() => { inp.removeAttribute('value'); return true; }, false);
                                     createdNodes.push(conv);
                                     srcName = isLast ? 'preview_surface' : 'preview_convert' + (i || '');
                                     srcIsPreviewNode = false;
@@ -684,6 +714,10 @@
                                     // selection); later hops chain convert→convert.
                                     if (srcIsPreviewNode) connectToPreview(inp, 'preview_node');
                                     else inp.setNodeName(srcName);
+                                    // Item 9: addTypedInput may have copied the
+                                    // nodedef default VALUE onto `inp` — strip it
+                                    // now that it's connected, either branch above.
+                                    mxSafe(() => { inp.removeAttribute('value'); return true; }, false);
                                     createdNodes.push(conv);
                                     srcName = 'preview_convert' + (i || '');
                                     srcIsPreviewNode = false;
@@ -703,6 +737,10 @@
                                 // itself for multi-output color3 taps.
                                 if (srcIsPreviewNode) connectToPreview(emiss, 'preview_node');
                                 else emiss.setNodeName(srcName);
+                                // Item 9: addTypedInput may have copied the
+                                // nodedef default VALUE onto `emiss` — strip it
+                                // now that it's connected, either branch above.
+                                mxSafe(() => { emiss.removeAttribute('value'); return true; }, false);
                             }
                         } else {
                             const shown = (types || []).join(', ') || 'unknown';
@@ -717,7 +755,12 @@
                         if (kind !== 'translation') {
                             try {
                                 const mat0 = doc.addNode('surfacematerial', 'preview_material', 'material');
-                                addTypedInput(mat0, 'surfaceshader', 'surfaceshader').setNodeName('preview_surface');
+                                const mat0Inp = addTypedInput(mat0, 'surfaceshader', 'surfaceshader');
+                                mat0Inp.setNodeName('preview_surface');
+                                // Item 9: addTypedInput may have copied the
+                                // nodedef default VALUE onto this fresh input —
+                                // strip it now that it's connected.
+                                mxSafe(() => { mat0Inp.removeAttribute('value'); return true; }, false);
                                 createdNodes.push(mat0);
                             } catch (matErr) { /* export falls back to wrapper-less doc */ }
                         }
@@ -746,10 +789,20 @@
                                 console.warn('writeToXmlString failed:', mxErr(mx, xmlErr));
                             }
                         }
+                        // The WASM binding's validate() has an overloadTable
+                        // {'0','1'} — the previous "boolean-only" comment here
+                        // was WRONG (verified headless, see graph-app.jsx's
+                        // matching fix for the Validate dialog). The 1-arg
+                        // overload `validate(holder)` fills holder.message
+                        // with the full newline-separated MaterialX diagnostic
+                        // list on failure, so a debug build gets the real
+                        // reason instead of a bare boolean.
                         if (typeof doc.validate === 'function') {
                             try {
-                                if (!doc.validate()) {
+                                const holder = {};
+                                if (!doc.validate(holder)) {
                                     console.warn(`MaterialX document failed validate() for "${nodeName}" — generation will likely fail.`);
+                                    if (DEBUG_SHADERS) console.warn(holder.message || '(no message)');
                                 }
                             } catch (vErr) {
                                 console.warn('doc.validate() threw:', mxErr(mx, vErr));

--- a/js/shared/mtlx-ui.jsx
+++ b/js/shared/mtlx-ui.jsx
@@ -219,6 +219,8 @@ const EnvDialog = ({
     exposure, onExposureChange,
     onImportFile, onReset,
     importError,
+    placement,
+    edgeRef,
 }) => {
     const popRef = React.useRef(null);
     const [pos, setPos] = React.useState(null);
@@ -230,18 +232,38 @@ const EnvDialog = ({
     // position would push this 224px-wide dialog past both the right and
     // bottom edges. Vertical flip is modeled on ColorSwatch.openPopover
     // above.
+    // This dialog is shared by the viewer/docs previews AND the graph
+    // preview. The graph preview panel is itself docked at the screen's
+    // right edge, so the default below/right-aligned placement would drop
+    // the dialog on top of the 3D canvas it belongs to — placement="left"
+    // is an opt-in used only there, opening the dialog over the graph
+    // canvas instead (harmless to cover).
     React.useEffect(() => {
         if (!open) return undefined;
         const rect = anchorRef.current ? anchorRef.current.getBoundingClientRect() : null;
         if (rect) {
-            const left = Math.max(8, Math.min(rect.right - ENV_DIALOG_W, window.innerWidth - ENV_DIALOG_W - 8));
-            const flip = rect.bottom + ENV_DIALOG_H > window.innerHeight;
-            setPos(flip
-                ? { left, bottom: window.innerHeight - rect.top + 4 }
-                : { left, top: rect.bottom + 4 });
+            if (placement === 'left') {
+                // Horizontal anchor is the PANEL's left edge (edgeRef), not
+                // the button's — the env button sits near the right edge of
+                // the (right-docked) preview panel, so anchoring to it would
+                // leave the dialog overlapping most of the panel, including
+                // the 3D canvas. Falls back to the button rect if no
+                // edgeRef was supplied. Vertical position is still taken
+                // from the button rect (unchanged).
+                const edgeRect = (edgeRef && edgeRef.current) ? edgeRef.current.getBoundingClientRect() : rect;
+                const left = Math.max(8, edgeRect.left - ENV_DIALOG_W - 8);
+                const top = Math.min(rect.top, window.innerHeight - ENV_DIALOG_H - 8);
+                setPos({ left, top });
+            } else {
+                const left = Math.max(8, Math.min(rect.right - ENV_DIALOG_W, window.innerWidth - ENV_DIALOG_W - 8));
+                const flip = rect.bottom + ENV_DIALOG_H > window.innerHeight;
+                setPos(flip
+                    ? { left, bottom: window.innerHeight - rect.top + 4 }
+                    : { left, top: rect.bottom + 4 });
+            }
         }
         return undefined;
-    }, [open]);
+    }, [open, placement]);
 
     useEscapeToClose(onClose, open);
 
@@ -344,6 +366,7 @@ const ViewportControls = ({
     isFullscreen, onToggleFullscreen,
     children,
     trailingChildren,
+    envDialogPlacement,
     containerClassName = 'absolute top-2 right-2 z-20 flex items-center gap-1',
     selectClassName = 'h-6 text-[11px] px-2 py-0 rounded border bg-gray-800/80 border-gray-600 text-gray-300',
     buttonClassName = (active) => `h-6 inline-flex items-center text-[11px] px-2 rounded border transition-colors ${
@@ -353,6 +376,11 @@ const ViewportControls = ({
     }`,
 }) => {
     const envBtnRef = React.useRef(null);
+    // Spans the full containerClassName strip (which itself spans the full
+    // panel width in the graph preview's docked layout), so its left edge
+    // approximates the PANEL's left edge — used by EnvDialog's placement="left"
+    // branch to clear the whole panel instead of just the env button.
+    const panelEdgeRef = React.useRef(null);
     const [envOpen, setEnvOpen] = React.useState(false);
     const [envRotation, setEnvRotation] = React.useState(0);   // degrees, 0-360
     const [envExposure, setEnvExposure] = React.useState(1.0);
@@ -414,7 +442,7 @@ const ViewportControls = ({
     };
 
     return (
-    <div className={containerClassName}>
+    <div ref={panelEdgeRef} className={containerClassName}>
         {children}
         <select
             value={geom}
@@ -444,8 +472,10 @@ const ViewportControls = ({
                 {viewRef && (
                     <EnvDialog
                         anchorRef={envBtnRef}
+                        edgeRef={panelEdgeRef}
                         open={envOpen}
                         onClose={() => setEnvOpen(false)}
+                        placement={envDialogPlacement}
                         envBg={envBg}
                         onToggleEnvBg={onToggleEnvBg}
                         rotation={envRotation}

--- a/js/site-header.js
+++ b/js/site-header.js
@@ -25,7 +25,12 @@
     // The old standalone pages (material-viewer.html, node-graph.html,
     // app.html) are now just redirect stubs that never load this script, so
     // the non-shell branch below is retained only as dead-code safety.
-    var IS_SHELL = /(^|\/)(index\.html)?$/i.test(location.pathname);
+    // Inside the VS Code webview the document URL is a vscode-webview://
+    // resource and never ends in index.html, but it genuinely IS the shell
+    // (hash-routed docs/viewer/graph views, same as index.html in a
+    // browser). bootstrap.js sets window.__MTLX_VSCODE__ BEFORE any site
+    // script loads, so it's a reliable second signal here.
+    var IS_SHELL = /(^|\/)(index\.html)?$/i.test(location.pathname) || !!window.__MTLX_VSCODE__;
 
     // The site name. Change it here and it changes everywhere
     // (header, and — via window.SITE_TITLE — anything React renders).
@@ -225,12 +230,18 @@
     var closeMobileMenu = function () {
         if (!mobileMenu || !navToggle) return;
         mobileMenu.classList.add('hidden');
+        mobileMenu.style.display = 'none';
         navToggle.setAttribute('aria-expanded', 'false');
     };
     if (navToggle && mobileMenu) {
         navToggle.addEventListener('click', function () {
             var willOpen = mobileMenu.classList.contains('hidden');
             mobileMenu.classList.toggle('hidden');
+            // The measured-collapse path below can force the hamburger
+            // visible at >=md widths (long nav labels overflowing), where
+            // the panel's own `md:hidden` class would keep it display:none
+            // even after `hidden` is removed — inline display must win.
+            mobileMenu.style.display = willOpen ? 'block' : 'none';
             navToggle.setAttribute('aria-expanded', willOpen ? 'true' : 'false');
         });
         // Any link inside the mobile panel (nav item or source/feedback/

--- a/js/viewer-app.jsx
+++ b/js/viewer-app.jsx
@@ -176,6 +176,11 @@
                 if (!loaded || !loaded.doc) return;
                 let xml;
                 try {
+                    // Item 9 belt-and-suspenders: strip any input that carries
+                    // both a value and a connection before handing the document
+                    // to the graph editor — self-heals documents loaded here
+                    // before this fix existed, not just ones built in this app.
+                    mxSafe(() => stripValuesFromConnectedInputs(loaded.doc), 0);
                     xml = loaded.mx.writeToXmlString(loaded.doc);
                 } catch (e) {
                     console.warn('Send to Editor: failed to serialize the document', e);

--- a/package.json
+++ b/package.json
@@ -33,9 +33,25 @@
     "materialx editor"
   ],
   "activationEvents": [
-    "onCustomEditor:materialxPlayground.editor"
+    "onCustomEditor:materialxPlayground.editor",
+    "onLanguage:mtlx"
   ],
   "contributes": {
+    "languages": [
+      {
+        "id": "mtlx",
+        "extensions": [".mtlx"],
+        "aliases": ["MaterialX", "mtlx"],
+        "configuration": "./vscode_extension/language/mtlx.language-configuration.json"
+      }
+    ],
+    "grammars": [
+      {
+        "language": "mtlx",
+        "scopeName": "text.mtlx",
+        "path": "./vscode_extension/language/mtlx.tmLanguage.json"
+      }
+    ],
     "customEditors": [
       {
         "viewType": "materialxPlayground.editor",

--- a/vscode_extension/README.md
+++ b/vscode_extension/README.md
@@ -107,6 +107,76 @@ replacing the default text editor). To make it the default, add to your
 }
 ```
 
+## Language features (`.mtlx` editing, validation, hover docs)
+
+These work in **any** editor for a `.mtlx` file — including VS Code's plain
+built-in text editor, not just the MaterialX Playground custom editor
+above — because they're registered against the `mtlx` language id
+(`.mtlx` files activate it automatically), independent of the custom
+editor.
+
+- **Syntax highlighting**: `.mtlx` files get XML-style syntax highlighting
+  (the bundled grammar just includes VS Code's own built-in `text.xml`
+  grammar — no MaterialX-specific tokenizing to maintain) plus
+  language-aware editing behavior: `Ctrl+/` toggles `<!-- -->` block
+  comments, and `<>`/quotes auto-close and surround a selection. The
+  language mode shows as "MaterialX" in the status bar.
+- **Live validation** (Problems squiggles + status bar), in two tiers,
+  re-run on a 400ms debounce as you type:
+  - **Tier 1 — XML well-formedness.** A small, dependency-free scanner
+    (this extension ships **zero** npm dependencies) that tokenizes tags
+    and attributes to catch mismatched/unclosed tags, malformed
+    attributes, duplicate attributes, and stray unescaped `&`/`<` —
+    with precise `{line, character}` squiggle ranges.
+  - **Tier 2 — MaterialX semantic validation.** Runs only once tier 1 is
+    clean: loads the same bundled MaterialX WASM build the Material
+    Viewer/Node Graph Editor use (headless, inside the extension host)
+    and actually parses + `validate()`s the document — catching things
+    like a node graph referencing a nonexistent node. Because this
+    build's `validate()` binding is boolean-only (no message strings) and
+    the WASM binding hands back no character offsets at all, the
+    resulting diagnostics are a best-effort scan for dangling references
+    and their squiggle lands near the *named* element rather than at an
+    exact reported column — an accepted approximation, not a bug.
+  - If the WASM build fails to load — most commonly a CRLF-corrupted
+    `JsMaterialXGenShader.data` archive from a bad Windows checkout of
+    this binary file — tier 2 silently and **permanently** degrades to
+    tier-1-only for the rest of that session (retrying on every
+    keystroke would be both slow and pointless). XML validation keeps
+    working regardless, and the reason is logged once to the
+    **MaterialX Playground** output channel.
+  - A status bar item, visible only while a `.mtlx` editor is active,
+    shows `$(check) MaterialX` when the open document is clean or
+    `$(error) MaterialX: N` with a tooltip listing the first few issues;
+    click it to jump to the Problems panel.
+- **Hover documentation**: hovering a node **category** — an element tag
+  name like `<standard_surface>` or `<mix>` (MaterialX nodes are just
+  elements named by category), or the value of a `node="..."` attribute
+  (`<nodedef>`/`<materialassign>` references) — shows that node's
+  description straight from the MaterialX specification (parsed from the
+  `MaterialX.PBRSpec.md` / `MaterialX.NPRSpec.md` /
+  `MaterialX.StandardNodes.md` files committed at the repo root) plus an
+  **Open documentation** link that opens/reuses the
+  `MaterialX: Open Node Documentation` panel scoped directly to that
+  node. Structural/document elements — `<materialx>`, `<nodegraph>`,
+  `<input>`, `<output>`, `<nodedef>`, `<look>`, `<xi:include>`, and
+  similar schema scaffolding — never produce a hover, only actual node
+  categories do. A category with no matching spec entry (e.g. a custom
+  node defined outside the standard libraries) still gets a headline plus
+  the Open documentation link; the docs site resolves name-only
+  permalinks by search rather than requiring an exact spec match.
+- **Docs panels default to 3D previews off**: the node documentation
+  panel's per-node 3D previews — whether opened via
+  `MaterialX: Open Node Documentation` or a hover's Open documentation
+  link above — start with 3D previews switched OFF. Each preview is its
+  own WASM shader-gen + WebGL context, which is heavy to pile on top of a
+  VS Code webview that, in practice, often already has a live MaterialX
+  Playground editor tab running its own such session. Toggling previews
+  on in the docs view's own UI sticks for the rest of that webview's
+  session (it does not silently flip back off); this default is scoped
+  to docs panels only — the Material Viewer/Node Graph Editor views never
+  read this preference at all.
+
 ## Settings
 
 - `materialx.defaultView` (`"viewer"` | `"graph"`, default `"viewer"`) —
@@ -162,17 +232,41 @@ replacing the default text editor). To make it the default, add to your
 
 ## How it works (brief)
 
-- `src/extension.js` registers the custom editor and its three commands
-  (send-to-playground, save-graph, open-docs).
+- `src/extension.js` registers the custom editor, its commands
+  (send-to-playground, save-graph, undo/redo-graph, open-docs — the last
+  accepts an optional node-category argument, see hover documentation
+  above), the diagnostic collection + status bar (`src/validator.js`),
+  and the hover provider (`src/hoverProvider.js`).
 - `src/editorProvider.js` builds the webview's HTML from
   `media/webview.html` (a hand-maintained mirror of `../index.html`'s
   `<head>`/`<body>`, kept in sync — see the comment at the top of that
   file) and wires up the extension<->webview messaging + live reload.
+  Also backs the document-less docs panel singleton
+  (`materialxPlayground.openDocs`), threading an arbitrary `location.hash`
+  (`#!docs`, or `#/<category>` for a hover's deep link) through to a
+  fresh panel or a re-navigated existing one.
 - `src/docScanner.js` is a Node-side port of the site's own
   `xi:include`/texture-reference crawler (`js/mtlx-engine.js`
   `resolveIncludes`, `js/graph-app.jsx` `extractFilenameRefs` +
   `loadPreset`'s BFS), so the same resolution logic runs against the real
   filesystem instead of an in-memory drag-and-drop file map.
+- `src/validator.js` is the two-tier `.mtlx` diagnostics engine described
+  under "Live validation" above: a dependency-free XML tokenizer (tier 1)
+  plus `src/mtlxNode.js`, a headless (no rendering/WebGL touched) loader
+  for the bundled MaterialX WASM build used for tier 2's actual
+  parse/`validate()` pass.
+- `src/specDocs.js` is a trimmed, Node-side port of `js/spec-parser.js`'s
+  markdown state machine (anchors/headings -> following paragraph text,
+  with the same link/bold/italic/entity cleanup), extracting only the
+  per-node DESCRIPTION text — not the full doc database (notes, port
+  tables, references) `js/spec-parser.js` builds for the website itself —
+  from the three spec `.md` files committed at the repo root. Parsed once
+  and cached for the life of the extension host process.
+- `src/hoverProvider.js` registers the hover provider: detects a node
+  category under the cursor (an element tag name, excluding structural/
+  document elements, or a `node="..."` attribute value), looks it up via
+  `src/specDocs.js`, and renders a trusted `MarkdownString` with the
+  description and an `Open documentation` command link.
 - `media/bootstrap.js` runs first inside the webview and adapts the
   extension's message into the exact
   `window.__mtlxPendingImport`/`__mtlxPendingViewerImport` +

--- a/vscode_extension/language/mtlx.language-configuration.json
+++ b/vscode_extension/language/mtlx.language-configuration.json
@@ -1,0 +1,18 @@
+{
+  "comments": {
+    "blockComment": ["<!--", "-->"]
+  },
+  "brackets": [
+    ["<", ">"]
+  ],
+  "autoClosingPairs": [
+    { "open": "<!--", "close": "-->" },
+    { "open": "\"", "close": "\"" },
+    { "open": "'", "close": "'" }
+  ],
+  "surroundingPairs": [
+    ["\"", "\""],
+    ["'", "'"],
+    ["<", ">"]
+  ]
+}

--- a/vscode_extension/language/mtlx.tmLanguage.json
+++ b/vscode_extension/language/mtlx.tmLanguage.json
@@ -1,0 +1,7 @@
+{
+  "name": "MaterialX",
+  "scopeName": "text.mtlx",
+  "patterns": [
+    { "include": "text.xml" }
+  ]
+}

--- a/vscode_extension/media/bootstrap.js
+++ b/vscode_extension/media/bootstrap.js
@@ -24,6 +24,35 @@
     // branch on it — e.g. to hide a browser-only affordance.
     window.__MTLX_VSCODE__ = true;
 
+    // Default the docs view's 3D previews OFF, once per webview state.
+    // The site's node-documentation grid (js/docs/) reads/writes
+    // localStorage 'mtlx_show_previews' as a hard kill-switch for its
+    // per-node Node3DPreview (each preview is its own WASM shader-gen +
+    // WebGL context) — '0' means off, anything else (including unset)
+    // means on. Outside VS Code that's a reasonable default (a browser
+    // tab is cheap to open/close), but a VS Code docs panel is usually
+    // opened alongside a live custom-editor webview that's ALREADY
+    // running its own WASM/WebGL instance (see docScanner/editorProvider
+    // and the "Multiple open .mtlx tabs" note in README.md) — piling a
+    // grid of per-node 3D previews on top, inside the same constrained
+    // webview host process, is heavy enough to want off by default here.
+    // Only touches the key if it has NEVER been set in this webview's
+    // storage (=== null), so: this fires once per fresh webview state,
+    // and the user's own later in-UI "3D previews: On" toggle (which
+    // writes '1') sticks for the rest of that session — this default
+    // never fights it back off. Embed/chromeless iframes (the graph
+    // editor's inline "?" docs dialog) force previews on regardless of
+    // this key, and the Graph/Viewer views never read it at all — this
+    // only affects docs panels/tabs.
+    try {
+        if (window.localStorage.getItem('mtlx_show_previews') === null) {
+            window.localStorage.setItem('mtlx_show_previews', '0');
+        }
+    } catch (e) {
+        // localStorage can throw (disabled storage, quota, etc.) — never
+        // let this default block the rest of bootstrap from running.
+    }
+
     // Decode a base64 string into a Uint8Array. Used for every binary
     // payload that crosses the extension<->webview postMessage boundary
     // (see the 'mtlx-fetch-result' and 'mtlx-open' handlers below) —

--- a/vscode_extension/src/editorProvider.js
+++ b/vscode_extension/src/editorProvider.js
@@ -539,4 +539,4 @@ class MaterialXEditorProvider {
     }
 }
 
-module.exports = { MaterialXEditorProvider, wireCommonWebviewMessages, saveActiveGraph, undoActiveGraph, redoActiveGraph, openDocsPanel };
+module.exports = { MaterialXEditorProvider, wireCommonWebviewMessages, saveActiveGraph, undoActiveGraph, redoActiveGraph, openDocsPanel, getSharedOutputChannel };

--- a/vscode_extension/src/extension.js
+++ b/vscode_extension/src/extension.js
@@ -2,13 +2,101 @@
 // extension. Registers the custom editor (editorProvider.js) that hosts
 // the site's Material Viewer / Node Graph Editor in a webview, plus two
 // commands: one that sends a .mtlx file into both views at once, and one
-// that opens the docs-only view, which has no backing document.
+// that opens the docs-only view, which has no backing document. Also
+// wires up live .mtlx diagnostics (validator.js: tier 1 XML well-
+// formedness, tier 2 MaterialX semantic validation) into a
+// DiagnosticCollection and a status bar summary, and hover documentation
+// (hoverProvider.js) for node categories.
 'use strict';
 
 const vscode = require('vscode');
-const { MaterialXEditorProvider, saveActiveGraph, undoActiveGraph, redoActiveGraph, openDocsPanel } = require('./editorProvider');
+const { MaterialXEditorProvider, saveActiveGraph, undoActiveGraph, redoActiveGraph, openDocsPanel, getSharedOutputChannel } = require('./editorProvider');
+const validator = require('./validator');
+const hoverProvider = require('./hoverProvider');
+
+// Diagnostics + status bar are created once in activate() but read/
+// written from the module-scope helpers below (toVsDiagnostics,
+// updateStatusBar, runValidation), so they're tracked at module scope
+// rather than as activate()-local consts.
+let diagnosticCollection = null;
+let statusBarItem = null;
+
+// validator.js's return shape ({ message, startLine, startChar, endLine,
+// endChar, severity: 'error' }) is plain objects, not vscode.Diagnostic
+// instances — validator.js/mtlxNode.js must stay independently loadable
+// with plain `node` (no require('vscode')), so this conversion happens
+// at the extension.js boundary instead.
+function toVsDiagnostics(items) {
+    return items.map((it) => new vscode.Diagnostic(
+        new vscode.Range(it.startLine, it.startChar, it.endLine, it.endChar),
+        it.message,
+        it.severity === 'warning' ? vscode.DiagnosticSeverity.Warning : vscode.DiagnosticSeverity.Error
+    ));
+}
+
+// Reads the currently active editor itself (no args) — called after
+// every diagnosticCollection update and on active-editor changes, so the
+// status bar always reflects whichever .mtlx tab (if any) is focused.
+function updateStatusBar() {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor || editor.document.languageId !== 'mtlx') {
+        statusBarItem.hide();
+        return;
+    }
+    const diags = diagnosticCollection.get(editor.document.uri) || [];
+    if (diags.length === 0) {
+        statusBarItem.text = '$(check) MaterialX';
+        statusBarItem.tooltip = 'No MaterialX validation issues.';
+    } else {
+        statusBarItem.text = '$(error) MaterialX: ' + diags.length;
+        const preview = diags.slice(0, 3).map((d) => '• ' + d.message).join('\n');
+        statusBarItem.tooltip = 'MaterialX validation issue' + (diags.length === 1 ? '' : 's') + ' (' + diags.length + '):\n' + preview + (diags.length > 3 ? '\n…' : '');
+    }
+    statusBarItem.show();
+}
+
+// Runs tier 1 + (when clean) tier 2 validation on `document` and updates
+// its diagnostics/the status bar. Never throws — a validator bug must
+// not break the editor.
+async function runValidation(document) {
+    if (document.languageId !== 'mtlx') return;
+    let items = [];
+    try {
+        items = await validator.validateDocument(document.getText());
+    } catch (e) {
+        items = []; // never let a validator bug break the editor
+    }
+    diagnosticCollection.set(document.uri, toVsDiagnostics(items));
+    const warning = validator.consumeTier2Warning();
+    if (warning) {
+        getSharedOutputChannel().appendLine('[' + new Date().toISOString() + '] MaterialX semantic validation (tier 2) is unavailable: ' + warning);
+    }
+    updateStatusBar();
+}
+
+// Debounced per-document so a fast typist doesn't re-run tier 1/2 on
+// every keystroke, and so multiple open .mtlx tabs don't share (and
+// clobber) a single timer. Mirrors editorProvider.js's
+// RELOAD_DEBOUNCE_MS naming/pattern.
+const VALIDATE_DEBOUNCE_MS = 400;
+const debounceTimers = new Map(); // uri.toString() -> NodeJS.Timeout
 
 function activate(context) {
+    // Before anything else, so semantic (tier 2) validation is ready as
+    // soon as the first .mtlx document is opened.
+    validator.init(context.extensionUri.fsPath);
+
+    diagnosticCollection = vscode.languages.createDiagnosticCollection('materialx');
+    context.subscriptions.push(diagnosticCollection);
+
+    statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
+    statusBarItem.command = 'workbench.actions.view.problems';
+    context.subscriptions.push(statusBarItem);
+
+    // Hover documentation for node categories (hoverProvider.js) — pushes
+    // its own disposable onto context.subscriptions.
+    hoverProvider.register(context);
+
     const provider = new MaterialXEditorProvider(context);
 
     context.subscriptions.push(
@@ -63,7 +151,18 @@ function activate(context) {
         // editorProvider.js's undoActiveGraph()/redoActiveGraph().
         vscode.commands.registerCommand('materialxPlayground.undoGraph', () => undoActiveGraph()),
         vscode.commands.registerCommand('materialxPlayground.redoGraph', () => redoActiveGraph()),
-        vscode.commands.registerCommand('materialxPlayground.openDocs', async () => {
+        // `category` is optional: no-arg (Command Palette / explorer menu)
+        // opens the docs library browser exactly as before ('#!docs').
+        // Passed a category string — from hoverProvider.js's "Open
+        // documentation" command link on a node hover, e.g.
+        // command:materialxPlayground.openDocs?["standard_surface"] — it
+        // instead deep-links straight to that node, using the SAME
+        // name-only permalink hash format the website's own hashToSel
+        // (js/docs/doc-links.jsx) resolves by search (exact match, then
+        // squashed-lowercase fallback), so an arbitrary category string
+        // always lands somewhere sensible even without knowing its
+        // lib/group.
+        vscode.commands.registerCommand('materialxPlayground.openDocs', async (category) => {
             try {
                 // Shares the docs-panel singleton with the graph editor's
                 // "?" button (editorProvider.js's openDocsPanel, which the
@@ -73,11 +172,44 @@ function activate(context) {
                 // index.html#!docs directly in a browser), and
                 // reveals/re-navigates the existing panel instead of
                 // spawning a new one if it's already open.
-                await openDocsPanel(context, '#!docs', vscode.ViewColumn.Active);
+                const hash = category ? '#/' + encodeURIComponent(String(category)) : '#!docs';
+                await openDocsPanel(context, hash, vscode.ViewColumn.Active);
             } catch (err) {
                 vscode.window.showErrorMessage('MaterialX Playground: failed to open node documentation — ' + (err && err.message ? err.message : String(err)));
             }
         })
+    );
+
+    // Live .mtlx diagnostics: validate anything already open, then keep
+    // validating on open/edit/close, and keep the status bar in sync
+    // with whichever editor is active.
+    for (const doc of vscode.workspace.textDocuments) {
+        if (doc.languageId === 'mtlx') runValidation(doc);
+    }
+    updateStatusBar();
+
+    context.subscriptions.push(
+        vscode.workspace.onDidOpenTextDocument((doc) => {
+            if (doc.languageId === 'mtlx') runValidation(doc);
+        }),
+        vscode.workspace.onDidChangeTextDocument((e) => {
+            if (e.document.languageId !== 'mtlx') return;
+            const key = e.document.uri.toString();
+            const existing = debounceTimers.get(key);
+            if (existing) clearTimeout(existing);
+            debounceTimers.set(key, setTimeout(() => {
+                debounceTimers.delete(key);
+                runValidation(e.document);
+            }, VALIDATE_DEBOUNCE_MS));
+        }),
+        vscode.workspace.onDidCloseTextDocument((doc) => {
+            const key = doc.uri.toString();
+            const existing = debounceTimers.get(key);
+            if (existing) { clearTimeout(existing); debounceTimers.delete(key); }
+            diagnosticCollection.delete(doc.uri);
+            updateStatusBar();
+        }),
+        vscode.window.onDidChangeActiveTextEditor(() => updateStatusBar())
     );
 }
 

--- a/vscode_extension/src/extension.js
+++ b/vscode_extension/src/extension.js
@@ -81,6 +81,18 @@ async function runValidation(document) {
 const VALIDATE_DEBOUNCE_MS = 400;
 const debounceTimers = new Map(); // uri.toString() -> NodeJS.Timeout
 
+// Shape-validated signature token for the materialxPlayground.openDocs
+// command's optional second argument: `<outType>` optionally followed by
+// `(<name>:<type>,...)` — exactly the grammar vscode_extension/src/
+// nodeSignature.js's buildSigToken emits (see that file's own comment on
+// why every token it can produce is guaranteed to match this), and the
+// same grammar js/docs/doc-links.jsx's parseSigHint expects on the other
+// end. Validated here (plus a length cap) before ever being spliced into
+// a URI — a command: link's JSON-encoded args are effectively untrusted
+// input by the time they reach a command handler (built from hover
+// markdown over a possibly hand-edited/untrusted .mtlx document).
+const SIG_TOKEN_RE = /^[\w.\-:]+(\([\w.\-:]+:[\w.\-:]+(,[\w.\-:]+:[\w.\-:]+)*\))?$/;
+
 function activate(context) {
     // Before anything else, so semantic (tier 2) validation is ready as
     // soon as the first .mtlx document is opened.
@@ -154,15 +166,22 @@ function activate(context) {
         // `category` is optional: no-arg (Command Palette / explorer menu)
         // opens the docs library browser exactly as before ('#!docs').
         // Passed a category string — from hoverProvider.js's "Open
-        // documentation" command link on a node hover, e.g.
+        // Interactive Documentation" command link on a node hover, e.g.
         // command:materialxPlayground.openDocs?["standard_surface"] — it
         // instead deep-links straight to that node, using the SAME
         // name-only permalink hash format the website's own hashToSel
         // (js/docs/doc-links.jsx) resolves by search (exact match, then
         // squashed-lowercase fallback), so an arbitrary category string
         // always lands somewhere sensible even without knowing its
-        // lib/group.
-        vscode.commands.registerCommand('materialxPlayground.openDocs', async (category) => {
+        // lib/group. `sig` is a further-optional signature-token second
+        // argument (also from hoverProvider.js, when the hovered
+        // element's own signature was derivable) that additionally
+        // pre-selects the matching signature/version once the node
+        // resolves — see js/docs/doc-links.jsx's parseSigHint and
+        // js/docs-app.jsx's matchSigHintToGroups. Both args are
+        // backward compatible: no-arg and category-only calls (existing
+        // callers, older cached command URIs) behave exactly as before.
+        vscode.commands.registerCommand('materialxPlayground.openDocs', async (category, sig) => {
             try {
                 // Shares the docs-panel singleton with the graph editor's
                 // "?" button (editorProvider.js's openDocsPanel, which the
@@ -172,7 +191,10 @@ function activate(context) {
                 // index.html#!docs directly in a browser), and
                 // reveals/re-navigates the existing panel instead of
                 // spawning a new one if it's already open.
-                const hash = category ? '#/' + encodeURIComponent(String(category)) : '#!docs';
+                const sigOk = typeof sig === 'string' && sig.length <= 512 && SIG_TOKEN_RE.test(sig);
+                const hash = category
+                    ? '#/' + encodeURIComponent(String(category)) + (sigOk ? '?sig=' + encodeURIComponent(sig) : '')
+                    : '#!docs';
                 await openDocsPanel(context, hash, vscode.ViewColumn.Active);
             } catch (err) {
                 vscode.window.showErrorMessage('MaterialX Playground: failed to open node documentation — ' + (err && err.message ? err.message : String(err)));

--- a/vscode_extension/src/hoverProvider.js
+++ b/vscode_extension/src/hoverProvider.js
@@ -1,0 +1,170 @@
+// hoverProvider.js — registers a vscode.languages.HoverProvider for the
+// 'mtlx' language: hovering a node CATEGORY (an element tag name that
+// isn't one of MaterialX's structural/document elements, or the value of
+// a node="X" attribute) shows its spec description (via specDocs.js) plus
+// a command link that opens/reuses the docs panel at that node
+// (materialxPlayground.openDocs, extended in extension.js to accept a
+// category argument). Structural elements and anything else that isn't a
+// recognizable category hover to nothing — never noisy.
+//
+// This file DOES require('vscode') (unlike specDocs.js/validator.js/
+// mtlxNode.js/docScanner.js) — it's UI-only glue, not part of the
+// pure-Node validation/doc-extraction core those files intentionally stay
+// independent of.
+'use strict';
+
+const vscode = require('vscode');
+const specDocs = require('./specDocs');
+
+// Structural/document elements — i.e. every non-node MaterialX element
+// that can appear as a tag name in a .mtlx file. Nodes are just elements
+// named by category (<standard_surface>, <mix>, <image>, ...), so
+// anything NOT in this set that looks like an element name is treated as
+// a node category. Built from the plan's explicit minimum list, cross-
+// checked against the MaterialX.*.md spec files committed at the repo
+// root (none of these names appear as a `### \`name\`` node heading in
+// any of the three) and against docScanner.js (which already treats
+// <nodegraph>/<input>/<xi:include> as structural for its own include/
+// texture-ref walk). 'comment' is MaterialX's XML <comment> element (an
+// explicit doc/comment node in the schema, distinct from `<!-- -->`).
+const STRUCTURAL_ELEMENTS = new Set([
+    'materialx', 'nodegraph', 'input', 'output', 'token', 'nodedef',
+    'implementation', 'typedef', 'member', 'unit', 'unittype', 'look',
+    'lookgroup', 'materialassign', 'visibility', 'collection', 'geominfo',
+    'geomprop', 'geompropdef', 'property', 'propertyset', 'propertyassign',
+    'variant', 'variantset', 'variantassign', 'backdrop', 'comment',
+    'xi:include',
+]);
+
+// Attribute-value detection: `node="X"` / `node='X'` (nodedef refs,
+// materialassign refs) — group 1 captures the WHOLE quoted token
+// (quotes included) so its position within the match can be located
+// unambiguously regardless of which quote character was used.
+const ATTR_NODE_RE = /\bnode\s*=\s*("[^"]*"|'[^']*')/g;
+
+// Word characters for a tag-name/attribute-value token: matches the
+// `\w[\w:.-]*` shape used throughout the MaterialX schema (namespaced
+// names like xi:include, dotted/hyphenated categories). Also used
+// (fully anchored, see CATEGORY_SHAPE_RE below) to validate a node="..."
+// attribute's raw value before ever treating it as a category — unlike a
+// tag name (already constrained to this shape by getWordRangeAtPosition
+// itself), an attribute value is arbitrary quoted text straight out of
+// the open document, which may be an untrusted/hand-crafted .mtlx file.
+const TOKEN_RE = /[\w:.\-]+/;
+const CATEGORY_SHAPE_RE = /^[\w:.\-]+$/;
+
+function buildHoverMarkdown(category, repoRootFsPath) {
+    const doc = specDocs.getNodeDoc(repoRootFsPath, category);
+
+    const md = new vscode.MarkdownString();
+    // Scoped trust, not `isTrusted = true`: a plain boolean would let ANY
+    // command: link execute, including one smuggled in through
+    // `doc.description` or (before the CATEGORY_SHAPE_RE guard below) a
+    // crafted node="..." attribute value — this hover only ever needs
+    // ONE command clickable, so only that one is enabled. `category`
+    // itself is validated by the caller to match CATEGORY_SHAPE_RE before
+    // this function is ever reached, so it's already injection-safe for
+    // the plain string concatenation below, but the restricted trust is
+    // kept anyway as defense in depth against anything the assumption
+    // above misses (e.g. a future caller).
+    md.isTrusted = { enabledCommands: ['materialxPlayground.openDocs'] };
+    md.appendMarkdown('**`<' + category + '>`** — MaterialX node\n\n');
+
+    if (doc && doc.description) {
+        md.appendMarkdown(doc.description + '\n\n');
+    }
+
+    // Command link args must be a JSON array (executeCommand-style),
+    // URI-encoded into the command: URI per VS Code's command-link
+    // convention (see e.g. workbench.action.openWalkthrough docs for the
+    // same encoding).
+    const commandArgs = encodeURIComponent(JSON.stringify([category]));
+    md.appendMarkdown('[Open documentation](command:materialxPlayground.openDocs?' + commandArgs + ')');
+
+    if (doc && doc.specUrl) {
+        md.appendMarkdown(' &nbsp;|&nbsp; [Spec](' + doc.specUrl + ')');
+    }
+
+    return md;
+}
+
+// Returns the word range at `position` ONLY if it's a tag-name token
+// directly preceded by '<' (mirrors `<(\w[\w:.-]*)` — the '<' is checked
+// as the literal character immediately before the matched token rather
+// than folded into the word-range regex, since '<' isn't itself a token
+// character and getWordRangeAtPosition needs a single contiguous
+// character class).
+function tagNameRangeAt(document, position) {
+    const range = document.getWordRangeAtPosition(position, TOKEN_RE);
+    if (!range || range.start.character === 0) return null;
+    const before = new vscode.Range(range.start.translate(0, -1), range.start);
+    if (document.getText(before) !== '<') return null;
+    return range;
+}
+
+// Returns the category string when `position` is inside the quoted value
+// of a node="..." attribute on the same line AND that value looks like a
+// plausible category identifier, else null.
+function nodeAttrValueAt(document, position) {
+    const line = document.lineAt(position.line).text;
+    const char = position.character;
+    ATTR_NODE_RE.lastIndex = 0;
+    let m;
+    while ((m = ATTR_NODE_RE.exec(line)) !== null) {
+        const quoted = m[1]; // e.g. '"standard_surface"', quotes included
+        const value = quoted.slice(1, -1);
+        // `quoted` is the trailing part of m[0] (the whole `node = "..."`
+        // match), so locating it within m[0] gives the quote's own
+        // position without assuming a fixed amount of whitespace around
+        // '='.
+        const quotedStart = m.index + m[0].lastIndexOf(quoted);
+        const valueStart = quotedStart + 1;
+        const valueEnd = valueStart + value.length;
+        if (char >= valueStart && char <= valueEnd) {
+            // The cursor is inside THIS attribute's value — whether or
+            // not it validates, no other match on the line could also
+            // contain this same position, so resolve (or reject) right
+            // here rather than continuing the loop. A value that doesn't
+            // look like a bare identifier (spaces, markup, quotes, ...)
+            // is both not a real MaterialX category AND not safe to
+            // splice into the trusted hover markdown built downstream —
+            // reject it rather than passing it through.
+            return CATEGORY_SHAPE_RE.test(value) ? value : null;
+        }
+    }
+    return null;
+}
+
+function provideHover(document, position, repoRootFsPath) {
+    const tagRange = tagNameRangeAt(document, position);
+    if (tagRange) {
+        const name = document.getText(tagRange);
+        if (STRUCTURAL_ELEMENTS.has(name.toLowerCase())) return null;
+        return new vscode.Hover(buildHoverMarkdown(name, repoRootFsPath), tagRange);
+    }
+
+    const attrValue = nodeAttrValueAt(document, position);
+    if (attrValue) {
+        return new vscode.Hover(buildHoverMarkdown(attrValue, repoRootFsPath));
+    }
+
+    return null;
+}
+
+// Registers the hover provider for 'mtlx' documents and pushes its
+// disposable onto context.subscriptions. repoRootFsPath (context.
+// extensionUri.fsPath) is captured once here and threaded through to
+// specDocs.getNodeDoc on every hover — specDocs.js caches its own parse
+// after the first call, so this is cheap.
+function register(context) {
+    const repoRootFsPath = context.extensionUri.fsPath;
+    context.subscriptions.push(
+        vscode.languages.registerHoverProvider('mtlx', {
+            provideHover(document, position) {
+                return provideHover(document, position, repoRootFsPath);
+            },
+        })
+    );
+}
+
+module.exports = { register };

--- a/vscode_extension/src/hoverProvider.js
+++ b/vscode_extension/src/hoverProvider.js
@@ -1,20 +1,24 @@
 // hoverProvider.js — registers a vscode.languages.HoverProvider for the
 // 'mtlx' language: hovering a node CATEGORY (an element tag name that
 // isn't one of MaterialX's structural/document elements, or the value of
-// a node="X" attribute) shows its spec description (via specDocs.js) plus
-// a command link that opens/reuses the docs panel at that node
-// (materialxPlayground.openDocs, extended in extension.js to accept a
-// category argument). Structural elements and anything else that isn't a
-// recognizable category hover to nothing — never noisy.
+// a node="X" attribute) shows its spec description (via specDocs.js), a
+// port table matching the hovered element's own signature when one can
+// be derived (via nodeSignature.js), and a command link that opens/
+// reuses the docs panel at that node — with the matching signature
+// deep-linked when derivable (materialxPlayground.openDocs, extended in
+// extension.js to accept an optional signature-token second argument).
+// Structural elements and anything else that isn't a recognizable
+// category hover to nothing — never noisy.
 //
-// This file DOES require('vscode') (unlike specDocs.js/validator.js/
-// mtlxNode.js/docScanner.js) — it's UI-only glue, not part of the
-// pure-Node validation/doc-extraction core those files intentionally stay
-// independent of.
+// This file DOES require('vscode') (unlike specDocs.js/nodeSignature.js/
+// validator.js/mtlxNode.js/docScanner.js) — it's UI-only glue, not part
+// of the pure-Node validation/doc-extraction core those files
+// intentionally stay independent of.
 'use strict';
 
 const vscode = require('vscode');
 const specDocs = require('./specDocs');
+const nodeSignature = require('./nodeSignature');
 
 // Structural/document elements — i.e. every non-node MaterialX element
 // that can appear as a tag name in a .mtlx file. Nodes are just elements
@@ -53,7 +57,14 @@ const ATTR_NODE_RE = /\bnode\s*=\s*("[^"]*"|'[^']*')/g;
 const TOKEN_RE = /[\w:.\-]+/;
 const CATEGORY_SHAPE_RE = /^[\w:.\-]+$/;
 
-function buildHoverMarkdown(category, repoRootFsPath) {
+// `ctx`: the hovered element's { type, inputs } (nodeSignature.js's
+// extractElementContext), or null when there is none — either the hover
+// was on a node="X" attribute value (no element to scan: the attribute's
+// OWNING element is a different tag entirely, e.g. <materialassign
+// node="...">) rather than the node's own opening tag, or extraction
+// failed/degraded. A null ctx just means "no signature info": the
+// description and a fallback table still render.
+function buildHoverMarkdown(category, repoRootFsPath, ctx) {
     const doc = specDocs.getNodeDoc(repoRootFsPath, category);
 
     const md = new vscode.MarkdownString();
@@ -74,12 +85,31 @@ function buildHoverMarkdown(category, repoRootFsPath) {
         md.appendMarkdown(doc.description + '\n\n');
     }
 
+    // Port table: prefer the table matching the hovered element's ACTUAL
+    // signature (ctx.type, resolved via pickTableForType against every
+    // table's output-port types) when derivable; otherwise fall back to
+    // the FIRST table — the same "no confident signature: show
+    // something rather than nothing" rule the docs site itself applies
+    // (js/docs-app.jsx ~:528's `pickTableForType(...) || portTables[0]`),
+    // so a hover on an element with no readable type (or no <input>
+    // children to key off of) still surfaces useful port data.
+    const tables = (doc && doc.port_tables) || [];
+    const table = nodeSignature.pickTableForType(tables, ctx && ctx.type) || tables[0] || null;
+    if (table) {
+        const rendered = nodeSignature.renderPortsMarkdown(table);
+        if (rendered) md.appendMarkdown(rendered + '\n\n');
+    }
+
     // Command link args must be a JSON array (executeCommand-style),
     // URI-encoded into the command: URI per VS Code's command-link
     // convention (see e.g. workbench.action.openWalkthrough docs for the
-    // same encoding).
-    const commandArgs = encodeURIComponent(JSON.stringify([category]));
-    md.appendMarkdown('[Open documentation](command:materialxPlayground.openDocs?' + commandArgs + ')');
+    // same encoding). A signature token — built from ctx, so only ever
+    // present on the tag-name hover path — is appended as a second arg
+    // when derivable, so the docs panel lands on (and pre-selects) the
+    // matching signature/version instead of the node's first.
+    const sigToken = nodeSignature.buildSigToken(ctx);
+    const commandArgs = encodeURIComponent(JSON.stringify(sigToken ? [category, sigToken] : [category]));
+    md.appendMarkdown('[Open Interactive Documentation](command:materialxPlayground.openDocs?' + commandArgs + ')');
 
     if (doc && doc.specUrl) {
         md.appendMarkdown(' &nbsp;|&nbsp; [Spec](' + doc.specUrl + ')');
@@ -140,12 +170,21 @@ function provideHover(document, position, repoRootFsPath) {
     if (tagRange) {
         const name = document.getText(tagRange);
         if (STRUCTURAL_ELEMENTS.has(name.toLowerCase())) return null;
-        return new vscode.Hover(buildHoverMarkdown(name, repoRootFsPath), tagRange);
+        // Hovering the element's OWN opening tag: extract its signature
+        // context (own type= + typed <input> children) from the full
+        // document text, offset at the tag name's own start.
+        const ctx = nodeSignature.extractElementContext(document.getText(), document.offsetAt(tagRange.start), name);
+        return new vscode.Hover(buildHoverMarkdown(name, repoRootFsPath, ctx), tagRange);
     }
 
     const attrValue = nodeAttrValueAt(document, position);
     if (attrValue) {
-        return new vscode.Hover(buildHoverMarkdown(attrValue, repoRootFsPath));
+        // A node="X" attribute value names a DIFFERENT element's
+        // nodedef/category (e.g. <materialassign node="...">) — there's
+        // no element here whose own signature to extract, so ctx is
+        // null (buildHoverMarkdown degrades to the first table, no
+        // signature-deep-linked command arg).
+        return new vscode.Hover(buildHoverMarkdown(attrValue, repoRootFsPath, null));
     }
 
     return null;

--- a/vscode_extension/src/mtlxNode.js
+++ b/vscode_extension/src/mtlxNode.js
@@ -1,0 +1,303 @@
+// mtlxNode.js — headless (extension-host) loader for the bundled
+// MaterialX WASM build (js/JsMaterialXGenShader.js), plus a semantic
+// (parse + validate) check for .mtlx documents. Pure Node: this module
+// must NOT require('vscode') anywhere, so it stays independently
+// loadable/testable with plain `node` — validator.js (the only caller)
+// enforces the same rule for the same reason.
+//
+// Mirrors (but does not import — js/mtlx-engine.js is a browser
+// global-scope script that references `window` and has no
+// module.exports) js/mtlx-engine.js's getMxEnv()/mxErr()/vecToArray()/
+// mxSafe() helpers, and js/viewer-app.jsx's loadMtlxDocument() parse
+// sequence, and js/graph-app.jsx's "Validate" dialog fallback scan.
+// docScanner.js's own header comment sets the precedent for "mirrors but
+// does not import" for exactly this reason (the site's code has no Node
+// entry point) — same situation here.
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { pathToFileURL } = require('url');
+
+// Expected byte size of js/JsMaterialXGenShader.data, the packed
+// emscripten virtual-FS archive carrying the MaterialX standard
+// library. See the KNOWN HAZARD comment in attemptLoad() below.
+const EXPECTED_DATA_SIZE = 1481718;
+
+// ---------------------------------------------------------------------
+// Local mirrors of js/mtlx-engine.js helpers (lines ~299-351 there).
+// Duplicated verbatim rather than required — see the file banner above.
+
+// Emscripten throws C++ exceptions as NUMBERS (raw exception pointers),
+// not Error objects — a bare catch that stringifies one shows a raw
+// pointer value instead of the real MaterialX message. Decode via
+// mx.getExceptionMessage when available; otherwise fall back to normal
+// Error/String handling. ALWAYS route caught MaterialX errors through
+// this.
+function mxErr(mx, e) {
+    try {
+        if (typeof e === 'number' && mx && typeof mx.getExceptionMessage === 'function') {
+            const msg = mx.getExceptionMessage(e);
+            // getExceptionMessage may return a string or [type, message]
+            if (Array.isArray(msg)) return msg.filter(Boolean).join(': ');
+            if (msg) return String(msg);
+        }
+    } catch (_) { /* fall through to generic handling */ }
+    if (e && e.message) return e.message;
+    return String(e);
+}
+
+// MaterialX JS marshals std::vector either as a real JS array or as a
+// {size(), get(i)} object depending on the binding; normalize to array.
+function vecToArray(v) {
+    if (!v) return [];
+    if (Array.isArray(v)) return v;
+    if (typeof v.size === 'function') {
+        const out = [];
+        for (let i = 0; i < v.size(); i++) out.push(v.get(i));
+        return out;
+    }
+    return [];
+}
+
+function mxSafe(fn, fb) {
+    try {
+        const v = fn();
+        return v == null ? fb : v;
+    } catch (e) {
+        return fb;
+    }
+}
+
+function mxElName(el) { return mxSafe(() => el.getName(), ''); }
+function mxElAttr(el, name) { return mxSafe(() => el.getAttribute(name), ''); }
+
+// ---------------------------------------------------------------------
+// Singleton wasm loader / permanent-degrade state machine.
+//
+// - loadPromise: the shared in-flight/resolved promise, so concurrent
+//   callers never trigger a second wasm load.
+// - failed: once true, EVERY subsequent call short-circuits to
+//   Promise.resolve(null) without re-attempting anything — a wasm init
+//   failure is treated as permanent for the life of the extension host
+//   process (retrying on every keystroke's validation pass would be
+//   both slow and pointless if the build is genuinely broken/missing).
+// - pendingError: the one-shot init-failure string for consumeInitError()
+//   below.
+//
+// On success, the FIRST caller's repoRoot wins forever — later calls
+// (even with a different repoRoot) get back the already-resolved env.
+// In practice there is exactly one extension host process and exactly
+// one repo root, so this is a non-issue, but it's worth documenting
+// since silently ignoring a second repoRoot argument could otherwise
+// look like a bug.
+let loadPromise = null;
+let failed = false;
+let pendingError = null;
+
+// Loads the bundled MaterialX wasm build the same way js/mtlx-engine.js's
+// getMxEnv() does in the browser: EsslShaderGenerator -> GenContext ->
+// loadStandardLibraries. This is safe to do headless (no rendering, no
+// WebGL/DOM touched) purely to obtain `stdlib` for
+// setDataLibrary/importLibrary — constructing a shader-generator object
+// does not require a graphics context.
+async function attemptLoad(repoRoot) {
+    const dataPath = path.join(repoRoot, 'js', 'JsMaterialXGenShader.data');
+
+    // KNOWN HAZARD: js/JsMaterialXGenShader.data is a packed emscripten
+    // virtual-FS archive — a BINARY file. A CRLF-smudged checkout (git
+    // autocrlf mangling a binary that should have been left alone)
+    // silently corrupts it, and wasm init then fails with a cryptic,
+    // unhelpful error far downstream (inside stdlib XML parsing, nowhere
+    // near this file). Catch it early with an actionable message instead.
+    // If the file is missing entirely, don't over-engineer this check —
+    // let the natural ENOENT surface later (from the dynamic import /
+    // emscripten's own file read), that error is already clear on its
+    // own.
+    try {
+        const stat = fs.statSync(dataPath);
+        if (stat.size !== EXPECTED_DATA_SIZE) {
+            throw new Error(
+                'MaterialX .data archive is ' + stat.size + ' bytes, expected ' + EXPECTED_DATA_SIZE
+                + ' — likely CRLF-corrupted by a Windows checkout (this is a binary file; see .gitattributes).'
+            );
+        }
+    } catch (e) {
+        if (e && e.code === 'ENOENT') {
+            // Missing entirely — fall through, let the natural failure
+            // below explain itself.
+        } else {
+            throw e;
+        }
+    }
+
+    const jsPath = path.join(repoRoot, 'js', 'JsMaterialXGenShader.js');
+    let mx = null;
+    try {
+        const mod = await import(pathToFileURL(jsPath).href);
+        mx = await mod.default({
+            // MUST return a plain filesystem path string, NOT a file://
+            // URL. Verified via grep of the minified glue
+            // (js/JsMaterialXGenShader.js): in the Node (`isNode`)
+            // branch, the .data package fetch does
+            // `require("fs").readFile(packageName, cb)` with NO file://
+            // handling at all — packageName comes straight from
+            // Module["locateFile"](REMOTE_PACKAGE_BASE, ""), so a
+            // file:// string here would make that readFile call ENOENT.
+            // The .wasm path goes through readAsync(filename), which
+            // DOES special-case file:// strings (`filename =
+            // isFileURI(filename) ? new URL(filename) : filename` before
+            // fs.readFileSync), so a bare path works there too. A single
+            // plain-path-returning locateFile satisfies both — do NOT
+            // "fix" this into a file:// URL later, it will break the
+            // .data fetch specifically.
+            locateFile: (fileName) => path.join(repoRoot, 'js', fileName),
+        });
+
+        if (!mx.EsslShaderGenerator || typeof mx.EsslShaderGenerator.create !== 'function') {
+            throw new Error('EsslShaderGenerator.create is not bound in this MaterialX build.');
+        }
+        if (typeof mx.GenContext !== 'function') {
+            throw new Error('GenContext is not bound in this MaterialX build.');
+        }
+        if (typeof mx.loadStandardLibraries !== 'function') {
+            throw new Error('loadStandardLibraries is not bound in this MaterialX build.');
+        }
+
+        const gen = mx.EsslShaderGenerator.create();
+        const genContext = new mx.GenContext(gen);
+        const stdlib = mx.loadStandardLibraries(genContext);
+
+        return { mx, stdlib };
+    } catch (e) {
+        // mx may or may not be set depending on where the failure
+        // happened (module resolved but loadStandardLibraries threw, vs.
+        // the dynamic import itself failing) — mxErr handles a null mx
+        // gracefully (falls through to generic Error/String handling).
+        throw new Error(mxErr(mx, e));
+    }
+}
+
+// Returns a Promise that resolves to { mx, stdlib } on success, or to
+// null if the loader is permanently degraded (including: it just failed
+// on THIS call). Never rejects.
+function getMxEnv(repoRoot) {
+    if (failed) return Promise.resolve(null);
+    if (loadPromise) return loadPromise;
+    loadPromise = attemptLoad(repoRoot).then(
+        (env) => env,
+        (e) => {
+            failed = true;
+            pendingError = e && e.message ? e.message : String(e);
+            return null;
+        }
+    );
+    return loadPromise;
+}
+
+// ---------------------------------------------------------------------
+// Semantic validation — mirrors js/viewer-app.jsx's loadMtlxDocument
+// (~lines 31-50) for the parse step, and js/graph-app.jsx's "Validate"
+// dialog (~lines 2062-2101) for the validate step + dangling-reference
+// fallback scan.
+
+// repoRoot: absolute fs path to the repo root (context.extensionUri.fsPath).
+// xmlText: the full document text.
+// Resolves (never rejects) to one of:
+//   { available: false }                                  — wasm unavailable
+//   { available: true, messages: [] }                      — parsed + validated clean
+//   { available: true, messages: [{ text, elementName }] } — parse error OR validate() issues
+async function validateSemantic(repoRoot, xmlText) {
+    try {
+        const env = await getMxEnv(repoRoot);
+        if (!env) return { available: false };
+        const { mx, stdlib } = env;
+
+        if (typeof mx.createDocument !== 'function') return { available: false };
+        const doc = mx.createDocument();
+
+        if (typeof mx.readFromXmlString !== 'function') {
+            // Mirrors js/viewer-app.jsx's defensive check (~line 36) —
+            // a missing binding is tier-2 unavailability, not a thrown
+            // error out of this function.
+            return { available: false };
+        }
+        try {
+            // ASYNC — mirrors js/viewer-app.jsx loadMtlxDocument
+            // (~line 45): without the await, everything downstream runs
+            // against a still-empty document.
+            await mx.readFromXmlString(doc, xmlText);
+        } catch (e) {
+            return {
+                available: true,
+                messages: [{ text: 'MaterialX could not parse the document: ' + mxErr(mx, e), elementName: null }],
+            };
+        }
+        if (typeof doc.setDataLibrary === 'function') doc.setDataLibrary(stdlib);
+        else doc.importLibrary(stdlib);
+
+        // The WASM binding's validate() is boolean-only in this build —
+        // it does NOT return message strings (js/graph-app.jsx's own
+        // "Validate" dialog comment, ~line 2063-2065, verified by
+        // reading the code). Mirror that dialog's degrade path exactly:
+        // no validate() binding at all -> unavailable, same as its
+        // `typeof parsed.doc.validate !== 'function'` check.
+        if (typeof doc.validate !== 'function') return { available: false };
+        let ok;
+        try {
+            ok = doc.validate();
+        } catch (e) {
+            return {
+                available: true,
+                messages: [{ text: 'MaterialX document failed validation: ' + mxErr(mx, e), elementName: null }],
+            };
+        }
+        if (ok) return { available: true, messages: [] };
+
+        // false result -> cheap best-effort scan for dangling
+        // nodename/nodegraph references on top-level nodes, exactly
+        // like the graph editor's own fallback (rather than a real
+        // diagnostic list, which this build's validate() doesn't give
+        // us).
+        const issues = [];
+        const nodes = vecToArray(mxSafe(() => doc.getNodes(), []));
+        for (const n of nodes) {
+            const nm = mxElName(n);
+            for (const inp of vecToArray(mxSafe(() => n.getInputs(), []))) {
+                const nn = mxElAttr(inp, 'nodename');
+                if (nn && !mxSafe(() => doc.getNode(nn), null)) {
+                    issues.push({ text: nm + '.' + mxElName(inp) + ' references missing node "' + nn + '"', elementName: nm });
+                }
+                const ng = mxElAttr(inp, 'nodegraph');
+                if (ng && !mxSafe(() => doc.getNodeGraph(ng), null)) {
+                    issues.push({ text: nm + '.' + mxElName(inp) + ' references missing nodegraph "' + ng + '"', elementName: nm });
+                }
+            }
+        }
+        if (!issues.length) {
+            issues.push({ text: 'MaterialX document failed validation (this build does not expose more specific diagnostic detail).', elementName: null });
+        }
+        return { available: true, messages: issues };
+    } catch (e) {
+        // Tier-2 unavailability must be silent to callers — any
+        // unexpected exception anywhere above becomes { available:
+        // false }, never a thrown error out of this function.
+        return { available: false };
+    }
+}
+
+// One-shot: returns the pending init-failure string and clears it, or
+// null if there's nothing new to report (never failed yet, or already
+// consumed by an earlier call). The loader stays permanently degraded
+// either way — this only controls whether the caller has already logged
+// it once.
+function consumeInitError() {
+    const err = pendingError;
+    pendingError = null;
+    return err;
+}
+
+module.exports = {
+    validateSemantic,
+    consumeInitError,
+};

--- a/vscode_extension/src/mtlxNode.js
+++ b/vscode_extension/src/mtlxNode.js
@@ -7,9 +7,11 @@
 //
 // Mirrors (but does not import — js/mtlx-engine.js is a browser
 // global-scope script that references `window` and has no
-// module.exports) js/mtlx-engine.js's getMxEnv()/mxErr()/vecToArray()/
-// mxSafe() helpers, and js/viewer-app.jsx's loadMtlxDocument() parse
-// sequence, and js/graph-app.jsx's "Validate" dialog fallback scan.
+// module.exports) js/mtlx-engine.js's getMxEnv()/mxErr() helpers, and
+// js/viewer-app.jsx's loadMtlxDocument() parse sequence, and
+// js/graph-app.jsx's "Validate" dialog — including its use of the
+// message-holder overload of validate() to recover real diagnostic text
+// (see the comment above the validate() call below).
 // docScanner.js's own header comment sets the precedent for "mirrors but
 // does not import" for exactly this reason (the site's code has no Node
 // entry point) — same situation here.
@@ -46,31 +48,6 @@ function mxErr(mx, e) {
     if (e && e.message) return e.message;
     return String(e);
 }
-
-// MaterialX JS marshals std::vector either as a real JS array or as a
-// {size(), get(i)} object depending on the binding; normalize to array.
-function vecToArray(v) {
-    if (!v) return [];
-    if (Array.isArray(v)) return v;
-    if (typeof v.size === 'function') {
-        const out = [];
-        for (let i = 0; i < v.size(); i++) out.push(v.get(i));
-        return out;
-    }
-    return [];
-}
-
-function mxSafe(fn, fb) {
-    try {
-        const v = fn();
-        return v == null ? fb : v;
-    } catch (e) {
-        return fb;
-    }
-}
-
-function mxElName(el) { return mxSafe(() => el.getName(), ''); }
-function mxElAttr(el, name) { return mxSafe(() => el.getAttribute(name), ''); }
 
 // ---------------------------------------------------------------------
 // Singleton wasm loader / permanent-degrade state machine.
@@ -198,15 +175,27 @@ function getMxEnv(repoRoot) {
 // ---------------------------------------------------------------------
 // Semantic validation — mirrors js/viewer-app.jsx's loadMtlxDocument
 // (~lines 31-50) for the parse step, and js/graph-app.jsx's "Validate"
-// dialog (~lines 2062-2101) for the validate step + dangling-reference
-// fallback scan.
+// dialog (~lines 2062-2101) for the validate step, including its use of
+// the message-holder overload of validate() (see below) to recover the
+// real diagnostic text instead of a bare boolean.
+
+// Parses a holder.message LINE's embedded serialized element (when
+// present), e.g. `<input name="surfaceshader" type="surfaceshader"
+// value="" nodename="preview_surface" />` -> tag "input" + attrs
+// {name, type, value, nodename}. This carries every attribute the
+// element has on ITSELF, but never a parent path — validator.js's
+// mapSemanticMessageToRange uses `tag` + `attrs` (not just the bare
+// `name="..."` value) to disambiguate same-named elements living under
+// different parents, by scoring how many OTHER attributes match.
+const ELEMENT_TAG_RE = /<([\w:.\-]+)((?:\s+[\w:.\-]+\s*=\s*"[^"]*")*)\s*\/?>/;
+const ELEMENT_ATTR_RE = /([\w:.\-]+)\s*=\s*"([^"]*)"/g;
 
 // repoRoot: absolute fs path to the repo root (context.extensionUri.fsPath).
 // xmlText: the full document text.
 // Resolves (never rejects) to one of:
 //   { available: false }                                  — wasm unavailable
 //   { available: true, messages: [] }                      — parsed + validated clean
-//   { available: true, messages: [{ text, elementName }] } — parse error OR validate() issues
+//   { available: true, messages: [{ text, tag, attrs, elementName }] } — parse error OR validate() issues
 async function validateSemantic(repoRoot, xmlText) {
     try {
         const env = await getMxEnv(repoRoot);
@@ -230,52 +219,76 @@ async function validateSemantic(repoRoot, xmlText) {
         } catch (e) {
             return {
                 available: true,
-                messages: [{ text: 'MaterialX could not parse the document: ' + mxErr(mx, e), elementName: null }],
+                messages: [{ text: 'MaterialX could not parse the document: ' + mxErr(mx, e), tag: null, attrs: null, elementName: null }],
             };
         }
         if (typeof doc.setDataLibrary === 'function') doc.setDataLibrary(stdlib);
         else doc.importLibrary(stdlib);
 
-        // The WASM binding's validate() is boolean-only in this build —
-        // it does NOT return message strings (js/graph-app.jsx's own
-        // "Validate" dialog comment, ~line 2063-2065, verified by
-        // reading the code). Mirror that dialog's degrade path exactly:
-        // no validate() binding at all -> unavailable, same as its
-        // `typeof parsed.doc.validate !== 'function'` check.
+        // The WASM binding's validate() has an overloadTable {'0','1'} —
+        // the PREVIOUS "boolean-only" comment here was WRONG (verified
+        // headless, and js/graph-app.jsx's matching old comment was
+        // wrong for the same reason — see that file's own fix). The
+        // 1-arg overload accepts a plain object "holder" and fills
+        // holder.message with the full newline-separated MaterialX
+        // diagnostic list on failure (each line typically embeds the
+        // offending element's serialized XML, including name="..."). No
+        // validate() binding at all -> unavailable, same as before.
         if (typeof doc.validate !== 'function') return { available: false };
+        const holder = {};
         let ok;
         try {
-            ok = doc.validate();
+            ok = doc.validate(holder);
         } catch (e) {
             return {
                 available: true,
-                messages: [{ text: 'MaterialX document failed validation: ' + mxErr(mx, e), elementName: null }],
+                messages: [{ text: 'MaterialX document failed validation: ' + mxErr(mx, e), tag: null, attrs: null, elementName: null }],
             };
         }
         if (ok) return { available: true, messages: [] };
 
-        // false result -> cheap best-effort scan for dangling
-        // nodename/nodegraph references on top-level nodes, exactly
-        // like the graph editor's own fallback (rather than a real
-        // diagnostic list, which this build's validate() doesn't give
-        // us).
+        // false result -> one issue per non-empty line of holder.message.
+        // Each line typically embeds the offending element's OWN
+        // serialized open tag — parsed via ELEMENT_TAG_RE/ELEMENT_ATTR_RE
+        // above into `tag` (e.g. "input") and `attrs` (its own attribute
+        // map), so validator.js's mapSemanticMessageToRange can
+        // disambiguate same-named elements living under different
+        // parents by scoring how many attributes match, instead of
+        // trusting the first name="..." found anywhere in the line.
+        // elementName is kept for backward compatibility with existing
+        // consumers that only look at it: attrs.name when the line had a
+        // parseable element, else the old first `name="..."` capture in
+        // the line, else null.
         const issues = [];
-        const nodes = vecToArray(mxSafe(() => doc.getNodes(), []));
-        for (const n of nodes) {
-            const nm = mxElName(n);
-            for (const inp of vecToArray(mxSafe(() => n.getInputs(), []))) {
-                const nn = mxElAttr(inp, 'nodename');
-                if (nn && !mxSafe(() => doc.getNode(nn), null)) {
-                    issues.push({ text: nm + '.' + mxElName(inp) + ' references missing node "' + nn + '"', elementName: nm });
-                }
-                const ng = mxElAttr(inp, 'nodegraph');
-                if (ng && !mxSafe(() => doc.getNodeGraph(ng), null)) {
-                    issues.push({ text: nm + '.' + mxElName(inp) + ' references missing nodegraph "' + ng + '"', elementName: nm });
+        const rawMessage = String(holder.message || '');
+        for (const rawLine of rawMessage.split(/\r\n|\r|\n/)) {
+            const line = rawLine.trim();
+            if (!line) continue;
+            const oldNameMatch = /name="([^"]+)"/.exec(line);
+            const oldName = oldNameMatch ? oldNameMatch[1] : null;
+
+            let tag = null;
+            let attrs = null;
+            const elMatch = ELEMENT_TAG_RE.exec(line);
+            if (elMatch) {
+                tag = elMatch[1];
+                attrs = {};
+                const attrBlob = elMatch[2] || '';
+                ELEMENT_ATTR_RE.lastIndex = 0;
+                let am;
+                while ((am = ELEMENT_ATTR_RE.exec(attrBlob)) !== null) {
+                    attrs[am[1]] = am[2];
                 }
             }
+            const elementName = (attrs && attrs.name) || oldName || null;
+            issues.push({ text: line, tag, attrs, elementName });
         }
+        // holder.message empty despite a false result (build variance,
+        // or a failure validate() itself can't attribute to any single
+        // line) -> a single generic fallback issue, never zero issues
+        // for a failed validation.
         if (!issues.length) {
-            issues.push({ text: 'MaterialX document failed validation (this build does not expose more specific diagnostic detail).', elementName: null });
+            issues.push({ text: 'MaterialX document failed validation.', tag: null, attrs: null, elementName: null });
         }
         return { available: true, messages: issues };
     } catch (e) {

--- a/vscode_extension/src/nodeSignature.js
+++ b/vscode_extension/src/nodeSignature.js
@@ -1,0 +1,405 @@
+// nodeSignature.js — headless (extension-host) helpers for matching a
+// hovered/edited MaterialX element to the right port TABLE and rendering
+// that table as hover markdown, plus building/round-tripping a compact
+// "signature token" so a hover's "Open Interactive Documentation" link
+// can deep-link the docs site straight to the matching signature. Pure
+// Node: this module must NOT require('vscode') anywhere, so it stays
+// independently loadable/testable with plain `node` — same rule
+// specDocs.js/validator.js/mtlxNode.js/docScanner.js already follow, for
+// the same reason (hoverProvider.js is the only caller, and it's fine
+// for THAT file to depend on vscode; this one stays free of it).
+//
+// Two families of exports:
+//   - SAME_AS_RE/resolveType/isOutputPort/uniqTypeTokens/signatureLabel/
+//     SIG_FAMILY_EXPANSIONS/expandSigToken/pickTableForType — a trimmed,
+//     otherwise VERBATIM Node port of js/docs/port-tables.jsx's
+//     signature-label helper cluster (not a require() of it — that file
+//     is Babel/JSX, executed in a browser <script type="text/babel">
+//     context with no module.exports, and exports its OWN copies of
+//     these onto `window` only for its internal use — see that file's
+//     own "no consumers outside this file" export-list comment). Kept
+//     byte-for-byte identical logic so a table match (or signature label)
+//     made here and one made by the docs site itself (js/docs-app.jsx's
+//     `pickTableForType(portTables, selectedGroup.type)`, js/docs/
+//     port-tables.jsx's own signatureLabel) never disagree for the same
+//     table data.
+//   - extractElementContext/buildSigToken/renderPortsMarkdown — new
+//     helpers with no site-side counterpart, specific to turning a raw
+//     .mtlx document's text + a tag-name offset into a signature and a
+//     compact hover-sized markdown rendering of a table's ports.
+'use strict';
+
+// ---------------------------------------------------------------------
+// Verbatim port of js/docs/port-tables.jsx's signature-label helper
+// cluster (~lines 247-356 there), trimmed of JSX/React context. See the
+// file banner above for why this is a port, not a require().
+
+// "Same as <port>" (optionally "... or <extra>") type-reference syntax
+// used throughout the spec's port tables (e.g. multiply's `in2`: "Same
+// as `in1` or float").
+const SAME_AS_RE = /^same as\s+(\S+?)(?:\s+or\s+(.+))?$/i;
+
+// Resolves a port's TYPE cell, following a "Same as X" chain to the
+// concrete type string(s) it ultimately refers to. `seen` guards against
+// a cyclical/self-referencing chain (defensive; the spec never actually
+// has one).
+const resolveType = (ports, portName, seen) => {
+    seen = seen || new Set();
+    const row = ports[portName];
+    if (!row || seen.has(portName)) return '';
+    seen.add(portName);
+    const t = (row.type || '').trim();
+    const m = t.match(SAME_AS_RE);
+    if (!m) return t;
+    const resolved = resolveType(ports, m[1], seen);
+    if (!resolved) return t; // unresolvable reference: keep raw text
+    return m[2] ? `${resolved}, ${m[2]}` : resolved;
+};
+
+// A port counts as an OUTPUT when its key is literally 'out', or its
+// description starts with "Output" (the spec's own convention for
+// naming a non-'out' output port, e.g. multi-output nodes).
+const isOutputPort = (name, row) =>
+    name === 'out' || /^output\b/i.test(row.description || '');
+
+// Split resolved type strings ("colorN, vectorN") into individual tokens
+// and dedupe at token level, so "Same as in1 or float" on a matrixNN
+// input yields "matrixNN, float" rather than "matrixNN, matrixNN, float".
+const uniqTypeTokens = (typeStrings) => {
+    const seen = new Set();
+    const out = [];
+    typeStrings.filter(Boolean).forEach(s =>
+        s.split(',').map(t => t.trim()).filter(Boolean).forEach(t => {
+            if (!seen.has(t)) { seen.add(t); out.push(t); }
+        })
+    );
+    return out;
+};
+
+// Verbatim port of js/docs/port-tables.jsx's signatureLabel (~lines
+// 280-294 there): an "inputs → output" type summary for a table, e.g.
+// "surfaceshader" or "boolean → float, integer" — used for hover
+// markdown's "**Signature:**" line (see renderPortsMarkdown below).
+// Reuses resolveType/isOutputPort/uniqTypeTokens above, the same helpers
+// the docs site's own signatureLabel closes over, so a label produced
+// here never disagrees with the one the docs site shows for the same
+// table data. Returns null when the table has no in/out types at all
+// worth summarizing.
+const signatureLabel = (table) => {
+    const ports = table.ports || {};
+    const names = Object.keys(ports);
+    const inTypes = uniqTypeTokens(names
+        .filter(n => !isOutputPort(n, ports[n]))
+        .map(n => resolveType(ports, n)));
+    const outTypes = uniqTypeTokens(names
+        .filter(n => isOutputPort(n, ports[n]))
+        .map(n => resolveType(ports, n)));
+    if (!inTypes.length && !outTypes.length) return null;
+    const inStr = inTypes.join(', ');
+    const outStr = outTypes.join(', ');
+    if (!outStr || inStr === outStr) return inStr || outStr;
+    if (!inStr) return `→ ${outStr}`;
+    return `${inStr} → ${outStr}`;
+};
+
+// Family placeholder -> concrete member types, as authored by the spec
+// (e.g. a table whose output is documented as "colorN" covers color2,
+// color3, AND color4 concretely).
+const SIG_FAMILY_EXPANSIONS = {
+    colorn: ['color2', 'color3', 'color4'],
+    vectorn: ['vector2', 'vector3', 'vector4'],
+    matrixnn: ['matrix33', 'matrix44'],
+};
+const expandSigToken = (tok) => {
+    const key = (tok || '').trim().toLowerCase();
+    return SIG_FAMILY_EXPANSIONS[key] || [key];
+};
+
+// Which markdown table documents the signature with this output type?
+// Spec write-ups that cover several signatures under one heading (e.g.
+// `multiply`: scalar/vector table + matrixNN table) author family tokens
+// ('float, colorN or vectorN', 'matrixNN') rather than splitting per
+// concrete type. Expand those tokens and pick the first table whose
+// OUTPUT port types (resolving "Same as X" chains via resolveType, and
+// falling back to ALL ports when a table has no output row) cover the
+// wanted concrete type.
+const pickTableForType = (tables, type) => {
+    if (!type || !tables || !tables.length) return null;
+    const want = type.trim().toLowerCase();
+    for (const table of tables) {
+        const ports = table.ports || {};
+        const names = Object.keys(ports);
+        let outNames = names.filter(n => isOutputPort(n, ports[n]));
+        if (!outNames.length) outNames = names;
+        const tokens = uniqTypeTokens(outNames.map(n => resolveType(ports, n)));
+        const expanded = tokens.reduce((acc, t) => acc.concat(expandSigToken(t)), []);
+        if (expanded.some(t => t === want)) return table;
+    }
+    return null;
+};
+
+// ---------------------------------------------------------------------
+// extractElementContext — bounded, best-effort scan of a raw .mtlx
+// document's TEXT (no XML parser: this must stay fast enough to run on
+// every hover, and tolerate a document that's mid-edit/invalid XML at
+// the moment of the hover) to recover the hovered element's own
+// `type="..."` attribute and its <input> children's name/type pairs.
+//
+// `text`: the FULL document text. `nameStartOffset`: the char offset of
+// the FIRST character of the tag name itself (i.e. right after the '<'
+// — hoverProvider.js passes `document.offsetAt(tagRange.start)`, where
+// tagRange is the tag-name word range). `tagName`: the tag name string
+// (e.g. "multiply").
+//
+// Returns { type: string|null, inputs: [{name, type}] }. Every scan
+// below is BOUNDED (a cap on chars scanned or matches inspected) so a
+// pathological/huge document can't make a single hover slow, and ANY
+// failure (bad args, an exception, a tag that never closes within its
+// cap) degrades to { type: null, inputs: [] } rather than throwing —
+// hoverProvider.js still shows the description/first table on a context
+// miss, so degrading silently is strictly better than a broken hover.
+const ELEMENT_TYPE_SHAPE_RE = /^[\w:]+$/;
+const INPUT_FIELD_SHAPE_RE = /^[\w:.\-]+$/;
+const OPEN_TAG_SCAN_CAP = 4000;
+const CHILDREN_SCAN_CAP = 20000;
+const INPUT_MATCH_CAP = 64;
+const MAX_CONTEXT_INPUTS = 8;
+
+function extractAttrValue(tagText, attrName) {
+    const re = new RegExp('\\b' + attrName + '\\s*=\\s*("([^"]*)"|\'([^\']*)\')');
+    const m = re.exec(tagText);
+    if (!m) return null;
+    return m[2] !== undefined ? m[2] : m[3];
+}
+
+function escapeRegExpLiteral(s) {
+    return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function extractElementContext(text, nameStartOffset, tagName) {
+    const FAIL = { type: null, inputs: [] };
+    try {
+        if (typeof text !== 'string' || typeof nameStartOffset !== 'number'
+            || nameStartOffset < 0 || nameStartOffset > text.length
+            || typeof tagName !== 'string' || !tagName) {
+            return FAIL;
+        }
+
+        // ---- Step 1: locate the end of the OPEN tag — the unquoted '>'
+        // that closes `<tagName ...>` or `<tagName .../>` — skipping over
+        // quoted attribute-value spans so a '>' inside a value (legal in
+        // an unescaped-but-still-parseable-by-real-XML-parsers attribute,
+        // though rare) doesn't terminate the tag early. Bounded: a tag
+        // that doesn't close within OPEN_TAG_SCAN_CAP chars is treated as
+        // a failure rather than scanned without limit.
+        const openLimit = Math.min(text.length, nameStartOffset + OPEN_TAG_SCAN_CAP);
+        let i = nameStartOffset;
+        let inQuote = null;
+        let gt = -1;
+        while (i < openLimit) {
+            const ch = text[i];
+            if (inQuote) {
+                if (ch === inQuote) inQuote = null;
+            } else if (ch === '"' || ch === "'") {
+                inQuote = ch;
+            } else if (ch === '>') {
+                gt = i;
+                break;
+            }
+            i++;
+        }
+        if (gt === -1) return FAIL;
+
+        const openTag = text.slice(nameStartOffset, gt + 1); // "tagName ...>" (or ".../>")
+        const selfClosing = /\/\s*>$/.test(openTag);
+
+        // ---- The element's own `type="..."` attribute, if any and if
+        // it looks like a plausible MaterialX type (word chars/colon
+        // only — no dots/hyphens, unlike input name/type below: an
+        // element's `type` is always a bare type name, never a
+        // versioned/namespaced identifier).
+        let type = null;
+        const rawType = extractAttrValue(openTag, 'type');
+        if (rawType !== null && ELEMENT_TYPE_SHAPE_RE.test(rawType)) type = rawType;
+
+        if (selfClosing) return { type, inputs: [] };
+
+        // ---- Step 2: children region — from just after the open tag's
+        // '>' to whichever comes first: the matching </tagName close
+        // tag, or a NESTED <tagName (the same tag name reopening — a
+        // guard against scanning past a malformed/never-closed element
+        // into an unrelated later element of the same category).
+        // Bounded to CHILDREN_SCAN_CAP chars; if neither boundary is
+        // found within the cap, the capped region itself is scanned
+        // (best-effort, not a failure — <input> children near the start
+        // of a huge element are still found).
+        const childStart = gt + 1;
+        const region = text.slice(childStart, Math.min(text.length, childStart + CHILDREN_SCAN_CAP));
+        const escapedTag = escapeRegExpLiteral(tagName);
+        const closeMatch = new RegExp('</' + escapedTag + '\\b').exec(region);
+        const nestedMatch = new RegExp('<' + escapedTag + '[\\s/>]').exec(region);
+        let regionEnd = region.length;
+        if (closeMatch && nestedMatch) regionEnd = Math.min(closeMatch.index, nestedMatch.index);
+        else if (closeMatch) regionEnd = closeMatch.index;
+        else if (nestedMatch) regionEnd = nestedMatch.index;
+        const childrenText = region.slice(0, regionEnd);
+
+        // ---- Step 3: <input ...> children — up to INPUT_MATCH_CAP raw
+        // matches inspected, up to MAX_CONTEXT_INPUTS kept (only those
+        // whose name AND type are both present and shape-valid).
+        const inputs = [];
+        const inputRe = /<input\b[^>]*?\/?>/g;
+        let seen = 0;
+        let m;
+        while (inputs.length < MAX_CONTEXT_INPUTS && seen < INPUT_MATCH_CAP && (m = inputRe.exec(childrenText)) !== null) {
+            seen++;
+            const tag = m[0];
+            const nm = extractAttrValue(tag, 'name');
+            const ty = extractAttrValue(tag, 'type');
+            if (nm === null || ty === null) continue;
+            if (!INPUT_FIELD_SHAPE_RE.test(nm) || !INPUT_FIELD_SHAPE_RE.test(ty)) continue;
+            inputs.push({ name: nm, type: ty });
+        }
+
+        return { type, inputs };
+    } catch (e) {
+        return FAIL;
+    }
+}
+
+// ---------------------------------------------------------------------
+// buildSigToken — a compact, URL-safe-once-encoded string encoding ctx's
+// output type and typed inputs, e.g. `color3(in1:color3,in2:float)`, or
+// just the bare output type (`surfaceshader`) when there are no typed
+// inputs to disambiguate with. Returns null when ctx has no usable
+// output type at all — nothing worth deep-linking a signature for.
+//
+// Every char buildSigToken can emit is validated upstream (ELEMENT_TYPE_
+// SHAPE_RE / INPUT_FIELD_SHAPE_RE above), so every token this function
+// produces is guaranteed to match extension.js's SIG_TOKEN_RE and
+// js/docs/doc-links.jsx's SIG_HINT_RE — both intentionally shaped to
+// accept exactly this grammar.
+function buildSigToken(ctx) {
+    if (!ctx || !ctx.type) return null;
+    const inputs = Array.isArray(ctx.inputs) ? ctx.inputs : [];
+    if (!inputs.length) return ctx.type;
+    return ctx.type + '(' + inputs.map((inp) => inp.name + ':' + inp.type).join(',') + ')';
+}
+
+// ---------------------------------------------------------------------
+// renderPortsMarkdown — a per-port DEFINITION LIST rendering of one port
+// TABLE ({headers, ports: {name: {type, default, description, ...}}}),
+// sized for a hover tooltip rather than the full docs page. This
+// replaces an earlier GFM pipe-table rendering: VS Code's hover CSS
+// renders pipe tables WITHOUT visible cell borders and stretches columns
+// unreadably (verified — `supportHtml` doesn't help either, since the
+// markdown sanitizer strips style attributes and the same CSS still
+// applies to the resulting plain <table>). A definition list with
+// code-span "chips" for name/type/default reads far better in that same
+// hover CSS: one block per port (name/type/default chips on one line,
+// description on the next), preceded by a "**Signature:**" line (see
+// signatureLabel above). `accepted_values` is dropped entirely (the
+// interactive docs page is the source of truth for enum lists), footnote
+// references are stripped (a hover has no References section to resolve
+// them against), long descriptions are truncated on a word boundary, and
+// the port count is capped so one giant node (e.g. a closure with 20+
+// inputs) can't produce an unreadable wall of hover text.
+const FOOTNOTE_REF_RE = /\[\^[^\]\s]+\]/g;
+const DESCRIPTION_MAX_LEN = 120;
+const MAX_TABLE_ROWS = 14;
+
+function stripFootnoteRefs(s) {
+    return s.replace(FOOTNOTE_REF_RE, '');
+}
+
+// Text placed INSIDE a `code span` (port name/type/default) must not
+// carry a backtick (would terminate the span early) or a pipe (harmless
+// in a definition list, but stripped anyway per the same "keep chip text
+// clean" rule) — never applied to the free-text description paragraph,
+// which isn't wrapped in a code span.
+function sanitizeChip(s) {
+    return s.replace(/[`|]/g, '');
+}
+
+// Truncates on a word boundary (never mid-word) and appends an ellipsis;
+// falls back to a hard cut only when no earlier space exists to break
+// on (a single very long "word", e.g. a URL).
+function truncateDescription(s) {
+    if (!s || s.length <= DESCRIPTION_MAX_LEN) return s;
+    const cut = s.slice(0, DESCRIPTION_MAX_LEN);
+    const lastSpace = cut.lastIndexOf(' ');
+    const trimmed = (lastSpace > 0 ? cut.slice(0, lastSpace) : cut).trim();
+    return trimmed + '…';
+}
+
+function cellText(raw, isDescription) {
+    let s = raw == null ? '' : String(raw).trim();
+    if (!s) return '';
+    s = stripFootnoteRefs(s);
+    if (isDescription) s = truncateDescription(s);
+    return s;
+}
+
+function renderPortsMarkdown(table) {
+    try {
+        if (!table || !table.ports) return '';
+        const portNames = Object.keys(table.ports);
+        if (!portNames.length) return '';
+
+        const blocks = [];
+
+        // Signature line first, e.g. "**Signature:** `boolean, integer,
+        // float, colorN, vectorN → surfaceshader`" — omitted entirely
+        // (rather than printed empty) when signatureLabel can't derive
+        // anything useful for this table.
+        const sigLabel = signatureLabel(table);
+        if (sigLabel) {
+            blocks.push('**Signature:** `' + sanitizeChip(sigLabel) + '`');
+        }
+
+        const shown = portNames.slice(0, MAX_TABLE_ROWS);
+        for (const pn of shown) {
+            const row = table.ports[pn] || {};
+            const name = sanitizeChip(stripFootnoteRefs(String(pn || '').trim()));
+            if (!name) continue;
+            const type = sanitizeChip(cellText(row.type, false));
+            const def = sanitizeChip(cellText(row.default, false));
+
+            // "**`name`** `type` — default `value`", trailing two spaces
+            // for a markdown hard line break so the description (when
+            // present) starts on its own line within the SAME block —
+            // omit the "— default ..." segment entirely when there's no
+            // default value to show.
+            let head = '**`' + name + '`**';
+            if (type) head += ' `' + type + '`';
+            if (def) head += ' — default `' + def + '`';
+            head += '  ';
+
+            const desc = cellText(row.description, true);
+            blocks.push(desc ? head + '\n' + desc : head);
+        }
+
+        let md = blocks.join('\n\n');
+        const remaining = portNames.length - shown.length;
+        if (remaining > 0) {
+            md += '\n\n_…and ' + remaining + ' more ports — open the full documentation below._';
+        }
+        return md;
+    } catch (e) {
+        return '';
+    }
+}
+
+module.exports = {
+    SAME_AS_RE,
+    resolveType,
+    isOutputPort,
+    uniqTypeTokens,
+    signatureLabel,
+    SIG_FAMILY_EXPANSIONS,
+    expandSigToken,
+    pickTableForType,
+    extractElementContext,
+    buildSigToken,
+    renderPortsMarkdown,
+};

--- a/vscode_extension/src/specDocs.js
+++ b/vscode_extension/src/specDocs.js
@@ -1,0 +1,355 @@
+// specDocs.js — headless (extension-host) extractor for per-node
+// DESCRIPTIONS ONLY out of the three MaterialX specification markdown
+// files committed at the repo root (MaterialX.PBRSpec.md,
+// MaterialX.NPRSpec.md, MaterialX.StandardNodes.md). Pure Node: this
+// module must NOT require('vscode') anywhere, so it stays independently
+// loadable/testable with plain `node` — same rule validator.js/
+// mtlxNode.js/docScanner.js already follow, for the same reason
+// (hoverProvider.js is the only caller, and it's fine for THAT file to
+// depend on vscode; this one stays free of it).
+//
+// This is a deliberately trimmed Node port of js/spec-parser.js's
+// parseMdDocs() state machine (anchors -> `### \`name\`` headings ->
+// following paragraph text -> cleanText markdown cleanup), NOT a
+// require() of it — js/spec-parser.js is a browser global-scope IIFE
+// that fetches the spec files over the network (raw.githubusercontent.com)
+// and joins them against live WASM nodedefs for the FULL doc database
+// (description + notes + port tables + references); this module only
+// ever wants the description paragraph(s) that appear directly after a
+// node's heading and before its first port table, read from the LOCAL
+// committed copies. Where the two logics overlap (heading/anchor
+// recognition, paragraph accumulation, table-start detection, cleanText's
+// link/bold/italic/entity cleanup) the logic here mirrors spec-parser.js
+// line for line; see the deviations called out inline below.
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+// ---------------------------------------------------------------------
+// Spec revision/link configuration — kept in lockstep with the constants
+// of the same name in js/spec-parser.js so a spec_url produced here
+// points at exactly the same GitHub blob/anchor the website would show
+// for the same node.
+const REPO = 'AcademySoftwareFoundation/MaterialX';
+const SPEC_TAG = 'v1.39.5';
+const SPEC_DIR = 'documents/Specification/';
+const BLOB_BASE = 'https://github.com/' + REPO + '/blob/' + SPEC_TAG + '/' + SPEC_DIR;
+
+// Files to parse, in the order they're merged (see buildCombinedMap
+// below) — stdlib first since it's the largest/most commonly-hovered
+// library, then the two extension libraries. Order only matters as a
+// tie-break for which file's anchor "wins" when the SAME category name
+// is documented in more than one spec file (e.g. `mix`/`add` each have a
+// generic stdlib entry AND a PBR-specific BSDF-layering entry) — the
+// description itself is the concatenation of every entry found across
+// every file/duplicate heading (see the merge comment below), so no
+// prose is lost either way, only the spec_url's target file/anchor.
+const SPEC_FILES = ['MaterialX.StandardNodes.md', 'MaterialX.PBRSpec.md', 'MaterialX.NPRSpec.md'];
+
+// ---------------------------------------------------------------------
+// Text cleanup — trimmed port of js/spec-parser.js's cleanText (only the
+// pieces description prose actually needs: math-span protection, entity
+// decoding, markdown link resolution, bold/italic/backtick stripping).
+// cleanCellValue (table-cell sentinels/quote-stripping) has no
+// counterpart here — this module never reads table cells.
+const MD_LINK_RE = /\[([^\]^][^\]]*)\]\(([^)]*)\)/g;
+const BOLD_US_RE = /__([^_]+)__/g;
+const BOLD_AST_RE = /\*\*([^*]+)\*\*/g;
+const ITALIC_RE = /(?<![\w])_([^_\s][^_]*)_(?![\w])/g;
+const MATH_RE = /\$\$[^$]+\$\$|\$[^$\n]+\$/g;
+
+// html.unescape equivalent. spec-parser.js does this via a throwaway
+// <textarea> (DOM RCDATA decoding); no DOM exists in the extension host,
+// so this ports its own non-DOM fallback branch verbatim.
+const ENTITY_FALLBACK = {
+    '&lt;': '<', '&gt;': '>', '&amp;': '&',
+    '&quot;': '"', '&#39;': "'", '&nbsp;': ' ',
+};
+function decodeEntities(val) {
+    if (val.indexOf('&') === -1) return val;
+    return val
+        .replace(/&#(\d+);/g, (m, d) => String.fromCodePoint(+d))
+        .replace(/&#x([0-9a-f]+);/gi, (m, h) => String.fromCodePoint(parseInt(h, 16)))
+        .replace(/&(lt|gt|amp|quot|#39|nbsp);/g, (m) => ENTITY_FALLBACK[m]);
+}
+
+// Same-file '#anchor' links resolve against the repoFile currently being
+// parsed; relative links resolve against the spec directory on GitHub —
+// identical rules to js/spec-parser.js's resolveLinkTarget.
+function resolveLinkTarget(target, repoFile) {
+    target = target.trim();
+    if (/^(https?:\/\/|mailto:)/.test(target)) return target;
+    if (target.startsWith('#')) return BLOB_BASE + repoFile + target;
+    while (target.startsWith('./')) target = target.slice(2);
+    while (target.startsWith('../')) target = target.slice(3);
+    return BLOB_BASE + target;
+}
+
+// Mirrors js/spec-parser.js's cleanText exactly (math spans stashed
+// before any stripping so LaTeX source survives, restored verbatim at
+// the end; links kept as markdown with an absolute, resolved target so
+// the resulting description remains valid markdown for a VS Code
+// MarkdownString hover; bold/italic markers stripped to plain text;
+// backticks stripped).
+function cleanText(val, repoFile) {
+    if (!val) return '';
+
+    const mathSpans = [];
+    val = val.replace(MATH_RE, (m) => {
+        mathSpans.push(m);
+        return '' + (mathSpans.length - 1) + '';
+    });
+
+    val = decodeEntities(val);
+    val = val.replace(MD_LINK_RE, (m, text, target) => '[' + text + '](' + resolveLinkTarget(target, repoFile) + ')');
+    val = val.replace(BOLD_US_RE, '$1');
+    val = val.replace(BOLD_AST_RE, '$1');
+    val = val.replace(ITALIC_RE, '$1');
+    val = val.replace(/`/g, '');
+
+    mathSpans.forEach((span, i) => {
+        val = val.replace('' + i + '', () => span);
+    });
+
+    return val.trim();
+}
+
+// ---------------------------------------------------------------------
+// Per-file markdown parse — trimmed port of js/spec-parser.js's
+// parseMdDocs. Recognizes the same anchor/heading/table structure but
+// drops everything the description doesn't need: footnotes, port table
+// cell contents, "notes" (prose AFTER the first port table). Returns
+// { name: [{ description, anchor }] } — an ARRAY per name because a
+// node name can appear more than once in one spec file (e.g. the color
+// `mix` and the shader `mix` both live in MaterialX.StandardNodes.md).
+const NODE_HEADING_RE = /^###\s+`([^`]+)`\s*$/;
+const ANY_HEADING_RE = /^#{1,6}\s+.*$/;
+const TABLE_SEP_RE = /^[-:\s]+$/;
+const ANCHOR_RE = /^<a\s+id="([^"]+)"/;
+const HTML_FILLER_RE = /^(<p>\s*<\/p>|<p\s*\/>|<\/?p>|<br\s*\/?>)$/i;
+
+function parseSpecFile(text, repoFile) {
+    const docs = {};
+    if (!text) return docs;
+    const lines = text.split(/\r\n|\n|\r/);
+
+    let lastAnchor = null;    // most recent <a id="..."> line, consumed by the next node heading
+    let node = null;          // { name, descParas: [], anchor, sawPortTable }
+    let paraBuffer = [];
+    let tableHeaders = null;  // headers of the table currently open, or null between tables
+    let inFence = false;      // inside a ``` fenced block
+
+    // Prose before the node's first Port-column table is the
+    // description; DELIBERATE DEVIATION from parseMdDocs: prose after
+    // that point (parseMdDocs' "notes") is parsed (to keep table-start
+    // detection correct) but never kept, since this module extracts
+    // descriptions ONLY.
+    const flushParagraph = () => {
+        if (node && paraBuffer.length && !node.sawPortTable) {
+            const paragraph = cleanText(paraBuffer.join(' '), repoFile);
+            if (paragraph) node.descParas.push(paragraph);
+        }
+        paraBuffer = [];
+    };
+
+    const closeNode = () => {
+        flushParagraph();
+        if (node) {
+            const description = node.descParas.join('\n\n');
+            if (description) {
+                (docs[node.name] = docs[node.name] || []).push({ description, anchor: node.anchor });
+            }
+        }
+        node = null;
+        tableHeaders = null;
+    };
+
+    for (const rawLine of lines) {
+        const line = rawLine.trim();
+
+        // Fenced blocks (```math ... ``` etc.): DELIBERATE DEVIATION from
+        // parseMdDocs, which keeps fenced content (folding ```math``` into
+        // a $$...$$ display-math paragraph). Fences essentially never
+        // appear in the short pre-table prose this module cares about
+        // (they're a "notes"/worked-example thing), so they're just
+        // skipped here rather than ported in full — one less place a
+        // hover tooltip's markdown could end up malformed.
+        if (line.startsWith('```')) {
+            inFence = !inFence;
+            continue;
+        }
+        if (inFence) continue;
+
+        if (!line) {
+            // Blank line: paragraph and table boundaries, same as parseMdDocs.
+            flushParagraph();
+            tableHeaders = null;
+            continue;
+        }
+
+        if (ANY_HEADING_RE.test(line)) {
+            const nodeMatch = NODE_HEADING_RE.exec(line);
+            if (nodeMatch) {
+                closeNode();
+                node = { name: nodeMatch[1].trim(), descParas: [], anchor: lastAnchor, sawPortTable: false };
+                lastAnchor = null;
+            } else {
+                // Any other heading — including a level>=4 sub-heading
+                // INSIDE a node's own prose (parseMdDocs keeps those as
+                // content) — ends the current node here. DELIBERATE
+                // DEVIATION: description-only mode has no "keep as
+                // content" bucket to route a sub-heading into, and by the
+                // time a real spec entry reaches a sub-heading it has
+                // already passed its port table in every file inspected
+                // for this module, so the description itself is unaffected
+                // in practice.
+                closeNode();
+            }
+            continue;
+        }
+
+        const anchorMatch = ANCHOR_RE.exec(line);
+        if (anchorMatch) {
+            lastAnchor = anchorMatch[1];
+            continue;
+        }
+
+        if (node === null) continue; // prose between sections
+        if (HTML_FILLER_RE.test(line)) continue;
+
+        if (line.startsWith('|')) {
+            flushParagraph();
+            const parts = line.split('|').map((p) => p.trim()).slice(1, -1);
+            const nonEmpty = parts.filter((p) => p);
+            if (parts.length && nonEmpty.length && nonEmpty.every((p) => TABLE_SEP_RE.test(p))) {
+                continue; // separator row (|---|---|...)
+            }
+            if (tableHeaders === null) {
+                // First pipe row of a new table -> header row. Only a
+                // table with a "Port" column flips sawPortTable (and thus
+                // ends description accumulation for good) — mirrors
+                // parseMdDocs treating a Port-less table as "ignore" (its
+                // rows never land in port_tables, so text after it still
+                // targets the description).
+                tableHeaders = parts.map((h) => h.toLowerCase());
+                if (tableHeaders.indexOf('port') !== -1) node.sawPortTable = true;
+            }
+            // Data rows: nothing to extract for a description-only parse.
+            continue;
+        }
+
+        paraBuffer.push(line);
+    }
+    closeNode();
+    return docs;
+}
+
+// ---------------------------------------------------------------------
+// Combine all three files into one category -> { description, specUrl? }
+// map, plus a squashed-lowercase index for the fallback lookup.
+//
+// A category found in more than one file/heading (see SPEC_FILES' order
+// comment above) has its descriptions CONCATENATED, mirroring
+// js/spec-parser.js's resolveDoc() "no confident nodegroup match: merge
+// everything so nothing is lost" fallback — this module has no nodedef/
+// nodegroup context to disambiguate with (getNodeDoc takes only a
+// category string), so that fallback is the only behavior available,
+// applied unconditionally rather than as one branch of resolveDoc.
+const squash = (s) => String(s).replace(/[-_]/g, '').toLowerCase();
+
+function buildCombinedMap(repoRoot) {
+    const merged = new Map(); // name -> { descParas: [], anchor: null, file: null }
+
+    for (const file of SPEC_FILES) {
+        let text;
+        try {
+            text = fs.readFileSync(path.join(repoRoot, file), 'utf8');
+        } catch (e) {
+            continue; // fail soft: missing/unreadable file -> skip it, per-file
+        }
+        const perFile = parseSpecFile(text, file);
+        for (const name of Object.keys(perFile)) {
+            let combined = merged.get(name);
+            if (!combined) {
+                combined = { descParas: [], anchor: null, file: null };
+                merged.set(name, combined);
+            }
+            for (const entry of perFile[name]) {
+                if (entry.description) combined.descParas.push(entry.description);
+                // First anchor found (in SPEC_FILES order, then file
+                // order) wins the spec_url's target file — every node
+                // heading in these files is immediately preceded by its
+                // own <a id="node-..."> line, so this is the anchor for
+                // the exact entry the description text came from, not a
+                // guess.
+                if (!combined.anchor && entry.anchor) {
+                    combined.anchor = entry.anchor;
+                    combined.file = file;
+                }
+            }
+        }
+    }
+
+    const byName = new Map();
+    const bySquashed = new Map(); // squashed key -> canonical category name, first match wins
+    for (const [name, combined] of merged) {
+        const description = combined.descParas.join('\n\n');
+        const entry = { description };
+        // Only set spec_url when a REAL anchor was parsed — no synthetic
+        // 'node-' + name.split('_').join('-') guess here (unlike
+        // js/spec-parser.js, which can afford to guess because it always
+        // knows the node's library/file from the live nodedef; this
+        // module, given just a category string, would risk pointing at a
+        // file that doesn't even contain the node). "when derivable, else
+        // omitted" per the spec.
+        if (combined.anchor) {
+            entry.specUrl = BLOB_BASE + combined.file + '#' + combined.anchor;
+        }
+        byName.set(name, entry);
+        const key = squash(name);
+        if (!bySquashed.has(key)) bySquashed.set(key, name);
+    }
+    return { byName, bySquashed };
+}
+
+// ---------------------------------------------------------------------
+// Public API.
+
+// Lazy + cached: parsed once, on the first getNodeDoc() call, then
+// reused for the lifetime of the extension host process — repo root is
+// fixed for the whole session (there is exactly one extension host
+// process and exactly one repo root, same assumption mtlxNode.js
+// documents for its own singleton). A later call with a different
+// repoRoot does NOT reparse; this mirrors mtlxNode.js's "first caller's
+// repoRoot wins forever" precedent for the same reason.
+let cachedMap = null;
+
+/**
+ * getNodeDoc(repoRoot, category) -> { description, specUrl? } | null
+ *
+ * (a) exact category-name match against the parsed spec files;
+ * (b) else a squashed-lowercase fallback (strip [_-], lowercase — same
+ *     idea as hashToSel's name-only branch in js/docs/doc-links.jsx);
+ * (c) specUrl included only when an anchor was actually found for that
+ *     category in one of the three files, omitted otherwise.
+ * Returns null when the category isn't documented in any of the three
+ * spec files under either lookup.
+ */
+function getNodeDoc(repoRoot, category) {
+    if (!category) return null;
+    if (!cachedMap) cachedMap = buildCombinedMap(repoRoot);
+
+    let entry = cachedMap.byName.get(category);
+    if (!entry) {
+        const canonical = cachedMap.bySquashed.get(squash(category));
+        if (canonical) entry = cachedMap.byName.get(canonical);
+    }
+    if (!entry) return null;
+
+    const out = { description: entry.description };
+    if (entry.specUrl) out.specUrl = entry.specUrl;
+    return out;
+}
+
+module.exports = { getNodeDoc };

--- a/vscode_extension/src/specDocs.js
+++ b/vscode_extension/src/specDocs.js
@@ -1,6 +1,6 @@
 // specDocs.js — headless (extension-host) extractor for per-node
-// DESCRIPTIONS ONLY out of the three MaterialX specification markdown
-// files committed at the repo root (MaterialX.PBRSpec.md,
+// DESCRIPTIONS and PORT TABLES out of the three MaterialX specification
+// markdown files committed at the repo root (MaterialX.PBRSpec.md,
 // MaterialX.NPRSpec.md, MaterialX.StandardNodes.md). Pure Node: this
 // module must NOT require('vscode') anywhere, so it stays independently
 // loadable/testable with plain `node` — same rule validator.js/
@@ -10,17 +10,20 @@
 //
 // This is a deliberately trimmed Node port of js/spec-parser.js's
 // parseMdDocs() state machine (anchors -> `### \`name\`` headings ->
-// following paragraph text -> cleanText markdown cleanup), NOT a
-// require() of it — js/spec-parser.js is a browser global-scope IIFE
-// that fetches the spec files over the network (raw.githubusercontent.com)
-// and joins them against live WASM nodedefs for the FULL doc database
-// (description + notes + port tables + references); this module only
-// ever wants the description paragraph(s) that appear directly after a
-// node's heading and before its first port table, read from the LOCAL
+// following paragraph text -> Port-column tables -> cleanText/
+// cleanCellValue markdown cleanup), NOT a require() of it —
+// js/spec-parser.js is a browser global-scope IIFE that fetches the spec
+// files over the network (raw.githubusercontent.com) and joins them
+// against live WASM nodedefs for the FULL doc database (description +
+// notes + port tables + references); this module only ever wants the
+// description paragraph(s) that appear directly after a node's heading,
+// plus the Port-column table(s) that follow them (skipping "notes" prose
+// AFTER those tables and footnote references), read from the LOCAL
 // committed copies. Where the two logics overlap (heading/anchor
-// recognition, paragraph accumulation, table-start detection, cleanText's
-// link/bold/italic/entity cleanup) the logic here mirrors spec-parser.js
-// line for line; see the deviations called out inline below.
+// recognition, paragraph accumulation, table header/row parsing,
+// cleanText/cleanCellValue's link/bold/italic/entity/sentinel cleanup)
+// the logic here mirrors spec-parser.js line for line; see the
+// deviations called out inline below.
 'use strict';
 
 const fs = require('fs');
@@ -49,10 +52,10 @@ const SPEC_FILES = ['MaterialX.StandardNodes.md', 'MaterialX.PBRSpec.md', 'Mater
 
 // ---------------------------------------------------------------------
 // Text cleanup — trimmed port of js/spec-parser.js's cleanText (only the
-// pieces description prose actually needs: math-span protection, entity
-// decoding, markdown link resolution, bold/italic/backtick stripping).
-// cleanCellValue (table-cell sentinels/quote-stripping) has no
-// counterpart here — this module never reads table cells.
+// pieces description/cell prose actually needs: math-span protection,
+// entity decoding, markdown link resolution, bold/italic/backtick
+// stripping) plus cleanCellValue (spec sentinel mapping + surrounding-
+// quote stripping for table cells, now that port tables are captured).
 const MD_LINK_RE = /\[([^\]^][^\]]*)\]\(([^)]*)\)/g;
 const BOLD_US_RE = /__([^_]+)__/g;
 const BOLD_AST_RE = /\*\*([^*]+)\*\*/g;
@@ -115,14 +118,53 @@ function cleanText(val, repoFile) {
     return val.trim();
 }
 
+// Sentinel placeholders used by the spec markdown's table cells, mapped
+// to display-friendly values. Matched against the *raw* cell content
+// before any markdown stripping, so the bold/italic regexes can't mangle
+// them. Verbatim from js/spec-parser.js's SENTINEL_MAP.
+const SENTINEL_MAP = {
+    '__empty__': '',
+    '__zero__': '0',
+    '__one__': '1',
+    '__half__': '0.5',
+    '__matrix33__': 'identity (matrix33)',
+    '__matrix44__': 'identity (matrix44)',
+    '_UV0_': 'UV0',
+    '_NA_': 'N/A',
+};
+
+// Cleanup for one table cell — verbatim port of js/spec-parser.js's
+// cleanCellValue, with repoFile threaded through to cleanText (this
+// module's cleanText takes repoFile as an explicit arg rather than
+// reading a module-level currentRepoFile, per its own comment above).
+function cleanCellValue(val, repoFile) {
+    if (!val) return '';
+    val = val.trim();
+
+    // Map spec sentinels first, on the raw value.
+    if (Object.prototype.hasOwnProperty.call(SENTINEL_MAP, val)) {
+        return SENTINEL_MAP[val];
+    }
+
+    val = cleanText(val, repoFile);
+
+    // Strip only *surrounding* symmetric quotes; never touch apostrophes
+    // or quotes inside the text ("renderer's", "minframe-maxframe").
+    if (val.length >= 2 && val[0] === val[val.length - 1] && (val[0] === '"' || val[0] === "'")) {
+        val = val.slice(1, -1).trim();
+    }
+    return val;
+}
+
 // ---------------------------------------------------------------------
 // Per-file markdown parse — trimmed port of js/spec-parser.js's
 // parseMdDocs. Recognizes the same anchor/heading/table structure but
-// drops everything the description doesn't need: footnotes, port table
-// cell contents, "notes" (prose AFTER the first port table). Returns
-// { name: [{ description, anchor }] } — an ARRAY per name because a
-// node name can appear more than once in one spec file (e.g. the color
-// `mix` and the shader `mix` both live in MaterialX.StandardNodes.md).
+// drops everything the description/port-table pair doesn't need:
+// footnotes and "notes" (prose AFTER the first port table). Returns
+// { name: [{ description, anchor, port_tables }] } — an ARRAY per name
+// because a node name can appear more than once in one spec file (e.g.
+// the color `mix` and the shader `mix` both live in
+// MaterialX.StandardNodes.md).
 const NODE_HEADING_RE = /^###\s+`([^`]+)`\s*$/;
 const ANY_HEADING_RE = /^#{1,6}\s+.*$/;
 const TABLE_SEP_RE = /^[-:\s]+$/;
@@ -135,18 +177,21 @@ function parseSpecFile(text, repoFile) {
     const lines = text.split(/\r\n|\n|\r/);
 
     let lastAnchor = null;    // most recent <a id="..."> line, consumed by the next node heading
-    let node = null;          // { name, descParas: [], anchor, sawPortTable }
+    let node = null;          // { name, descParas: [], anchor, port_tables: [] }
     let paraBuffer = [];
-    let tableHeaders = null;  // headers of the table currently open, or null between tables
+    let currentTable = null;  // { headers, ports } for the table currently open, or null between tables
     let inFence = false;      // inside a ``` fenced block
 
     // Prose before the node's first Port-column table is the
     // description; DELIBERATE DEVIATION from parseMdDocs: prose after
     // that point (parseMdDocs' "notes") is parsed (to keep table-start
     // detection correct) but never kept, since this module extracts
-    // descriptions ONLY.
+    // descriptions and port tables ONLY, not notes/references. A node
+    // has "seen its first port table" once node.port_tables is
+    // non-empty — mirrors parseMdDocs' targetParagraphs() switching from
+    // _desc_paras to _note_paras the same way.
     const flushParagraph = () => {
-        if (node && paraBuffer.length && !node.sawPortTable) {
+        if (node && paraBuffer.length && !node.port_tables.length) {
             const paragraph = cleanText(paraBuffer.join(' '), repoFile);
             if (paragraph) node.descParas.push(paragraph);
         }
@@ -157,12 +202,19 @@ function parseSpecFile(text, repoFile) {
         flushParagraph();
         if (node) {
             const description = node.descParas.join('\n\n');
-            if (description) {
-                (docs[node.name] = docs[node.name] || []).push({ description, anchor: node.anchor });
+            // Keep this node's entry when it carries a description OR at
+            // least one real (non-ignored) port table — a heading that
+            // somehow produced neither has nothing worth surfacing.
+            if (description || node.port_tables.length) {
+                (docs[node.name] = docs[node.name] || []).push({
+                    description,
+                    anchor: node.anchor,
+                    port_tables: node.port_tables,
+                });
             }
         }
         node = null;
-        tableHeaders = null;
+        currentTable = null;
     };
 
     for (const rawLine of lines) {
@@ -184,7 +236,7 @@ function parseSpecFile(text, repoFile) {
         if (!line) {
             // Blank line: paragraph and table boundaries, same as parseMdDocs.
             flushParagraph();
-            tableHeaders = null;
+            currentTable = null;
             continue;
         }
 
@@ -192,7 +244,7 @@ function parseSpecFile(text, repoFile) {
             const nodeMatch = NODE_HEADING_RE.exec(line);
             if (nodeMatch) {
                 closeNode();
-                node = { name: nodeMatch[1].trim(), descParas: [], anchor: lastAnchor, sawPortTable: false };
+                node = { name: nodeMatch[1].trim(), descParas: [], anchor: lastAnchor, port_tables: [] };
                 lastAnchor = null;
             } else {
                 // Any other heading — including a level>=4 sub-heading
@@ -225,17 +277,41 @@ function parseSpecFile(text, repoFile) {
             if (parts.length && nonEmpty.length && nonEmpty.every((p) => TABLE_SEP_RE.test(p))) {
                 continue; // separator row (|---|---|...)
             }
-            if (tableHeaders === null) {
-                // First pipe row of a new table -> header row. Only a
-                // table with a "Port" column flips sawPortTable (and thus
-                // ends description accumulation for good) — mirrors
-                // parseMdDocs treating a Port-less table as "ignore" (its
-                // rows never land in port_tables, so text after it still
-                // targets the description).
-                tableHeaders = parts.map((h) => h.toLowerCase());
-                if (tableHeaders.indexOf('port') !== -1) node.sawPortTable = true;
+            if (currentTable === null) {
+                // First pipe row of a new table -> header row. Mirrors
+                // js/spec-parser.js's header normalization exactly
+                // (lowercase, spaces -> underscores: "Accepted Values"
+                // -> "accepted_values") so this module's port_tables
+                // shape matches the site's. Only a table with a "port"
+                // column is a REAL port table (pushed to
+                // node.port_tables, which also ends description
+                // accumulation for good, see flushParagraph above) — a
+                // Port-less table is consumed but ignored, mirroring
+                // parseMdDocs treating it the same way (its rows never
+                // land in port_tables, so text after it still targets
+                // the description).
+                const headers = parts.map((h) => h.toLowerCase().split(' ').join('_'));
+                currentTable = { headers, ports: {} };
+                if (headers.indexOf('port') !== -1) {
+                    node.port_tables.push(currentTable);
+                } else {
+                    currentTable.ignore = true;
+                }
+            } else if (!currentTable.ignore) {
+                // Data row of the currently open (real) port table.
+                const headers = currentTable.headers;
+                const rowData = {};
+                headers.forEach((h, i) => {
+                    rowData[h] = cleanCellValue(i < parts.length ? parts[i] : '', repoFile);
+                });
+                const portName = (rowData.port || '').trim();
+                delete rowData.port;
+                // Guard against a stray header row being read as data
+                // (e.g. two tables not separated by a blank line).
+                if (portName && portName.toLowerCase() !== 'port') {
+                    currentTable.ports[portName] = rowData;
+                }
             }
-            // Data rows: nothing to extract for a description-only parse.
             continue;
         }
 
@@ -246,20 +322,24 @@ function parseSpecFile(text, repoFile) {
 }
 
 // ---------------------------------------------------------------------
-// Combine all three files into one category -> { description, specUrl? }
-// map, plus a squashed-lowercase index for the fallback lookup.
+// Combine all three files into one category -> { description, port_tables,
+// specUrl? } map, plus a squashed-lowercase index for the fallback lookup.
 //
 // A category found in more than one file/heading (see SPEC_FILES' order
-// comment above) has its descriptions CONCATENATED, mirroring
+// comment above) has its descriptions CONCATENATED and its port_tables
+// CONCATENATED (in file order, then heading order within a file — the
+// same order parseSpecFile discovered them in), mirroring
 // js/spec-parser.js's resolveDoc() "no confident nodegroup match: merge
-// everything so nothing is lost" fallback — this module has no nodedef/
-// nodegroup context to disambiguate with (getNodeDoc takes only a
-// category string), so that fallback is the only behavior available,
-// applied unconditionally rather than as one branch of resolveDoc.
+// everything so nothing is lost" fallback (including its
+// `entries.reduce((acc, e) => acc.concat(e.port_tables || []), [])` for
+// port_tables specifically) — this module has no nodedef/nodegroup
+// context to disambiguate with (getNodeDoc takes only a category
+// string), so that fallback is the only behavior available, applied
+// unconditionally rather than as one branch of resolveDoc.
 const squash = (s) => String(s).replace(/[-_]/g, '').toLowerCase();
 
 function buildCombinedMap(repoRoot) {
-    const merged = new Map(); // name -> { descParas: [], anchor: null, file: null }
+    const merged = new Map(); // name -> { descParas: [], portTables: [], anchor: null, file: null }
 
     for (const file of SPEC_FILES) {
         let text;
@@ -272,11 +352,14 @@ function buildCombinedMap(repoRoot) {
         for (const name of Object.keys(perFile)) {
             let combined = merged.get(name);
             if (!combined) {
-                combined = { descParas: [], anchor: null, file: null };
+                combined = { descParas: [], portTables: [], anchor: null, file: null };
                 merged.set(name, combined);
             }
             for (const entry of perFile[name]) {
                 if (entry.description) combined.descParas.push(entry.description);
+                if (entry.port_tables && entry.port_tables.length) {
+                    combined.portTables = combined.portTables.concat(entry.port_tables);
+                }
                 // First anchor found (in SPEC_FILES order, then file
                 // order) wins the spec_url's target file — every node
                 // heading in these files is immediately preceded by its
@@ -295,7 +378,7 @@ function buildCombinedMap(repoRoot) {
     const bySquashed = new Map(); // squashed key -> canonical category name, first match wins
     for (const [name, combined] of merged) {
         const description = combined.descParas.join('\n\n');
-        const entry = { description };
+        const entry = { description, port_tables: combined.portTables };
         // Only set spec_url when a REAL anchor was parsed — no synthetic
         // 'node-' + name.split('_').join('-') guess here (unlike
         // js/spec-parser.js, which can afford to guess because it always
@@ -326,12 +409,16 @@ function buildCombinedMap(repoRoot) {
 let cachedMap = null;
 
 /**
- * getNodeDoc(repoRoot, category) -> { description, specUrl? } | null
+ * getNodeDoc(repoRoot, category) -> { description, port_tables, specUrl? } | null
  *
  * (a) exact category-name match against the parsed spec files;
  * (b) else a squashed-lowercase fallback (strip [_-], lowercase — same
  *     idea as hashToSel's name-only branch in js/docs/doc-links.jsx);
- * (c) specUrl included only when an anchor was actually found for that
+ * (c) port_tables is the {headers, ports} array parsed for this category
+ *     (see parseSpecFile above), possibly empty — same shape
+ *     js/docs/port-tables.jsx's getPortTables()/pickTableForType() and
+ *     this extension's nodeSignature.js consume;
+ * (d) specUrl included only when an anchor was actually found for that
  *     category in one of the three files, omitted otherwise.
  * Returns null when the category isn't documented in any of the three
  * spec files under either lookup.
@@ -347,7 +434,7 @@ function getNodeDoc(repoRoot, category) {
     }
     if (!entry) return null;
 
-    const out = { description: entry.description };
+    const out = { description: entry.description, port_tables: entry.port_tables || [] };
     if (entry.specUrl) out.specUrl = entry.specUrl;
     return out;
 }

--- a/vscode_extension/src/validator.js
+++ b/vscode_extension/src/validator.js
@@ -1,0 +1,424 @@
+// validator.js — two-tier .mtlx diagnostics.
+//
+// Tier 1 (scanXml): a hand-rolled, dependency-free XML well-formedness
+// scanner. Runs on every document change, synchronously, with no wasm
+// involved — catches the mistakes that actually happen while hand-
+// editing a .mtlx file (unclosed tags, mismatched close tags, unescaped
+// '&', malformed attributes) fast enough to run on a debounce timer per
+// keystroke. This extension ships with ZERO npm dependencies, so this is
+// a tokenizer, not a real XML parser.
+//
+// Tier 2 (validateDocument, when tier 1 is clean): defers to
+// mtlxNode.validateSemantic for an actual MaterialX parse + validate()
+// pass, then heuristically maps its free-text messages back onto a
+// document range (the WASM binding hands back no offsets at all).
+//
+// Pure Node, same as mtlxNode.js: must NOT require('vscode') anywhere —
+// the return shape here is plain objects ({ message, startLine,
+// startChar, endLine, endChar, severity }), not vscode.Diagnostic
+// instances, precisely so this stays independently loadable/testable
+// with plain `node`. extension.js converts to vscode.Diagnostic at the
+// boundary.
+'use strict';
+
+const mtlxNode = require('./mtlxNode');
+
+// ---------------------------------------------------------------------
+// Shared position mapping: precompute line-start offsets once per scan,
+// then binary-search to convert an absolute char offset to {line,
+// character} (0-indexed). The regex sweep handles CRLF correctly
+// without double-counting a line break: \r\n is consumed as a single
+// 2-char match, and offsets are only ever computed at real token
+// positions, never AT a break character itself.
+function computeLineStarts(text) {
+    const starts = [0];
+    const re = /\r\n|\r|\n/g;
+    let m;
+    while ((m = re.exec(text)) !== null) {
+        starts.push(m.index + m[0].length);
+    }
+    return starts;
+}
+
+function offsetToPos(lineStarts, offset) {
+    let lo = 0;
+    let hi = lineStarts.length - 1;
+    while (lo < hi) {
+        const mid = (lo + hi + 1) >> 1;
+        if (lineStarts[mid] <= offset) lo = mid;
+        else hi = mid - 1;
+    }
+    return { line: lo, character: offset - lineStarts[lo] };
+}
+
+// ---------------------------------------------------------------------
+// Tier 1 — scanXml(text) -> Array<{ message, startLine, startChar,
+// endLine, endChar, severity: 'error' }>
+//
+// A single forward-moving cursor walks the whole text. EVERY branch,
+// including every error branch, advances the cursor past whatever it
+// just failed to parse — a hand-rolled tokenizer that doesn't guarantee
+// this hangs the extension host on every keystroke (this runs on a
+// debounce timer per document change; see extension.js). Recovery after
+// a malformed tag/attribute skips forward to the next unquoted '>' (or
+// EOF) so one bad edit produces one diagnostic, not a cascade of
+// spurious ones over the rest of the file.
+function scanXml(text) {
+    const lineStarts = computeLineStarts(text);
+    const errors = [];
+    const addError = (startOffset, endOffset, message) => {
+        const s = offsetToPos(lineStarts, startOffset);
+        const e = offsetToPos(lineStarts, Math.max(endOffset, startOffset));
+        errors.push({ message, startLine: s.line, startChar: s.character, endLine: e.line, endChar: e.character, severity: 'error' });
+    };
+
+    const len = text.length;
+    // Open-tag stack: { name, start, end } — start/end is the tag NAME's
+    // own char range within its opening tag (e.g. the "node" in
+    // "<node "), used both for a mismatched-close-tag message and for
+    // the end-of-document "Unclosed tag" diagnostic, so each unclosed
+    // tag squiggles at its OWN opening position rather than all piling
+    // up at EOF.
+    const stack = [];
+
+    // Excludes '<' too (matching isAttrNameChar below) — without it, a
+    // stray '<' typo'd into a tag name (e.g. "<input<name=...") is
+    // silently swallowed into a garbage tag name instead of being
+    // flagged, which defeats tier 1's whole job on the (explicitly
+    // supported) path where tier 2/wasm is unavailable and this scanner
+    // is the only thing catching malformed XML at all.
+    const isTagNameChar = (ch) => ch !== undefined && !/[\s/><]/.test(ch);
+    const isAttrNameChar = (ch) => ch !== undefined && !/[\s=/>"'<]/.test(ch);
+    const isWs = (ch) => ch === ' ' || ch === '\t' || ch === '\n' || ch === '\r';
+
+    const readWhile = (start, pred) => {
+        let i = start;
+        while (i < len && pred(text[i])) i++;
+        return i;
+    };
+    const skipWs = (start) => readWhile(start, isWs);
+
+    // & entity refs, valid inside both top-level text runs and attribute
+    // values: &amp; &lt; &gt; &apos; &quot; or a numeric ref (&#123; /
+    // &#x1F;, case-insensitive x).
+    const ENTITY_RE = /^(?:amp|lt|gt|apos|quot);|^#[0-9]+;|^#[xX][0-9a-fA-F]+;/;
+    function checkEntities(start, end) {
+        for (let i = start; i < end; i++) {
+            if (text[i] !== '&') continue;
+            const rest = text.slice(i + 1, Math.min(end, i + 32));
+            if (!ENTITY_RE.test(rest)) {
+                addError(i, Math.min(end, i + 6), "Invalid entity reference (unescaped '&' or unknown entity)");
+            }
+        }
+    }
+
+    let cursor = 0;
+
+    outer:
+    while (cursor < len) {
+        const lt = text.indexOf('<', cursor);
+        if (lt === -1) {
+            checkEntities(cursor, len);
+            break;
+        }
+        checkEntities(cursor, lt);
+
+        if (text.startsWith('<!--', lt)) {
+            const close = text.indexOf('-->', lt + 4);
+            if (close === -1) {
+                addError(lt, lt + 3, 'Unterminated comment');
+                break outer;
+            }
+            cursor = close + 3;
+            continue;
+        }
+
+        if (text.startsWith('<![CDATA[', lt)) {
+            const close = text.indexOf(']]>', lt + 9);
+            if (close === -1) {
+                addError(lt, lt + 9, 'Unterminated CDATA section');
+                break outer;
+            }
+            cursor = close + 3;
+            continue;
+        }
+
+        if (text.startsWith('<?', lt)) {
+            const close = text.indexOf('?>', lt + 2);
+            if (close === -1) {
+                addError(lt, lt + 2, 'Unterminated processing instruction');
+                break outer;
+            }
+            cursor = close + 2;
+            continue;
+        }
+
+        if (text.startsWith('<!', lt)) {
+            // e.g. <!DOCTYPE ...> — scan to the next '>' not inside a
+            // quoted span. MaterialX files don't use DOCTYPE internal
+            // subsets, so this simplified (no nested '[' ']' tracking)
+            // scan is good enough.
+            let i = lt + 2;
+            let inQuote = null;
+            let found = -1;
+            while (i < len) {
+                const ch = text[i];
+                if (inQuote) {
+                    if (ch === inQuote) inQuote = null;
+                } else if (ch === '"' || ch === "'") {
+                    inQuote = ch;
+                } else if (ch === '>') {
+                    found = i;
+                    break;
+                }
+                i++;
+            }
+            if (found === -1) {
+                addError(lt, lt + 2, 'Unterminated declaration');
+                break outer;
+            }
+            cursor = found + 1;
+            continue;
+        }
+
+        if (text[lt + 1] === '/') {
+            // Closing tag: </name >
+            const nameStart = lt + 2;
+            const nameEnd = readWhile(nameStart, isTagNameChar);
+            const name = text.slice(nameStart, nameEnd);
+            if (!name) {
+                addError(lt, lt + 1, "Unexpected '<' — not a valid tag/comment/CDATA start");
+                cursor = lt + 1;
+                continue;
+            }
+            const afterWs = skipWs(nameEnd);
+            if (text[afterWs] !== '>') {
+                addError(lt, nameEnd, 'Unterminated tag </' + name + '>');
+                break outer;
+            }
+            cursor = afterWs + 1;
+            if (stack.length === 0) {
+                addError(nameStart, nameEnd, 'Closing tag </' + name + '> has no matching open tag');
+            } else {
+                const top = stack[stack.length - 1];
+                if (top.name !== name) {
+                    addError(nameStart, nameEnd, 'Mismatched closing tag: expected </' + top.name + '> but found </' + name + '>');
+                }
+                // Pop regardless of match — a single missing/extra tag
+                // must not cascade into an error per remaining tag.
+                stack.pop();
+            }
+            continue;
+        }
+
+        // Opening / self-closing tag: <name ...> or <name .../>
+        {
+            const nameStart = lt + 1;
+            const nameEnd = readWhile(nameStart, isTagNameChar);
+            const name = text.slice(nameStart, nameEnd);
+            if (!name) {
+                addError(lt, lt + 1, "Unexpected '<' — not a valid tag/comment/CDATA start");
+                cursor = lt + 1;
+                continue;
+            }
+
+            let i = nameEnd;
+            const seenAttrs = new Set();
+            let selfClosing = false;
+            let terminated = false;
+            let malformed = false;
+
+            const recoverToGt = (from) => {
+                const gt = text.indexOf('>', from);
+                terminated = gt !== -1;
+                return gt === -1 ? len : gt + 1;
+            };
+
+            while (i < len) {
+                i = skipWs(i);
+                if (i >= len) break;
+                const ch = text[i];
+
+                if (ch === '/') {
+                    if (text[i + 1] === '>') {
+                        selfClosing = true;
+                        terminated = true;
+                        i += 2;
+                    } else {
+                        addError(i, i + 1, 'Malformed attribute syntax in tag <' + name + '>');
+                        malformed = true;
+                        i = recoverToGt(i);
+                    }
+                    break;
+                }
+                if (ch === '>') {
+                    terminated = true;
+                    i += 1;
+                    break;
+                }
+                if (!isAttrNameChar(ch)) {
+                    addError(i, i + 1, 'Malformed attribute syntax in tag <' + name + '>');
+                    malformed = true;
+                    i = recoverToGt(i);
+                    break;
+                }
+
+                // Attribute name.
+                const attrNameStart = i;
+                const attrNameEnd = readWhile(i, isAttrNameChar);
+                const attrName = text.slice(attrNameStart, attrNameEnd);
+                if (seenAttrs.has(attrName)) {
+                    addError(attrNameStart, attrNameEnd, 'Duplicate attribute "' + attrName + '"');
+                } else {
+                    seenAttrs.add(attrName);
+                }
+
+                i = skipWs(attrNameEnd);
+                if (text[i] !== '=') {
+                    addError(attrNameStart, attrNameEnd, 'Attribute value for "' + attrName + '" is not properly quoted');
+                    malformed = true;
+                    i = recoverToGt(i);
+                    break;
+                }
+                i = skipWs(i + 1);
+                const quote = text[i];
+                if (quote !== '"' && quote !== "'") {
+                    addError(attrNameStart, attrNameEnd, 'Attribute value for "' + attrName + '" is not properly quoted');
+                    malformed = true;
+                    i = recoverToGt(i);
+                    break;
+                }
+                const valueStart = i + 1;
+                let j = valueStart;
+                let closedAt = -1;
+                while (j < len) {
+                    if (text[j] === quote) { closedAt = j; break; }
+                    if (text[j] === '<') break;
+                    j++;
+                }
+                if (closedAt === -1) {
+                    addError(attrNameStart, attrNameEnd, 'Attribute value for "' + attrName + '" is not properly quoted');
+                    malformed = true;
+                    i = recoverToGt(j);
+                    break;
+                }
+                checkEntities(valueStart, closedAt);
+                i = closedAt + 1;
+                // Loop back for the next attribute.
+            }
+
+            if (!terminated && !malformed) {
+                addError(lt, nameEnd, 'Unterminated tag <' + name + '>');
+                break outer;
+            }
+
+            cursor = i;
+            if (malformed) {
+                // Not well-formed — don't push onto the stack.
+                continue;
+            }
+            if (!selfClosing) {
+                stack.push({ name, start: nameStart, end: nameEnd });
+            }
+            continue;
+        }
+    }
+
+    // Any names left on the stack at EOF are unclosed — one diagnostic
+    // per remaining entry, positioned at that tag's OWN opening range.
+    for (const entry of stack) {
+        addError(entry.start, entry.end, 'Unclosed tag <' + entry.name + '>');
+    }
+
+    return errors;
+}
+
+// ---------------------------------------------------------------------
+// Tier 2 — best-effort position mapping for mtlxNode.validateSemantic's
+// free-text { text, elementName } messages (the WASM binding hands back
+// no character offsets at all). This is a heuristic, not exact: it
+// guesses at names the message is likely about and searches for the
+// first place that name appears as an attribute value, so it can
+// occasionally point at the wrong occurrence of a common name, or fall
+// back to a generic location. That's an accepted limitation of a
+// boolean-only validate() binding, not a bug to chase here.
+function escapeRegExp(s) {
+    return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// Finds `name = "candidate"` (or similar) and returns the char range of
+// just the candidate substring between the quotes, or null.
+function findCandidateRange(text, candidate) {
+    if (!candidate) return null;
+    const re = new RegExp('=\\s*"' + escapeRegExp(candidate) + '"');
+    const m = re.exec(text);
+    if (!m) return null;
+    const quoteAt = m.index + m[0].lastIndexOf('"');
+    return { start: quoteAt + 1, end: quoteAt + 1 + candidate.length };
+}
+
+function mapSemanticMessageToRange(text, lineStarts, item) {
+    const candidates = [];
+    if (item.elementName) candidates.push(item.elementName);
+    const quoted = item.text.match(/"([^"]+)"/g) || [];
+    for (const q of quoted) candidates.push(q.slice(1, -1));
+    if (item.text.indexOf('/') !== -1) {
+        const parts = item.text.split('/');
+        candidates.push(parts[parts.length - 1]);
+    }
+
+    for (const candidate of candidates) {
+        const range = findCandidateRange(text, candidate);
+        if (range) {
+            const s = offsetToPos(lineStarts, range.start);
+            const e = offsetToPos(lineStarts, range.end);
+            return { message: item.text, startLine: s.line, startChar: s.character, endLine: e.line, endChar: e.character, severity: 'error' };
+        }
+    }
+
+    // No candidate matched anything — fall back to the first
+    // <materialx tag's line, or {0,0}-{0,10} if the document doesn't
+    // even have one.
+    const idx = text.indexOf('<materialx');
+    if (idx !== -1) {
+        const s = offsetToPos(lineStarts, idx);
+        return { message: item.text, startLine: s.line, startChar: 0, endLine: s.line, endChar: 10, severity: 'error' };
+    }
+    return { message: item.text, startLine: 0, startChar: 0, endLine: 0, endChar: 10, severity: 'error' };
+}
+
+// ---------------------------------------------------------------------
+// Orchestration.
+
+let repoRoot = null;
+
+// Called once by extension.js at activation.
+function init(root) {
+    repoRoot = root;
+}
+
+async function validateDocument(text) {
+    const tier1 = scanXml(text);
+    if (tier1.length) return tier1; // tier 2 only runs when tier 1 is clean
+    if (!repoRoot) return tier1; // not initialized yet — stay silent
+
+    let tier2;
+    try {
+        tier2 = await mtlxNode.validateSemantic(repoRoot, text);
+    } catch (e) {
+        return tier1; // tier-2 unavailability is ALWAYS silent
+    }
+    if (!tier2 || !tier2.available || !tier2.messages || !tier2.messages.length) return tier1;
+
+    const lineStarts = computeLineStarts(text);
+    return tier2.messages.map((m) => mapSemanticMessageToRange(text, lineStarts, m));
+}
+
+// One-shot forward of mtlxNode's init-failure string, for extension.js
+// to log to the output channel exactly once. Returns null if there's
+// nothing new (never failed yet, or already consumed).
+function consumeTier2Warning() {
+    return mtlxNode.consumeInitError();
+}
+
+module.exports = { scanXml, init, validateDocument, consumeTier2Warning };

--- a/vscode_extension/src/validator.js
+++ b/vscode_extension/src/validator.js
@@ -335,29 +335,118 @@ function scanXml(text) {
 
 // ---------------------------------------------------------------------
 // Tier 2 — best-effort position mapping for mtlxNode.validateSemantic's
-// free-text { text, elementName } messages (the WASM binding hands back
-// no character offsets at all). This is a heuristic, not exact: it
-// guesses at names the message is likely about and searches for the
-// first place that name appears as an attribute value, so it can
-// occasionally point at the wrong occurrence of a common name, or fall
-// back to a generic location. That's an accepted limitation of a
-// boolean-only validate() binding, not a bug to chase here.
+// free-text { text, tag, attrs, elementName } messages (the WASM binding
+// hands back no character offsets at all). The PRIMARY path
+// (findElementNameRange, used when the message line carried a
+// serialized element) disambiguates same-named elements living under
+// different parents by scoring how many of the offending element's OTHER
+// attributes match; the FALLBACK path (findCandidateRange, used only
+// when there's no serialized element to key off of) is a cruder
+// heuristic that just searches for a bare attribute VALUE anywhere in
+// the document, so it can occasionally point at the wrong occurrence of
+// a common name. That's an accepted limitation of a boolean-only
+// validate() binding, not a bug to chase here.
 function escapeRegExp(s) {
     return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 // Finds `name = "candidate"` (or similar) and returns the char range of
-// just the candidate substring between the quotes, or null.
+// just the candidate substring between the quotes, or null. FALLBACK
+// ONLY — see mapSemanticMessageToRange; used when the message line has
+// no serialized element to disambiguate with, so this settles for the
+// FIRST occurrence anywhere in the document.
 function findCandidateRange(text, candidate) {
     if (!candidate) return null;
     const re = new RegExp('=\\s*"' + escapeRegExp(candidate) + '"');
     const m = re.exec(text);
     if (!m) return null;
-    const quoteAt = m.index + m[0].lastIndexOf('"');
+    // OPENING quote, not the closing one: the pattern ends `="` right
+    // before the value, so the FIRST quote in the match (indexOf) is the
+    // opening one. Using lastIndexOf here (the previous bug) grabs the
+    // CLOSING quote instead, shifting the reported range one character
+    // past the end of the value.
+    const quoteAt = m.index + m[0].indexOf('"');
     return { start: quoteAt + 1, end: quoteAt + 1 + candidate.length };
 }
 
+// Scores how many of `attrs` (excluding `name`, already used to locate
+// the candidate tag) are present verbatim as attr="value" inside
+// `tagText` — used by findElementNameRange to disambiguate multiple
+// same-tag, same-name elements (e.g. two <input name="in"> under
+// different parent nodes) by how well their OTHER attributes match the
+// failing element's own serialized form.
+function scoreAttrs(tagText, attrs) {
+    let score = 0;
+    for (const key in attrs) {
+        if (!Object.prototype.hasOwnProperty.call(attrs, key) || key === 'name') continue;
+        if (tagText.indexOf(key + '="' + attrs[key] + '"') !== -1) score++;
+    }
+    return score;
+}
+
+// PRIMARY path: finds the best-matching `<tag ... name="NAME" ...>`
+// occurrence in the document for a message line that carried a
+// serialized element (mtlxNode.js's ELEMENT_TAG_RE). The serialized
+// message line has all of the offending element's OWN attributes but no
+// parent path, so `name` alone can collide with an unrelated element of
+// the same tag/name elsewhere in the document — every occurrence is
+// scored by how many of the OTHER attrs (type, nodename, nodegraph,
+// interfacename, value, ...) match verbatim, and the highest-scoring hit
+// wins (first hit wins ties). Returns the char range of just the `name`
+// attribute's VALUE (between its quotes), or null if `tag`/`attrs.name`
+// don't match anywhere in the document.
+function findElementNameRange(text, tag, attrs) {
+    const name = attrs && attrs.name;
+    if (!tag || !name) return null;
+    const re = new RegExp('<' + escapeRegExp(tag) + '\\b[^>]*?\\bname\\s*=\\s*"' + escapeRegExp(name) + '"', 'g');
+    let best = null;
+    let bestScore = -1;
+    let m;
+    while ((m = re.exec(text)) !== null) {
+        // Candidate's FULL open tag, from the match start out to the
+        // next '>' — the match itself may stop mid-attribute-list (it's
+        // non-greedy up to the `name` attribute), so this widens the
+        // scored text to include attributes that come AFTER `name` too.
+        const gt = text.indexOf('>', m.index);
+        const tagText = gt === -1 ? m[0] : text.slice(m.index, gt + 1);
+        const score = scoreAttrs(tagText, attrs);
+        if (score > bestScore) {
+            bestScore = score;
+            // The match ends exactly at the `name` value's closing
+            // quote (non-greedy up to the literal `name="NAME"`), so the
+            // OPENING quote is the first '"' at or after where `name`
+            // itself starts in m[0] — found with indexOf (never
+            // lastIndexOf), so a `name`-like substring earlier in the
+            // tag's other attribute values can't shift the result.
+            const nameIdx = m[0].search(/\bname\s*=\s*"/);
+            if (nameIdx !== -1) {
+                const quoteAt = m.index + m[0].indexOf('"', nameIdx);
+                best = { start: quoteAt + 1, end: quoteAt + 1 + name.length };
+            }
+        }
+        if (re.lastIndex === m.index) re.lastIndex++; // guard against a zero-length match
+    }
+    return best;
+}
+
 function mapSemanticMessageToRange(text, lineStarts, item) {
+    // Primary: the message line carried a serialized element — scan the
+    // document for the best-matching `<tag ... name="...">` (scored
+    // against the element's OTHER attributes) rather than trusting the
+    // first bare name value found anywhere.
+    if (item.tag && item.attrs && item.attrs.name) {
+        const range = findElementNameRange(text, item.tag, item.attrs);
+        if (range) {
+            const s = offsetToPos(lineStarts, range.start);
+            const e = offsetToPos(lineStarts, range.end);
+            return { message: item.text, startLine: s.line, startChar: s.character, endLine: e.line, endChar: e.character, severity: 'error' };
+        }
+    }
+
+    // Fallback: no serialized element on this line (or its tag/name
+    // didn't match anywhere in the document) — fall back to the older,
+    // cruder heuristic of searching for any quoted substring from the
+    // message text as a bare attribute VALUE anywhere in the document.
     const candidates = [];
     if (item.elementName) candidates.push(item.elementName);
     const quoted = item.text.match(/"([^"]+)"/g) || [];


### PR DESCRIPTION
### Add specDocs.js for MaterialX specification extraction and validator js for XML diagnostics

- Implemented specDocs.js to extract descriptions from MaterialX specification markdown files, providing a clean API for retrieving node documentation.
- Introduced validator.js to perform two-tier diagnostics on .mtlx files, including a lightweight XML well-formedness scanner and a semantic validation layer using mtlxNode.
- Both modules are designed to operate independently of the VS Code API, ensuring they can be tested and used in a Node.js environment.

### feat: add MaterialX hover port-table matching, extract port tables in specDocs, improve validator element disambiguation