### PR TITLE
Refactor for code reuse and readability across site and VS Code extension

### DIFF
--- a/js/docs-app.jsx
+++ b/js/docs-app.jsx
@@ -61,6 +61,69 @@
             return candidates[0];
         };
 
+        // Which table(s) to render for the current selection: documented
+        // nodes with SEVERAL port tables under one heading (e.g.
+        // `multiply`: scalar/vector table + matrixNN table) narrow to the
+        // ONE table matching the selected signature's output type once
+        // there's more than one live signature to choose from — otherwise
+        // every table renders stacked, which reads as duplicated content.
+        // Single-table documented nodes are unaffected. Undocumented nodes
+        // show the ONE auto-generated table matching the selected group.
+        // groupDefVersions and dedupeDefsBySignature (js/docs/port-
+        // tables.jsx) walk the SAME getMatchingNodeDefs(name) list in the
+        // same order with the same signature key (nodeDefSigKey), so index
+        // `sig` lines up across sigGroups and autoDoc.tables — see
+        // buildAutoTablesFromDefs. The `sigCount > 1` gate here must stay
+        // in sync with the same gate on typesOverride/defaultsOverride at
+        // the call site below (all three only read live nodedef data once
+        // there's more than one signature to disambiguate with).
+        const resolveDisplayTables = (portTables, sigCount, selectedGroup, autoDoc, sig, effectiveTables) =>
+            portTables.length > 0
+                ? (portTables.length > 1 && sigCount > 1 && selectedGroup
+                    ? [pickTableForType(portTables, selectedGroup.type) || portTables[0]]
+                    : portTables)
+                : (sigCount > 1 ? [autoDoc && autoDoc.tables && autoDoc.tables[sig]].filter(Boolean)
+                    : effectiveTables);
+
+        // Previewability decided from the selected signature's exact types
+        // (group/version data), passed down to Node3DPreview — the
+        // previewer must not re-derive signature info from nodedefs.
+        // Returns a user-facing notice string when the signature can't be
+        // previewed in isolation, else null (also null before the groups
+        // have loaded, and for multi-output/translation signatures, which
+        // the previewer decides on its own — see its working translation
+        // branch).
+        const resolvePreviewDisabled = (selectedGroup, selectedVersion, selectedNode) => {
+            if (!selectedGroup || !selectedVersion) return null; // groups not loaded — previewer decides
+            const CLOSURE = ['BSDF', 'EDF', 'VDF'];
+            const VIEWABLE = ['color3', 'color4', 'float', 'vector2', 'vector3', 'vector4'];
+            const out = selectedGroup.type;
+            // '+'-joined multi-output signature, or the literal 'multioutput'
+            // type string a real multi-output nodedef's getType() returns —
+            // no single primary output type to gate on; multioutput
+            // signatures (including translation graphs) are deferred to the
+            // previewer, which has a working translation branch.
+            if (!out || out.indexOf('+') !== -1 || out === 'multioutput') return null;
+            const inTypes = Object.values(selectedVersion.inputTypes || {});
+            const hasClosureInput = inTypes.some((t) => CLOSURE.indexOf(t) !== -1);
+            // A surfaceshader with unbound closure (BSDF/EDF) inputs passes
+            // the VIEWABLE-ish gate below but renders as a meaningless black
+            // ball — catch it before the generic previewable check.
+            if (out === 'surfaceshader' && hasClosureInput) {
+                return `No preview for "${selectedNode.name}" — its closure inputs (BSDF/EDF) are unbound in an isolated preview; open it in the node graph editor and wire it up to see a result.`;
+            }
+            const previewable = VIEWABLE.indexOf(out) !== -1
+                || out === 'surfaceshader'
+                || out === 'material'
+                || (out === 'BSDF' && !hasClosureInput)
+                || (out === 'EDF' && !hasClosureInput);
+            if (previewable) return null;
+            if (CLOSURE.indexOf(out) !== -1 && hasClosureInput) {
+                return `No preview for "${selectedNode.name}" — closure operators (BSDF/EDF/VDF in and out) aren't previewed in isolation. Open it in the node graph editor to see it in context.`;
+            }
+            return `No preview for "${selectedNode.name}" — it outputs ${out}, which isn't a viewable color surface. Try it in the node graph editor.`;
+        };
+
         function App({ active = true, inline = false, initialHash } = {}) {
             // Embed mode: focused single-node view, iframed by the graph
             // editor (index.html?embed=1#/<lib>/<group>/<name>) — flag is
@@ -607,24 +670,11 @@
             const sigCount = sigGroups.length;
             const sig = Math.min(sigIndex, Math.max(sigCount - 1, 0));
             const selectedGroup = sigGroups[sig] || null;
-            // Documented nodes: when the spec write-up authors SEVERAL port
-            // tables under one heading (e.g. `multiply`: scalar/vector table
-            // + matrixNN table) and there's more than one live signature to
-            // choose from, show only the ONE table matching the selected
-            // signature's output type — otherwise every table renders
-            // stacked, which reads as duplicated content. Single-table
-            // documented nodes are unaffected. Undocumented nodes show the
-            // ONE auto-generated table matching the selected group.
-            // groupDefVersions and dedupeDefsBySignature walk the SAME
-            // getMatchingNodeDefs(name) list in the same order with the same
-            // signature key (nodeDefSigKey), so index `sig` lines up across
-            // sigGroups and autoDoc.tables — see buildAutoTablesFromDefs.
-            const displayTables = portTables.length > 0
-                ? (portTables.length > 1 && sigCount > 1 && selectedGroup
-                    ? [pickTableForType(portTables, selectedGroup.type) || portTables[0]]
-                    : portTables)
-                : (sigCount > 1 ? [autoDoc && autoDoc.tables && autoDoc.tables[sig]].filter(Boolean)
-                    : effectiveTables);
+            // Which table(s) to render — see resolveDisplayTables above for
+            // the full selection rules (documented multi-table narrowing,
+            // undocumented auto-table pick, sigGroups/autoDoc.tables index
+            // alignment).
+            const displayTables = resolveDisplayTables(portTables, sigCount, selectedGroup, autoDoc, sig, effectiveTables);
             // Concrete type this signature previews as (null → auto-pick).
             // While nodeVersionGroups is still loading (async), fall back to
             // the markdown-table-derived heuristic so the preview isn't
@@ -648,38 +698,9 @@
             const defaultsOverride = selectedVersion && (sigCount > 1 || !selectedVersion.isDefaultVersion)
                 ? selectedVersion.defaults : null;
             // Previewability decided HERE, where the selected signature's exact
-            // types are known, and passed down — the previewer must not re-derive
-            // signature info from nodedefs.
-            const previewDisabled = (() => {
-                if (!selectedGroup || !selectedVersion) return null; // groups not loaded — previewer decides
-                const CLOSURE = ['BSDF', 'EDF', 'VDF'];
-                const VIEWABLE = ['color3', 'color4', 'float', 'vector2', 'vector3', 'vector4'];
-                const out = selectedGroup.type;
-                // '+'-joined multi-output signature, or the literal 'multioutput'
-                // type string a real multi-output nodedef's getType() returns —
-                // no single primary output type to gate on; multioutput
-                // signatures (including translation graphs) are deferred to the
-                // previewer, which has a working translation branch.
-                if (!out || out.indexOf('+') !== -1 || out === 'multioutput') return null;
-                const inTypes = Object.values(selectedVersion.inputTypes || {});
-                const hasClosureInput = inTypes.some((t) => CLOSURE.indexOf(t) !== -1);
-                // A surfaceshader with unbound closure (BSDF/EDF) inputs passes
-                // the VIEWABLE-ish gate below but renders as a meaningless black
-                // ball — catch it before the generic previewable check.
-                if (out === 'surfaceshader' && hasClosureInput) {
-                    return `No preview for "${selectedNode.name}" — its closure inputs (BSDF/EDF) are unbound in an isolated preview; open it in the node graph editor and wire it up to see a result.`;
-                }
-                const previewable = VIEWABLE.indexOf(out) !== -1
-                    || out === 'surfaceshader'
-                    || out === 'material'
-                    || (out === 'BSDF' && !hasClosureInput)
-                    || (out === 'EDF' && !hasClosureInput);
-                if (previewable) return null;
-                if (CLOSURE.indexOf(out) !== -1 && hasClosureInput) {
-                    return `No preview for "${selectedNode.name}" — closure operators (BSDF/EDF/VDF in and out) aren't previewed in isolation. Open it in the node graph editor to see it in context.`;
-                }
-                return `No preview for "${selectedNode.name}" — it outputs ${out}, which isn't a viewable color surface. Try it in the node graph editor.`;
-            })();
+            // types are known, and passed down — see resolvePreviewDisabled
+            // above for the type-gating rules.
+            const previewDisabled = resolvePreviewDisabled(selectedGroup, selectedVersion, selectedNode);
             // Column set for the displayed table(s).
             const columns = displayTables.length > 0 ? unionColumns(displayTables) : [];
             // Footnote references: map key -> {n, url, text}, numbered by

--- a/js/docs/port-tables.jsx
+++ b/js/docs/port-tables.jsx
@@ -24,20 +24,31 @@
             return [];
         };
 
+        // def.getActiveInputs()/getActiveOutputs(), falling back to
+        // getInputs()/getOutputs() on older bindings that don't expose the
+        // Active variants — the vecToArray-wrapped pattern repeated at
+        // every nodedef-walking helper below.
+        const defInputs = (def) => vecToArray(def.getActiveInputs ? def.getActiveInputs()
+            : (def.getInputs ? def.getInputs() : null));
+        const defOutputs = (def) => vecToArray(def.getActiveOutputs ? def.getActiveOutputs()
+            : (def.getOutputs ? def.getOutputs() : null));
+        // An input/output element's type, or '' if the wasm binding throws
+        // (e.g. a detached/invalid element) — used wherever a type is only
+        // needed for a display/signature string and a thrown exception
+        // shouldn't abort the whole computation.
+        const safeType = (el) => { try { return el.getType(); } catch (e) { return ''; } };
+
         // A TYPE-SIGNATURE key for a WASM nodedef — the ordered input types
         // plus the resolved output type, independent of version. Two
         // nodedefs sharing this key are the SAME signature at different
         // VERSIONS (standard_surface 1.0.1 / 1.0.0: identical ports, only
         // defaults differ) — see dedupeDefsBySignature.
         const nodeDefSigKey = (def) => {
-            const inputs = vecToArray(def.getActiveInputs ? def.getActiveInputs()
-                : (def.getInputs ? def.getInputs() : null));
-            const inTypes = inputs.map((inp) => { try { return inp.getType(); } catch (e) { return ''; } }).join(',');
+            const inTypes = defInputs(def).map(safeType).join(',');
             let outType = '';
             try { outType = def.getType(); } catch (e) { /* none */ }
-            const outs = vecToArray(def.getActiveOutputs ? def.getActiveOutputs()
-                : (def.getOutputs ? def.getOutputs() : null));
-            if (outs.length) outType = outs.map((o) => { try { return o.getType(); } catch (e) { return ''; } }).join('+');
+            const outs = defOutputs(def);
+            if (outs.length) outType = outs.map(safeType).join('+');
             return outType + '|' + inTypes;
         };
 
@@ -72,8 +83,7 @@
                 try { isDefaultVersion = !!(def.getDefaultVersion && def.getDefaultVersion()); } catch (e) { /* none */ }
                 const defaults = {};
                 const inputTypes = {};
-                const inputs = vecToArray(def.getActiveInputs ? def.getActiveInputs()
-                    : (def.getInputs ? def.getInputs() : null));
+                const inputs = defInputs(def);
                 for (const inp of inputs) {
                     let nm = '', dv = '';
                     try { nm = inp.getName(); } catch (e) { /* skip */ }
@@ -83,8 +93,7 @@
                     try { inputTypes[nm] = inp.getType(); } catch (e) { /* none */ }
                 }
                 const outputTypes = {};
-                const outputs = vecToArray(def.getActiveOutputs ? def.getActiveOutputs()
-                    : (def.getOutputs ? def.getOutputs() : null));
+                const outputs = defOutputs(def);
                 if (outputs.length) {
                     for (const out of outputs) {
                         let nm = '';
@@ -161,8 +170,7 @@
             for (const def of defs) {
                 const ports = {};
                 let anyEnum = false;
-                const inputs = vecToArray(def.getActiveInputs ? def.getActiveInputs()
-                    : (def.getInputs ? def.getInputs() : null));
+                const inputs = defInputs(def);
                 for (const inp of inputs) {
                     let dv = '', enumv = '';
                     try { dv = (inp.getValueString && inp.getValueString()) || ''; } catch (e) { /* none */ }
@@ -171,8 +179,7 @@
                     if (enumv) { row.accepted_values = enumv; anyEnum = true; }
                     ports[inp.getName()] = row;
                 }
-                const outs = vecToArray(def.getActiveOutputs ? def.getActiveOutputs()
-                    : (def.getOutputs ? def.getOutputs() : null));
+                const outs = defOutputs(def);
                 if (outs.length === 0) {
                     let t = 'output';
                     try { t = def.getType(); } catch (e) { /* keep */ }
@@ -279,7 +286,8 @@
 
         const signatureLabel = (table) => {
             const ports = table.ports || {};
-            const names = Object.keys(ports);            const inTypes = uniqTypeTokens(names
+            const names = Object.keys(ports);
+            const inTypes = uniqTypeTokens(names
                 .filter(n => !isOutputPort(n, ports[n]))
                 .map(n => resolveType(ports, n)));
             const outTypes = uniqTypeTokens(names
@@ -502,6 +510,7 @@
 
         // ---- public API ----
         // headerLabel, the column-layout consts (CANONICAL_ORDER etc.),
+        // the nodedef-walking helpers (defInputs, defOutputs, safeType),
         // and the signature-label helper cluster (SAME_AS_RE, resolveType,
         // isOutputPort, uniqTypeTokens, signatureLabel, SIG_CONCRETE_TOKEN,
         // SIG_PREVIEW_PREFERENCE, SIG_FAMILY_EXPANSIONS, expandSigToken)

--- a/js/graph-app.jsx
+++ b/js/graph-app.jsx
@@ -373,8 +373,8 @@
                     // second rAF lets the first frame (with scopeBusy=true
                     // already committed and painted) land before the
                     // rebuild-triggering setScope below runs.
-                    await new Promise((r) => requestAnimationFrame(r));
-                    await new Promise((r) => requestAnimationFrame(r));
+                    await nextFrame();
+                    await nextFrame();
                     setScope(next);
                 })();
             };
@@ -568,8 +568,8 @@
 
             // Connect-time literal stash (item 4a): the moment a wire is
             // attached, the pre-existing literal on that input is destroyed
-            // (removeAttribute('value') at every connect site below) so the
-            // document doesn't carry both a wire AND a stale value.
+            // (mxRemoveAttr(point, 'value') at every connect site below) so
+            // the document doesn't carry both a wire AND a stale value.
             // Stashing it here lets severConnection (below) bring it
             // straight back when the wire is later removed, instead of
             // falling back to the nodedef default. Keyed by the input
@@ -726,12 +726,12 @@
                 setBusy(true);
                 setStatus('Parsing ' + path + ' \u2026');
                 try {
-                    let xml = await map[path].text();
+                    const { raw, resolved } = await readMtlxText(map[path], path, map);
                     // Validate source-of-truth (noteDocXml, declared near
                     // docRev above): the RAW, as-opened text of the picked
-                    // file — captured BEFORE xi:include resolution splices
-                    // in other files' content below, and well before
-                    // parseMtlxDocument or any healing ever touches it.
+                    // file — NOT the xi:include-resolved text the parse
+                    // below consumes, and well before parseMtlxDocument or
+                    // any healing ever touches it.
                     // This is exactly what the VS Code extension's own
                     // tier-2 validator (vscode_extension/src/mtlxNode.js's
                     // validateSemantic) validates too — it readFromXmlString's
@@ -739,12 +739,8 @@
                     // so capturing the resolved/merged text here instead
                     // would let the graph's Validate button diverge from
                     // what VS Code shows for any document using includes.
-                    noteDocXml(xml);
-                    if (/<xi:include\b/.test(xml)) {
-                        const dir = path.indexOf('/') >= 0 ? path.slice(0, path.lastIndexOf('/')) : '';
-                        xml = await resolveIncludes(xml, map, dir);
-                    }
-                    const p = await parseMtlxDocument(xml);
+                    noteDocXml(raw);
+                    const p = await parseMtlxDocument(resolved);
                     p.label = path;
                     setParsed(p);
                     setScope('');
@@ -918,22 +914,18 @@
 
                 let p;
                 try {
-                    let xml = await merged[pick].text();
+                    const { raw, resolved } = await readMtlxText(merged[pick], pick, merged);
                     // Validate source-of-truth (noteDocXml, declared near
-                    // docRev above): the raw external-edit text, captured
-                    // BEFORE xi:include resolution (parity with
-                    // loadDocument's raw-text capture) and critically
-                    // BEFORE either early return below — the parse-failure
+                    // docRev above): the raw external-edit text — not the
+                    // xi:include-resolved text (parity with loadDocument's
+                    // raw-text capture) — and critically noted BEFORE
+                    // either early return below: the parse-failure
                     // return (a mid-edit broken file should still turn the
                     // Validate button red with the parse error, exactly
                     // what VS Code's own Problems panel shows for it) and
                     // the sameAsCurrent return (see its own comment).
-                    noteDocXml(xml);
-                    if (/<xi:include\b/.test(xml)) {
-                        const dir = pick.indexOf('/') >= 0 ? pick.slice(0, pick.lastIndexOf('/')) : '';
-                        xml = await resolveIncludes(xml, merged, dir);
-                    }
-                    p = await parseMtlxDocument(xml);
+                    noteDocXml(raw);
+                    p = await parseMtlxDocument(resolved);
                 } catch (e) {
                     // The live session must survive a mid-edit broken file
                     // (e.g. the user is mid-keystroke on an unbalanced tag
@@ -1311,8 +1303,8 @@
                         if (!el) continue;
                         const x = Math.round((pos.x / 240) * 10000) / 10000;
                         const y = Math.round((pos.y / 240) * 10000) / 10000;
-                        mxSafe(() => { el.setAttribute('xpos', String(x)); return true; }, false);
-                        mxSafe(() => { el.setAttribute('ypos', String(y)); return true; }, false);
+                        mxSetAttr(el, 'xpos', String(x));
+                        mxSetAttr(el, 'ypos', String(y));
                         wrote = true;
                     }
                     if (wrote) markDirty();
@@ -1528,6 +1520,33 @@
                 return true; // continuous rAF shows it next frame
             };
 
+            // Resolve a flow id ('n:'/'g:' prefixed) to its document
+            // element — a real node looked up on `container`, a nodegraph
+            // instance looked up on `doc` regardless of scope. Shared by
+            // applyParamEdit and applyColorspace; connectionPoint's own
+            // n:/g:/o: resolution is richer (it also falls back to
+            // getChild) and stays separate.
+            const elForFlowId = (container, doc, id) => {
+                const name = id.slice(2);
+                if (id.indexOf('n:') === 0 && container) return mxSafe(() => container.getNode(name), null);
+                if (id.indexOf('g:') === 0) return mxSafe(() => doc.getNodeGraph(name), null);
+                return null;
+            };
+
+            // Shared repatch tail: re-derive a node's visible port list
+            // from an updated allInputs array — re-deriving (instead of
+            // caching `inputs`) is what makes a value landing back at its
+            // nodedef default drop the row out of "set inputs" mode.
+            const withPatchedInputs = (n, upd) => {
+                const allInputs = (n.data.allInputs || n.data.inputs || []).map(upd);
+                return Object.assign({}, n, {
+                    data: Object.assign({}, n.data, {
+                        allInputs,
+                        inputs: visiblePortsFor(allInputs, n.data.portMode || 'authored'),
+                    }),
+                });
+            };
+
             // Write a new literal value onto an input — into the real MaterialX
             // document when the bindings allow it, and always into the on-screen
             // flow. The flow is patched IN PLACE (no rebuild) so layout, viewport
@@ -1547,9 +1566,7 @@
                     && fMeta.defValue !== undefined && newValue === fMeta.defValue;
                 if (parsed) {
                     const name = nodeId.slice(2);
-                    const container = scope
-                        ? mxSafe(() => parsed.doc.getNodeGraph(scope), null)
-                        : parsed.doc;
+                    const container = scopeContainer();
                     let wrote = false;
                     let fastType = '';
                     if (nodeId.indexOf('i:') === 0) {
@@ -1561,9 +1578,7 @@
                         wrote = !!target && mxSafe(() => { mxWriteValue(target, newValue, mxElType(target)); return true; }, false);
                         fastType = target ? mxSafe(() => mxElType(target), '') : '';
                     } else {
-                        let el = null;
-                        if (nodeId.indexOf('n:') === 0 && container) el = mxSafe(() => container.getNode(name), null);
-                        else if (nodeId.indexOf('g:') === 0) el = mxSafe(() => parsed.doc.getNodeGraph(name), null);
+                        const el = elForFlowId(container, parsed.doc, nodeId);
                         if (revertsToDefault) {
                             // Drop the authored element (when there is one) —
                             // the nodedef default takes over again.
@@ -1602,15 +1617,7 @@
                         const upd = (i) => i.name === inputName
                             ? Object.assign({}, i, { value: newValue, authored: !revertsToDefault })
                             : i;
-                        const allInputs = (n.data.allInputs || n.data.inputs || []).map(upd);
-                        return Object.assign({}, n, {
-                            data: Object.assign({}, n.data, {
-                                allInputs,
-                                // Re-derive the visible rows: a value back at
-                                // its default drops out of "set inputs" mode.
-                                inputs: visiblePortsFor(allInputs, n.data.portMode || 'authored'),
-                            }),
-                        });
+                        return withPatchedInputs(n, upd);
                     }),
                 }));
             };
@@ -1642,16 +1649,12 @@
                 if (!parsed) return;
                 const type = inputType || 'filename';
                 const name = nodeId.slice(2);
-                const container = scope
-                    ? mxSafe(() => parsed.doc.getNodeGraph(scope), null)
-                    : parsed.doc;
+                const container = scopeContainer();
                 let target = null;
                 if (nodeId.indexOf('i:') === 0) {
                     target = container ? mxSafe(() => container.getInput(name), null) : null;
                 } else {
-                    let el = null;
-                    if (nodeId.indexOf('n:') === 0 && container) el = mxSafe(() => container.getNode(name), null);
-                    else if (nodeId.indexOf('g:') === 0) el = mxSafe(() => parsed.doc.getNodeGraph(name), null);
+                    const el = elForFlowId(container, parsed.doc, nodeId);
                     // The input must exist to carry the attribute (an empty
                     // value is valid); created with a guaranteed type.
                     if (el) target = ensureTypedInput(parsed.doc, el, inputName, type);
@@ -1661,17 +1664,13 @@
                     return;
                 }
                 if (cs) {
-                    mxSafe(() => {
-                        if (typeof target.setColorSpace === 'function') target.setColorSpace(cs);
-                        else target.setAttribute('colorspace', cs);
-                        return true;
-                    }, false);
+                    mxSetColorspace(target, cs);
                 } else {
-                    mxSafe(() => { target.removeAttribute('colorspace'); return true; }, false);
+                    mxRemoveAttr(target, 'colorspace');
                     // An input element now carrying NOTHING reverts outright
                     // (same rule as severConnection / value reverts).
-                    const bare = !mxSafe(() => target.getAttribute('value'), '')
-                        && !CONN_ATTRS.some((a) => mxSafe(() => target.getAttribute(a), ''));
+                    const bare = !mxElAttr(target, 'value')
+                        && !CONN_ATTRS.some((a) => mxElAttr(target, a));
                     if (bare && nodeId.indexOf('n:') === 0) {
                         const par = mxSafe(() => target.getParent(), null);
                         if (par) mxSafe(() => { par.removeChild(inputName); return true; }, false);
@@ -1690,13 +1689,7 @@
                                 authored: !!cs || i.connected
                                     || (i.defValue !== undefined && i.value !== i.defValue),
                             });
-                        const allInputs = (n.data.allInputs || n.data.inputs || []).map(upd);
-                        return Object.assign({}, n, {
-                            data: Object.assign({}, n.data, {
-                                allInputs,
-                                inputs: visiblePortsFor(allInputs, n.data.portMode || 'authored'),
-                            }),
-                        });
+                        return withPatchedInputs(n, upd);
                     }),
                 }));
             };
@@ -1755,10 +1748,7 @@
                     setError('Send to Viewer failed: ' + error);
                     return;
                 }
-                const files = {};
-                Object.keys(fileMapRef.current || {}).forEach((k) => {
-                    if (!/\.mtlx$/i.test(k)) files[k] = fileMapRef.current[k];
-                });
+                const files = looseFilesFrom(fileMapRef.current);
                 openInViewer({ xml, name: defaultExportBase(), files });
             };
 
@@ -1806,11 +1796,7 @@
                         }
                     }
                 }
-                const a = document.createElement('a');
-                a.href = URL.createObjectURL(blob);
-                a.download = base + '.mtlx';
-                a.click();
-                setTimeout(() => URL.revokeObjectURL(a.href), 5000);
+                downloadBlob(blob, base + '.mtlx');
                 markSaved(); // the just-downloaded file matches the current document
                 return true;
             };
@@ -1855,11 +1841,7 @@
                     setError('Export failed: ' + String(e && e.message || e));
                     return false;
                 }
-                const a = document.createElement('a');
-                a.href = URL.createObjectURL(blob);
-                a.download = name + '.zip';
-                a.click();
-                setTimeout(() => URL.revokeObjectURL(a.href), 5000);
+                downloadBlob(blob, name + '.zip');
                 markSaved(); // the just-downloaded zip's document matches the current one
                 return true;
             };
@@ -1944,9 +1926,9 @@
             //  (1) xi:include: "look" files (e.g. "Brass (tiled look)")
             //      pull in a separate sibling .mtlx for the actual
             //      material — resolveIncludes (js/mtlx-engine.js:535,
-            //      invoked from loadDocument above) inlines those from
-            //      the SAME dropped-file map this preset flow builds, but
-            //      only if that sibling doc was actually fetched into it.
+            //      via loadDocument's readMtlxText above) inlines those
+            //      from the SAME dropped-file map this preset flow builds,
+            //      but only if that sibling doc was actually fetched into it.
             //  (2) filename refs that escape the preset's own directory
             //      via literal "../" segments in the authored value AND/OR
             //      an inheritable `fileprefix="..."` attribute (MaterialX
@@ -2248,20 +2230,21 @@
 
             const clearConnAttrs = (point) => {
                 for (const a of CONN_ATTRS) {
-                    if (!mxSafe(() => point.getAttribute(a), '')) continue;
-                    const ok = mxSafe(() => { point.removeAttribute(a); return true; }, false);
-                    if (!ok) mxSafe(() => { point.setAttribute(a, ''); return true; }, false);
+                    if (!mxElAttr(point, a)) continue;
+                    const ok = mxRemoveAttr(point, a);
+                    if (!ok) mxSetAttr(point, a, '');
                 }
             };
 
             // Stash a connection point's about-to-be-destroyed literal
-            // (item 4a) — called immediately before every removeAttribute
-            // ('value') below that runs as part of writing a NEW connection
-            // onto an input, so severConnection can bring it back later
-            // instead of falling back to the nodedef default. A no-op when
-            // the input carries no value, or its path can't be resolved.
+            // (item 4a) — called immediately before every mxRemoveAttr
+            // (…, 'value') below that runs as part of writing a NEW
+            // connection onto an input, so severConnection can bring it
+            // back later instead of falling back to the nodedef default. A
+            // no-op when the input carries no value, or its path can't be
+            // resolved.
             const stashValueBeforeRemoval = (point) => {
-                const val = mxSafe(() => point.getAttribute('value'), '');
+                const val = mxElAttr(point, 'value');
                 if (!val) return;
                 const key = mxSafe(() => point.getNamePath(), '');
                 if (!key) return;
@@ -2294,15 +2277,15 @@
                 const key = mxSafe(() => point.getNamePath(), '');
                 const stashed = key && stashedValuesRef.current[key];
                 if (stashed) {
-                    mxSafe(() => { point.setAttribute('value', stashed); return true; }, false);
+                    mxSetAttr(point, 'value', stashed);
                     delete stashedValuesRef.current[key];
                     return stashed;
                 }
                 const kind = String(targetId || '').slice(0, 2);
                 if (kind !== 'n:' && kind !== 'g:') return null;
-                const curVal = mxSafe(() => point.getAttribute('value'), '');
+                const curVal = mxElAttr(point, 'value');
                 if (curVal) return curVal;
-                if (mxSafe(() => point.getAttribute('colorspace'), '')) return null;
+                if (mxElAttr(point, 'colorspace')) return null;
                 const par = mxSafe(() => point.getParent(), null);
                 const nm = mxElName(point);
                 if (par && nm) {
@@ -2385,13 +2368,7 @@
                                 ? { connected: false, authored: false, keepRow: true,
                                     value: i.defValue !== undefined ? i.defValue : i.value }
                                 : { connected: false })));
-                const allInputs = (n.data.allInputs || n.data.inputs || []).map(upd);
-                return Object.assign({}, n, {
-                    data: Object.assign({}, n.data, {
-                        allInputs,
-                        inputs: visiblePortsFor(allInputs, n.data.portMode || 'authored'),
-                    }),
-                });
+                return withPatchedInputs(n, upd);
             };
 
             // Switch the displayed node to another SIGNATURE (a distinct
@@ -2422,7 +2399,7 @@
 
                 // Raw attribute write first — the binding's setType has
                 // produced wrong types in this build (see ensureTypedInput).
-                mxSafe(() => { el.setAttribute('type', def.type); return true; }, false);
+                mxSetAttr(el, 'type', def.type);
                 if (mxElType(el) !== def.type) {
                     mxSafe(() => { el.setType(def.type); return true; }, false);
                 }
@@ -2430,9 +2407,9 @@
                 // Pin the exact nodedef when the output type alone is
                 // ambiguous; otherwise keep the document clean. Any version
                 // pinned to the OLD signature no longer applies.
-                if (group.ambiguous) mxSafe(() => { el.setAttribute('nodedef', def.name); return true; }, false);
-                else mxSafe(() => { el.removeAttribute('nodedef'); return true; }, false);
-                mxSafe(() => { el.removeAttribute('version'); return true; }, false);
+                if (group.ambiguous) mxSetAttr(el, 'nodedef', def.name);
+                else mxRemoveAttr(el, 'nodedef');
+                mxRemoveAttr(el, 'version');
 
                 // Authored inputs: name+type matches survive UNLESS they're
                 // unconnected AND still equal the OLD default (untouched —
@@ -2527,8 +2504,8 @@
                 const c = scopeContainer();
                 const el = c && mxSafe(() => c.getNode(flowId.slice(2)), null);
                 if (!el) return;
-                if (versionDef.isDefaultVersion) mxSafe(() => { el.removeAttribute('version'); return true; }, false);
-                else mxSafe(() => { el.setAttribute('version', versionDef.version); return true; }, false);
+                if (versionDef.isDefaultVersion) mxRemoveAttr(el, 'version');
+                else mxSetAttr(el, 'version', versionDef.version);
                 setDocRev((r) => r + 1);
                 markDirty();
 
@@ -2555,6 +2532,32 @@
                 });
             };
 
+            // Write a connection SOURCE onto a connection point — shared by
+            // onConnect and both wirePendingConnection branches (item 9):
+            // clear any stale connection attrs, then set interfacename (a
+            // nodegraph interface-input source), nodegraph (a nodegraph-
+            // instance source) or nodename (a real node source); output=
+            // only when the source really declares several outputs — the
+            // synthesized single "out" handle must not leak into the
+            // document. A connected input takes its value from the wire —
+            // a literal alongside it would make the document invalid, so
+            // it's stashed first (item 4a, so disconnecting later can
+            // bring it straight back) then stripped.
+            const writeConnSource = (point, srcId, outName, srcOutputs) => {
+                clearConnAttrs(point);
+                const srcName = srcId.slice(2);
+                if (srcId.indexOf('i:') === 0) {
+                    mxSetAttr(point, 'interfacename', srcName);
+                } else {
+                    mxSetAttr(point, srcId.indexOf('g:') === 0 ? 'nodegraph' : 'nodename', srcName);
+                    if (outName && (srcOutputs || []).length > 1) {
+                        mxSetAttr(point, 'output', outName);
+                    }
+                }
+                stashValueBeforeRemoval(point);
+                mxRemoveAttr(point, 'value');
+            };
+
             // Drag-completed connection: write the connection attributes
             // onto the target input, replace any edge already feeding it
             // (an input has exactly one source), and add the new edge.
@@ -2572,30 +2575,8 @@
                 if (parsed) {
                     const point = connectionPoint(target, targetHandle, true);
                     if (point) {
-                        clearConnAttrs(point);
-                        const srcName = source.slice(2);
-                        if (source.indexOf('i:') === 0) {
-                            mxSafe(() => { point.setAttribute('interfacename', srcName); return true; }, false);
-                        } else {
-                            mxSafe(() => {
-                                point.setAttribute(source.indexOf('g:') === 0 ? 'nodegraph' : 'nodename', srcName);
-                                return true;
-                            }, false);
-                            // output= only when the source really declares
-                            // several outputs — the synthesized single "out"
-                            // handle must not leak into the document.
-                            const srcNode = flow.nodes.find((n) => n.id === source);
-                            const outs = (srcNode && srcNode.data.outputs) || [];
-                            if (outName && outs.length > 1) {
-                                mxSafe(() => { point.setAttribute('output', outName); return true; }, false);
-                            }
-                        }
-                        // A connected input takes its value from the wire — a
-                        // literal alongside it would make the document invalid.
-                        // Stash it first (item 4a) so disconnecting later
-                        // can bring it straight back.
-                        stashValueBeforeRemoval(point);
-                        mxSafe(() => { point.removeAttribute('value'); return true; }, false);
+                        const srcNode = flow.nodes.find((n) => n.id === source);
+                        writeConnSource(point, source, outName, srcNode && srcNode.data.outputs);
                         setDocRev((r) => r + 1);
                         markDirty();
                     } else {
@@ -2959,12 +2940,12 @@
                 if (kind === 'n:' && c) {
                     // Referrers live in the SAME container as the node.
                     for (const p of connectables(c)) {
-                        if (mxElAttr(p, 'nodename') === oldName) mxSafe(() => { p.setAttribute('nodename', newName); return true; }, false);
+                        if (mxElAttr(p, 'nodename') === oldName) mxSetAttr(p, 'nodename', newName);
                     }
                 } else if (kind === 'g:') {
                     // Referrers to a nodegraph live at the DOC ROOT.
                     for (const p of connectables(parsed.doc)) {
-                        if (mxElAttr(p, 'nodegraph') === oldName) mxSafe(() => { p.setAttribute('nodegraph', newName); return true; }, false);
+                        if (mxElAttr(p, 'nodegraph') === oldName) mxSetAttr(p, 'nodegraph', newName);
                     }
                     if (parsed.nodegraphs) { // scope dropdown
                         parsed.nodegraphs = parsed.nodegraphs.map((g) => (g === oldName ? newName : g));
@@ -2973,7 +2954,7 @@
                 } else if (kind === 'i:' && c) {
                     // Interface input referrers live inside the SAME graph.
                     for (const p of connectables(c)) {
-                        if (mxElAttr(p, 'interfacename') === oldName) mxSafe(() => { p.setAttribute('interfacename', newName); return true; }, false);
+                        if (mxElAttr(p, 'interfacename') === oldName) mxSetAttr(p, 'interfacename', newName);
                     }
                 } else if (kind === 'o:' && scope !== '') {
                     // A nodegraph output — referenced from the doc root as
@@ -2982,7 +2963,7 @@
                     // the document, so there's nothing to rewrite there.
                     for (const p of connectables(parsed.doc)) {
                         if (mxElAttr(p, 'nodegraph') === scope && mxElAttr(p, 'output') === oldName) {
-                            mxSafe(() => { p.setAttribute('output', newName); return true; }, false);
+                            mxSetAttr(p, 'output', newName);
                         }
                     }
                 }
@@ -3117,8 +3098,8 @@
                         // Same double-rAF idiom as changeScope — lets the
                         // overlay actually paint before the deletion (and
                         // the preview regen it triggers) runs.
-                        await new Promise((r) => requestAnimationFrame(r));
-                        await new Promise((r) => requestAnimationFrame(r));
+                        await nextFrame();
+                        await nextFrame();
                         try {
                             targets.forEach((id) => deleteNode(id));
                         } finally {
@@ -3129,6 +3110,29 @@
                 }
                 targets.forEach((id) => deleteNode(id));
                 return true;
+            };
+
+            // A screen point (default: the panel's own center — "the
+            // current viewport center") converted to flow-space via the
+            // live RF instance, falling back to project() for older RF
+            // builds. Null when neither `inst` nor `host` is available (or
+            // RF exposes neither conversion method) — callers keep
+            // whatever default position they already had in that case.
+            const viewportCenterFlow = (inst, host, point) => {
+                if (!inst || !host) return null;
+                const r = host.getBoundingClientRect();
+                const p = point || { x: r.left + r.width / 2, y: r.top + r.height / 2 };
+                if (typeof inst.screenToFlowPosition === 'function') return inst.screenToFlowPosition(p);
+                if (typeof inst.project === 'function') return inst.project({ x: p.x - r.left, y: p.y - r.top });
+                return null;
+            };
+
+            // Write a flow-space (pixel) position as an element's xpos/
+            // ypos, converted to the MaterialX Graph Editor convention (1
+            // unit = 240px, rounded to 4 decimals — see layoutScope).
+            const writeFlowPos = (el, x, y) => {
+                mxSetAttr(el, 'xpos', String(Math.round((x / 240) * 10000) / 10000));
+                mxSetAttr(el, 'ypos', String(Math.round((y / 240) * 10000) / 10000));
             };
 
             // Add a stdlib node (picked in the Tab palette) to the CURRENT
@@ -3168,11 +3172,11 @@
                 if (pinNodedef && def) {
                     // A type hint was used to disambiguate — lock in that
                     // exact signature explicitly.
-                    mxSafe(() => { el.setAttribute('nodedef', def.name); return true; }, false);
+                    mxSetAttr(el, 'nodedef', def.name);
                 } else if (def && def.ambiguous) {
                     // When several signatures share this output type, pin the
                     // exact one — otherwise MaterialX could resolve a sibling.
-                    mxSafe(() => { el.setAttribute('nodedef', def.name); return true; }, false);
+                    mxSetAttr(el, 'nodedef', def.name);
                 }
                 // Descriptor → flow node, exactly the shape toFlow builds.
                 const ports = collectPorts(el);
@@ -3261,14 +3265,8 @@
                 if (!placedAtDrop) {
                     // Drop it at the center of the current viewport.
                     const host = panelRef.current;
-                    if (inst && host) {
-                        const r = host.getBoundingClientRect();
-                        if (typeof inst.screenToFlowPosition === 'function') {
-                            pos = inst.screenToFlowPosition({ x: r.left + r.width / 2, y: r.top + r.height / 2 });
-                        } else if (typeof inst.project === 'function') {
-                            pos = inst.project({ x: r.width / 2, y: r.height / 2 });
-                        }
-                    }
+                    const centered = viewportCenterFlow(inst, host);
+                    if (centered) pos = centered;
                     pos = {
                         x: pos.x - NODE_W / 2,
                         y: pos.y - nodeHeight({ inputs: data.inputs, outputs: data.outputs }) / 2,
@@ -3276,8 +3274,7 @@
                 }
                 // Persist the drop position right away (same convention as
                 // onNodeDragStop), so a scope round-trip keeps it.
-                mxSafe(() => { el.setAttribute('xpos', String(Math.round((pos.x / 240) * 10000) / 10000)); return true; }, false);
-                mxSafe(() => { el.setAttribute('ypos', String(Math.round((pos.y / 240) * 10000) / 10000)); return true; }, false);
+                writeFlowPos(el, pos.x, pos.y);
                 setFlow((prev) => ({
                     edges: prev.edges,
                     nodes: prev.nodes.concat([{ id, type: 'mtlx', position: pos, data }]),
@@ -3295,9 +3292,9 @@
             // addNodeFromCatalog. `pending` is the info captured by
             // openPortAdd; `created` is addNodeFromCatalog's return value.
             // Writes the connection attributes exactly the way onConnect
-            // does (ensureTypedInput + nodename/output, output= only when
-            // the source declares several outputs), then applies the same
-            // setDocRev/markDirty/setFlow tail onConnect uses.
+            // does (ensureTypedInput + the shared writeConnSource), then
+            // applies the same setDocRev/markDirty/setFlow tail onConnect
+            // uses.
             const wirePendingConnection = (created, pending) => {
                 if (!created || !pending || !parsed) return;
                 const doc = parsed.doc;
@@ -3313,15 +3310,9 @@
                     if (!existingEl) return;
                     point = ensureTypedInput(doc, existingEl, pending.port, pending.portType);
                     if (!point) return;
-                    clearConnAttrs(point);
                     const outs = created.outputs || [];
                     const outMatch = outs.find((o) => o.type === pending.portType) || outs[0];
-                    mxSafe(() => { point.setAttribute('nodename', created.name); return true; }, false);
-                    if (outMatch && outMatch.name && outs.length > 1) {
-                        mxSafe(() => { point.setAttribute('output', outMatch.name); return true; }, false);
-                    }
-                    stashValueBeforeRemoval(point); // item 4a
-                    mxSafe(() => { point.removeAttribute('value'); return true; }, false);
+                    writeConnSource(point, created.id, outMatch && outMatch.name, outs);
                     targetFlowId = pending.nodeId;
                     targetInputName = pending.port;
                     srcId = created.id;
@@ -3334,28 +3325,11 @@
                     if (!inMatch) return;
                     point = ensureTypedInput(doc, created.el, inMatch.name, pending.portType);
                     if (!point) return;
-                    clearConnAttrs(point);
-                    const srcName = pending.nodeId.slice(2);
-                    if (pending.nodeId.indexOf('i:') === 0) {
-                        // A nodegraph interface input as source is a pin
-                        // reference, not a node — same distinction onConnect
-                        // makes.
-                        mxSafe(() => { point.setAttribute('interfacename', srcName); return true; }, false);
-                    } else {
-                        mxSafe(() => {
-                            point.setAttribute(pending.nodeId.indexOf('g:') === 0 ? 'nodegraph' : 'nodename', srcName);
-                            return true;
-                        }, false);
-                        // output= only when the source really declares
-                        // several outputs — same guard as onConnect.
-                        const srcNode = flow.nodes.find((n) => n.id === pending.nodeId);
-                        const srcOuts = (srcNode && srcNode.data.outputs) || [];
-                        if (pending.port && srcOuts.length > 1) {
-                            mxSafe(() => { point.setAttribute('output', pending.port); return true; }, false);
-                        }
-                    }
-                    stashValueBeforeRemoval(point); // item 4a
-                    mxSafe(() => { point.removeAttribute('value'); return true; }, false);
+                    // A nodegraph interface input as source is a pin
+                    // reference, not a node — same distinction onConnect
+                    // makes (writeConnSource above).
+                    const srcNode = flow.nodes.find((n) => n.id === pending.nodeId);
+                    writeConnSource(point, pending.nodeId, pending.port, srcNode && srcNode.data.outputs);
                     targetFlowId = created.id;
                     targetInputName = inMatch.name;
                     srcId = pending.nodeId;
@@ -3418,7 +3392,7 @@
                         else el.setAttribute('type', type);
                         return true;
                     }, false);
-                    if (mxElType(el) !== type) mxSafe(() => { el.setAttribute('type', type); return true; }, false);
+                    if (mxElType(el) !== type) mxSetAttr(el, 'type', type);
                 }
 
                 const id = (kind === 'iface-input' ? 'i:' : 'o:') + name;
@@ -3440,20 +3414,13 @@
                 let pos = { x: 40, y: 40 };
                 const inst = rfInstRef.current;
                 const host = panelRef.current;
-                if (inst && host) {
-                    const r = host.getBoundingClientRect();
-                    if (typeof inst.screenToFlowPosition === 'function') {
-                        pos = inst.screenToFlowPosition({ x: r.left + r.width / 2, y: r.top + r.height / 2 });
-                    } else if (typeof inst.project === 'function') {
-                        pos = inst.project({ x: r.width / 2, y: r.height / 2 });
-                    }
-                }
+                const centered = viewportCenterFlow(inst, host);
+                if (centered) pos = centered;
                 pos = {
                     x: pos.x - NODE_W / 2,
                     y: pos.y - nodeHeight({ inputs: data.inputs, outputs: data.outputs }) / 2,
                 };
-                mxSafe(() => { el.setAttribute('xpos', String(Math.round((pos.x / 240) * 10000) / 10000)); return true; }, false);
-                mxSafe(() => { el.setAttribute('ypos', String(Math.round((pos.y / 240) * 10000) / 10000)); return true; }, false);
+                writeFlowPos(el, pos.x, pos.y);
 
                 setDocRev((r) => r + 1);
                 markDirty();
@@ -3600,8 +3567,8 @@
                     }
                     const el = mxSafe(() => container.addNode(entry.category, newName, entry.type), null);
                     if (!el) continue;
-                    if (entry.nodedef) mxSafe(() => { el.setAttribute('nodedef', entry.nodedef); return true; }, false);
-                    if (entry.version) mxSafe(() => { el.setAttribute('version', entry.version); return true; }, false);
+                    if (entry.nodedef) mxSetAttr(el, 'nodedef', entry.nodedef);
+                    if (entry.version) mxSetAttr(el, 'version', entry.version);
                     nameMap[entry.name] = newName;
                     created.push({ el, entry, newName });
                 }
@@ -3617,26 +3584,22 @@
                         const target = ensureTypedInput(parsed.doc, el, inp.name, inp.type);
                         if (!target) continue;
                         if (inp.nodename && nameMap[inp.nodename]) {
-                            mxSafe(() => { target.setAttribute('nodename', nameMap[inp.nodename]); return true; }, false);
-                            if (inp.output) mxSafe(() => { target.setAttribute('output', inp.output); return true; }, false);
+                            mxSetAttr(target, 'nodename', nameMap[inp.nodename]);
+                            if (inp.output) mxSetAttr(target, 'output', inp.output);
                             // Item 9: ensureTypedInput above may have copied the
                             // nodedef default VALUE onto this freshly-created
                             // input — a connected input must not also carry one.
-                            mxSafe(() => { target.removeAttribute('value'); return true; }, false);
+                            mxRemoveAttr(target, 'value');
                         } else if (inp.nodegraph && nameMap[inp.nodegraph]) {
-                            mxSafe(() => { target.setAttribute('nodegraph', nameMap[inp.nodegraph]); return true; }, false);
-                            if (inp.output) mxSafe(() => { target.setAttribute('output', inp.output); return true; }, false);
+                            mxSetAttr(target, 'nodegraph', nameMap[inp.nodegraph]);
+                            if (inp.output) mxSetAttr(target, 'output', inp.output);
                             // Item 9: same as the nodename branch above.
-                            mxSafe(() => { target.removeAttribute('value'); return true; }, false);
+                            mxRemoveAttr(target, 'value');
                         } else if (inp.value !== '') {
                             mxSafe(() => { mxWriteValue(target, inp.value, inp.type); return true; }, false);
                         }
                         if (inp.colorspace) {
-                            mxSafe(() => {
-                                if (typeof target.setColorSpace === 'function') target.setColorSpace(inp.colorspace);
-                                else target.setAttribute('colorspace', inp.colorspace);
-                                return true;
-                            }, false);
+                            mxSetColorspace(target, inp.colorspace);
                         }
                     }
                 }
@@ -3649,25 +3612,13 @@
                 let center = { x: 40, y: 40 };
                 const inst = rfInstRef.current;
                 const host = panelRef.current;
-                if (inst && host) {
-                    const r = host.getBoundingClientRect();
-                    if (typeof inst.screenToFlowPosition === 'function') {
-                        center = inst.screenToFlowPosition({ x: r.left + r.width / 2, y: r.top + r.height / 2 });
-                    } else if (typeof inst.project === 'function') {
-                        center = inst.project({ x: r.width / 2, y: r.height / 2 });
-                    }
-                }
+                const centered = viewportCenterFlow(inst, host);
+                if (centered) center = centered;
                 for (const { el, entry } of created) {
-                    const x = center.x + (entry.pos.x - cx);
-                    const y = center.y + (entry.pos.y - cy);
-                    mxSafe(() => { el.setAttribute('xpos', String(Math.round((x / 240) * 10000) / 10000)); return true; }, false);
-                    mxSafe(() => { el.setAttribute('ypos', String(Math.round((y / 240) * 10000) / 10000)); return true; }, false);
+                    writeFlowPos(el, center.x + (entry.pos.x - cx), center.y + (entry.pos.y - cy));
                 }
                 for (const { el, entry } of createdGraphs) {
-                    const x = center.x + (entry.pos.x - cx);
-                    const y = center.y + (entry.pos.y - cy);
-                    mxSafe(() => { el.setAttribute('xpos', String(Math.round((x / 240) * 10000) / 10000)); return true; }, false);
-                    mxSafe(() => { el.setAttribute('ypos', String(Math.round((y / 240) * 10000) / 10000)); return true; }, false);
+                    writeFlowPos(el, center.x + (entry.pos.x - cx), center.y + (entry.pos.y - cy));
                 }
                 setDocRev((r) => r + 1);
                 markDirty();
@@ -3725,8 +3676,8 @@
                 const nameSet = new Set(names);
                 setActionBusy('Grouping' + '\u2026');
                 (async () => {
-                    await new Promise((r) => requestAnimationFrame(r));
-                    await new Promise((r) => requestAnimationFrame(r));
+                    await nextFrame();
+                    await nextFrame();
                     // [mtlx-perf] timing (item 2) — off unless MTLX_PERF_LOG.
                     const __perfStart = MTLX_PERF_LOG ? performance.now() : 0;
                     try {
@@ -3764,10 +3715,10 @@
                     for (const entry of entries) {
                         const el = mxSafe(() => g.addNode(entry.category, entry.name, entry.type), null);
                         if (!el) continue;
-                        if (entry.nodedef) mxSafe(() => { el.setAttribute('nodedef', entry.nodedef); return true; }, false);
-                        if (entry.version) mxSafe(() => { el.setAttribute('version', entry.version); return true; }, false);
-                        mxSafe(() => { el.setAttribute('xpos', String(entry.pos.x)); return true; }, false);
-                        mxSafe(() => { el.setAttribute('ypos', String(entry.pos.y)); return true; }, false);
+                        if (entry.nodedef) mxSetAttr(el, 'nodedef', entry.nodedef);
+                        if (entry.version) mxSetAttr(el, 'version', entry.version);
+                        mxSetAttr(el, 'xpos', String(entry.pos.x));
+                        mxSetAttr(el, 'ypos', String(entry.pos.y));
                         inner[entry.name] = el;
                     }
 
@@ -3782,13 +3733,13 @@
                             if (internalSrc) {
                                 const target = ensureTypedInput(doc, el, inp.name, inp.type);
                                 if (!target) continue;
-                                mxSafe(() => { target.setAttribute('nodename', inp.nodename); return true; }, false);
-                                if (inp.output) mxSafe(() => { target.setAttribute('output', inp.output); return true; }, false);
+                                mxSetAttr(target, 'nodename', inp.nodename);
+                                if (inp.output) mxSetAttr(target, 'output', inp.output);
                                 // Item 9: ensureTypedInput may have copied the
                                 // nodedef default VALUE onto this input — strip
                                 // it now that it's connected (matches the
                                 // external branch below, which already does this).
-                                mxSafe(() => { target.removeAttribute('value'); return true; }, false);
+                                mxRemoveAttr(target, 'value');
                                 continue;
                             }
                             const external = inp.nodename || inp.nodegraph || inp.interfacename;
@@ -3803,16 +3754,16 @@
                                         else gin.setAttribute('type', inp.type);
                                         return true;
                                     }, false);
-                                    if (mxElType(gin) !== inp.type) mxSafe(() => { gin.setAttribute('type', inp.type); return true; }, false);
+                                    if (mxElType(gin) !== inp.type) mxSetAttr(gin, 'type', inp.type);
                                 }
-                                if (inp.nodename) mxSafe(() => { gin.setAttribute('nodename', inp.nodename); return true; }, false);
-                                if (inp.nodegraph) mxSafe(() => { gin.setAttribute('nodegraph', inp.nodegraph); return true; }, false);
-                                if (inp.output) mxSafe(() => { gin.setAttribute('output', inp.output); return true; }, false);
+                                if (inp.nodename) mxSetAttr(gin, 'nodename', inp.nodename);
+                                if (inp.nodegraph) mxSetAttr(gin, 'nodegraph', inp.nodegraph);
+                                if (inp.output) mxSetAttr(gin, 'output', inp.output);
 
                                 const target = ensureTypedInput(doc, el, inp.name, inp.type);
                                 if (!target) continue;
-                                mxSafe(() => { target.removeAttribute('value'); return true; }, false);
-                                mxSafe(() => { target.setAttribute('interfacename', pinName); return true; }, false);
+                                mxRemoveAttr(target, 'value');
+                                mxSetAttr(target, 'interfacename', pinName);
                                 continue;
                             }
                             if (inp.value !== '' && inp.value != null) {
@@ -3820,11 +3771,7 @@
                                 if (!target) continue;
                                 mxSafe(() => { mxWriteValue(target, inp.value, inp.type); return true; }, false);
                                 if (inp.colorspace) {
-                                    mxSafe(() => {
-                                        if (typeof target.setColorSpace === 'function') target.setColorSpace(inp.colorspace);
-                                        else target.setAttribute('colorspace', inp.colorspace);
-                                        return true;
-                                    }, false);
+                                    mxSetColorspace(target, inp.colorspace);
                                 }
                             }
                         }
@@ -3869,10 +3816,10 @@
                                             else gout.setAttribute('type', type);
                                             return true;
                                         }, false);
-                                        if (mxElType(gout) !== type) mxSafe(() => { gout.setAttribute('type', type); return true; }, false);
+                                        if (mxElType(gout) !== type) mxSetAttr(gout, 'type', type);
                                     }
-                                    mxSafe(() => { gout.setAttribute('nodename', srcName); return true; }, false);
-                                    if (outName && outs.length > 1) mxSafe(() => { gout.setAttribute('output', outName); return true; }, false);
+                                    mxSetAttr(gout, 'nodename', srcName);
+                                    if (outName && outs.length > 1) mxSetAttr(gout, 'output', outName);
                                     outPin = newPin;
                                     outPins[key] = outPin;
                                 }
@@ -3882,10 +3829,10 @@
                         const point = connectionPoint(e.target, e.targetHandle, true);
                         if (!point) continue;
                         clearConnAttrs(point);
-                        mxSafe(() => { point.setAttribute('nodegraph', gName); return true; }, false);
-                        mxSafe(() => { point.setAttribute('output', outPin); return true; }, false);
+                        mxSetAttr(point, 'nodegraph', gName);
+                        mxSetAttr(point, 'output', outPin);
                         stashValueBeforeRemoval(point); // item 4a
-                        mxSafe(() => { point.removeAttribute('value'); return true; }, false);
+                        mxRemoveAttr(point, 'value');
                     }
 
                     // 7: remove the original root nodes WITHOUT severing the
@@ -3900,8 +3847,8 @@
                     const xs = entries.map((en) => en.pos.x), ys = entries.map((en) => en.pos.y);
                     const cx = xs.reduce((a, b) => a + b, 0) / xs.length;
                     const cy = ys.reduce((a, b) => a + b, 0) / ys.length;
-                    mxSafe(() => { g.setAttribute('xpos', String(cx)); return true; }, false);
-                    mxSafe(() => { g.setAttribute('ypos', String(cy)); return true; }, false);
+                    mxSetAttr(g, 'xpos', String(cx));
+                    mxSetAttr(g, 'ypos', String(cy));
 
                     setDocRev((r) => r + 1);
                     markDirty();
@@ -3964,8 +3911,8 @@
                 if (mxElAttr(g, 'nodedef')) return;
                 setActionBusy('Ungrouping' + '\u2026');
                 (async () => {
-                    await new Promise((r) => requestAnimationFrame(r));
-                    await new Promise((r) => requestAnimationFrame(r));
+                    await nextFrame();
+                    await nextFrame();
                     // [mtlx-perf] timing — off unless MTLX_PERF_LOG.
                     const __perfStart = MTLX_PERF_LOG ? performance.now() : 0;
                     let __nodeCount = 0;
@@ -3975,7 +3922,7 @@
                         // and step 6 below removes g.
                         const pinsSnapshot = vecToArray(mxSafe(() => g.getInputs(), [])).map((p) => ({
                             name: mxElName(p), type: mxElType(p),
-                            value: mxSafe(() => p.getAttribute('value'), ''),
+                            value: mxElAttr(p, 'value'),
                             colorspace: mxElAttr(p, 'colorspace'),
                             nodename: mxElAttr(p, 'nodename'),
                             nodegraph: mxElAttr(p, 'nodegraph'),
@@ -4053,13 +4000,13 @@
                         for (const entry of entries) {
                             const el = mxSafe(() => doc.addNode(entry.category, nameMap[entry.name], entry.type), null);
                             if (!el) continue;
-                            if (entry.nodedef) mxSafe(() => { el.setAttribute('nodedef', entry.nodedef); return true; }, false);
-                            if (entry.version) mxSafe(() => { el.setAttribute('version', entry.version); return true; }, false);
+                            if (entry.nodedef) mxSetAttr(el, 'nodedef', entry.nodedef);
+                            if (entry.version) mxSetAttr(el, 'version', entry.version);
                             if (entry.pos) {
                                 const x = entry.pos.x + (graphPos.x - centroid.x);
                                 const y = entry.pos.y + (graphPos.y - centroid.y);
-                                mxSafe(() => { el.setAttribute('xpos', String(x)); return true; }, false);
-                                mxSafe(() => { el.setAttribute('ypos', String(y)); return true; }, false);
+                                mxSetAttr(el, 'xpos', String(x));
+                                mxSetAttr(el, 'ypos', String(y));
                             }
                             created[entry.name] = el;
                         }
@@ -4075,17 +4022,13 @@
                         const applyPinSource = (point, pin) => {
                             clearConnAttrs(point);
                             if (pin.nodename || pin.nodegraph) {
-                                if (pin.nodename) mxSafe(() => { point.setAttribute('nodename', pin.nodename); return true; }, false);
-                                if (pin.nodegraph) mxSafe(() => { point.setAttribute('nodegraph', pin.nodegraph); return true; }, false);
-                                if (pin.output) mxSafe(() => { point.setAttribute('output', pin.output); return true; }, false);
+                                if (pin.nodename) mxSetAttr(point, 'nodename', pin.nodename);
+                                if (pin.nodegraph) mxSetAttr(point, 'nodegraph', pin.nodegraph);
+                                if (pin.output) mxSetAttr(point, 'output', pin.output);
                             } else if (pin.value !== '' && pin.value != null) {
                                 mxSafe(() => { mxWriteValue(point, pin.value, pin.type); return true; }, false);
                                 if (pin.colorspace) {
-                                    mxSafe(() => {
-                                        if (typeof point.setColorSpace === 'function') point.setColorSpace(pin.colorspace);
-                                        else point.setAttribute('colorspace', pin.colorspace);
-                                        return true;
-                                    }, false);
+                                    mxSetColorspace(point, pin.colorspace);
                                 }
                             }
                             // else: the pin itself carried neither — leave
@@ -4117,8 +4060,8 @@
                                     const target = ensureTypedInput(doc, el, inp.name, inp.type);
                                     if (!target) continue;
                                     clearConnAttrs(target);
-                                    mxSafe(() => { target.setAttribute('nodename', nameMap[inp.nodename]); return true; }, false);
-                                    if (inp.output) mxSafe(() => { target.setAttribute('output', inp.output); return true; }, false);
+                                    mxSetAttr(target, 'nodename', nameMap[inp.nodename]);
+                                    if (inp.output) mxSetAttr(target, 'output', inp.output);
                                     continue;
                                 }
                                 if (inp.nodegraph) {
@@ -4134,9 +4077,9 @@
                                     const target = ensureTypedInput(doc, el, inp.name, inp.type);
                                     if (!target) continue;
                                     clearConnAttrs(target);
-                                    mxSafe(() => { target.setAttribute('nodegraph', inp.nodegraph); return true; }, false);
-                                    if (inp.nodename) mxSafe(() => { target.setAttribute('nodename', inp.nodename); return true; }, false);
-                                    if (inp.output) mxSafe(() => { target.setAttribute('output', inp.output); return true; }, false);
+                                    mxSetAttr(target, 'nodegraph', inp.nodegraph);
+                                    if (inp.nodename) mxSetAttr(target, 'nodename', inp.nodename);
+                                    if (inp.output) mxSetAttr(target, 'output', inp.output);
                                     continue;
                                 }
                                 if (inp.value !== '' && inp.value != null) {
@@ -4144,11 +4087,7 @@
                                     if (!target) continue;
                                     mxSafe(() => { mxWriteValue(target, inp.value, inp.type); return true; }, false);
                                     if (inp.colorspace) {
-                                        mxSafe(() => {
-                                            if (typeof target.setColorSpace === 'function') target.setColorSpace(inp.colorspace);
-                                            else target.setAttribute('colorspace', inp.colorspace);
-                                            return true;
-                                        }, false);
+                                        mxSetColorspace(target, inp.colorspace);
                                     }
                                 }
                             }
@@ -4210,7 +4149,7 @@
                                 const newName = nameMap[outSnap.nodename];
                                 if (!newName) continue;
                                 clearConnAttrs(point);
-                                mxSafe(() => { point.setAttribute('nodename', newName); return true; }, false);
+                                mxSetAttr(point, 'nodename', newName);
                                 // output= whenever the ORIGINAL graph output
                                 // snapshot explicitly named a port — even if
                                 // the recreated source's own outputsCount
@@ -4219,7 +4158,7 @@
                                 // multi-output; only omit output= when the
                                 // original never had one to disambiguate.
                                 if (outSnap.output) {
-                                    mxSafe(() => { point.setAttribute('output', outSnap.output); return true; }, false);
+                                    mxSetAttr(point, 'output', outSnap.output);
                                 }
                             } else if (outSnap.interfacename) {
                                 // Pass-through output: the graph's <output>
@@ -4521,8 +4460,8 @@
                     if (!el) continue;
                     const x = Math.round((n.position.x / 240) * 10000) / 10000;
                     const y = Math.round((n.position.y / 240) * 10000) / 10000;
-                    mxSafe(() => { el.setAttribute('xpos', String(x)); return true; }, false);
-                    mxSafe(() => { el.setAttribute('ypos', String(y)); return true; }, false);
+                    mxSetAttr(el, 'xpos', String(x));
+                    mxSetAttr(el, 'ypos', String(y));
                     wrote = true;
                 }
                 if (wrote) markDirty();
@@ -4855,7 +4794,7 @@
             // that nodedef belongs to.
             const currentDefName = React.useMemo(() => {
                 if (!panelSigGroups) return '';
-                const c = scope ? mxSafe(() => parsed.doc.getNodeGraph(scope), null) : parsed.doc;
+                const c = scopeContainer();
                 const el = c && mxSafe(() => c.getNode(displayNode.id.slice(2)), null);
                 if (!el) return '';
                 const def = resolveVersionedNodeDef(el, parsed.doc);
@@ -5206,7 +5145,7 @@
                                         const v = e.target.value;
                                         setDocColorspace(v);
                                         if (v) mxSafe(() => { parsed.doc.setColorSpace(v); return true; }, false);
-                                        else mxSafe(() => { parsed.doc.removeAttribute('colorspace'); return true; }, false);
+                                        else mxRemoveAttr(parsed.doc, 'colorspace');
                                         setDocRev((r) => r + 1);
                                         markDirty();
                                         e.target.blur(); /* keyboard shortcuts like Backspace must go back to the canvas, not the select */

--- a/js/graph/dialogs.jsx
+++ b/js/graph/dialogs.jsx
@@ -8,6 +8,64 @@
 // file has NO top-level import/export — it self-exports via a single
 // Object.assign(window, {}) at the bottom.
 
+        // Shared chrome for all six dialogs below: a full-viewport backdrop
+        // (mousedown outside the panel closes it, unless
+        // `backdropCloseDisabled`), a centered panel, and a header bar with
+        // a title and a × close button (optionally preceded by
+        // `headerRight` extras — XmlDialog's Copy button, DocsDialog's
+        // open-in-new-tab link). Each dialog keeps its OWN useEscapeToClose
+        // call rather than the frame owning it — the `when` condition
+        // differs per dialog (e.g. ExportDialog/PresetsDialog additionally
+        // gate it on `!busy`), so the frame has no single answer for when a
+        // given dialog should stop listening for Esc.
+        // `keepMounted` (DocsDialog only): instead of unmounting while
+        // closed, the backdrop stays in the DOM with a `hidden` class
+        // toggled on it instead — keeps the embedded docs App warm across
+        // close/reopen. Every other dialog unmounts on close via its own
+        // `if (!open) return null` guard before ever reaching this
+        // component; this component's own `open` check is a harmless
+        // second guard for KeybindsHelp and DocsDialog, which don't
+        // pre-check it themselves (KeybindsHelp has no `open` prop at all —
+        // it's mounted/unmounted by its caller instead — so it always
+        // passes `open={true}` here).
+        // `closeDisabled`/`backdropCloseDisabled` (Export/Presets only):
+        // while a caller-supplied async action is in flight (`busy`), both
+        // the × button and backdrop-click-to-close are disabled so the
+        // dialog can't be dismissed mid-request. Left undefined by every
+        // other dialog, which reproduces their close button's ORIGINAL
+        // markup exactly (no `disabled` attribute, no `disabled:opacity-40`
+        // class — that class is only appended when a dialog actually wires
+        // up `closeDisabled`).
+        const DialogFrame = ({
+            open, title, titleClassName, panelClassName, onClose, children,
+            headerRight, closeDisabled, backdropCloseDisabled = false,
+            keepMounted = false,
+        }) => {
+            if (!open && !keepMounted) return null;
+            return (
+                <div
+                    className={'absolute inset-0 z-50 flex items-center justify-center bg-gray-950/70' + (keepMounted && !open ? ' hidden' : '')}
+                    onMouseDown={backdropCloseDisabled ? undefined : onClose}
+                >
+                    <div className={panelClassName} onMouseDown={(e) => e.stopPropagation()}>
+                        <div className="flex items-center justify-between px-4 py-2.5 border-b border-gray-700 bg-gray-900/70">
+                            <span className={titleClassName || 'text-[13px] font-bold text-gray-100'}>{title}</span>
+                            <div className="flex items-center gap-2">
+                                {headerRight}
+                                <button
+                                    onClick={onClose}
+                                    disabled={closeDisabled}
+                                    title="Close"
+                                    className={'text-gray-400 hover:text-gray-200 leading-none text-lg px-1' + (closeDisabled !== undefined ? ' disabled:opacity-40' : '')}
+                                >{'×'}</button>
+                            </div>
+                        </div>
+                        {children}
+                    </div>
+                </div>
+            );
+        };
+
         // Every keyboard shortcut and mouse interaction currently live in
         // the editor — kept as one list so it can't silently drift from
         // reality; update it alongside whatever handler it documents.
@@ -44,28 +102,26 @@
             const keybinds = IN_VSCODE ? KEYBINDS.filter((k) => k.keys !== 'Drag & drop files') : KEYBINDS;
             useEscapeToClose(onClose, active);
             return (
-                <div className="absolute inset-0 z-50 flex items-center justify-center bg-gray-950/70"
-                    onMouseDown={onClose}>
-                    <div className="bg-gray-800/95 backdrop-blur border border-gray-600 rounded-lg shadow-2xl w-[34rem] max-w-[90%] max-h-[80%] overflow-hidden flex flex-col"
-                        onMouseDown={(e) => e.stopPropagation()}>
-                        <div className="flex items-center justify-between px-4 py-2.5 border-b border-gray-700 bg-gray-900/70">
-                            <div className="text-sm font-bold text-gray-100">Keyboard shortcuts</div>
-                            <button onClick={onClose} title="Close" className="text-gray-400 hover:text-gray-200 leading-none text-lg px-1">{'×'}</button>
-                        </div>
-                        <div className="overflow-y-auto custom-scrollbar px-4 py-3">
-                            <table className="w-full text-[11px] font-mono">
-                                <tbody>
-                                    {keybinds.map((k) => (
-                                        <tr key={k.keys} className="align-top">
-                                            <td className="py-1 pr-3 whitespace-nowrap text-blue-300">{k.keys}</td>
-                                            <td className="py-1 text-gray-300">{k.desc}</td>
-                                        </tr>
-                                    ))}
-                                </tbody>
-                            </table>
-                        </div>
+                <DialogFrame
+                    open={true}
+                    title="Keyboard shortcuts"
+                    titleClassName="text-sm font-bold text-gray-100"
+                    onClose={onClose}
+                    panelClassName="bg-gray-800/95 backdrop-blur border border-gray-600 rounded-lg shadow-2xl w-[34rem] max-w-[90%] max-h-[80%] overflow-hidden flex flex-col"
+                >
+                    <div className="overflow-y-auto custom-scrollbar px-4 py-3">
+                        <table className="w-full text-[11px] font-mono">
+                            <tbody>
+                                {keybinds.map((k) => (
+                                    <tr key={k.keys} className="align-top">
+                                        <td className="py-1 pr-3 whitespace-nowrap text-blue-300">{k.keys}</td>
+                                        <td className="py-1 text-gray-300">{k.desc}</td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
                     </div>
-                </div>
+                </DialogFrame>
             );
         }
 
@@ -108,36 +164,32 @@
             useEscapeToClose(onClose, active && open);
 
             return (
-                <div className={'absolute inset-0 z-50 flex items-center justify-center bg-gray-950/70' + (open ? '' : ' hidden')}
-                    onMouseDown={onClose}>
-                    <div className="bg-gray-800/95 backdrop-blur border border-gray-600 rounded-lg shadow-2xl w-[min(64rem,94%)] h-[90%] overflow-hidden flex flex-col"
-                        onMouseDown={(e) => e.stopPropagation()}>
-                        <div className="flex items-center justify-between px-4 py-2.5 border-b border-gray-700 bg-gray-900/70">
-                            <span className="text-[13px] font-bold text-gray-100">{label}</span>
-                            <div className="flex items-center gap-2">
-                                {!IN_VSCODE && (
-                                <a href={fullUrl} target="_blank" rel="noopener noreferrer" title="Open in a new tab"
-                                    className="text-gray-400 hover:text-gray-200 leading-none text-sm px-1">{'↗'}</a>
-                                )}
-                                <button onClick={onClose} title="Close" className="text-gray-400 hover:text-gray-200 leading-none text-lg px-1">{'×'}</button>
+                <DialogFrame
+                    open={open}
+                    keepMounted
+                    title={label}
+                    onClose={onClose}
+                    panelClassName="bg-gray-800/95 backdrop-blur border border-gray-600 rounded-lg shadow-2xl w-[min(64rem,94%)] h-[90%] overflow-hidden flex flex-col"
+                    headerRight={!IN_VSCODE && (
+                        <a href={fullUrl} target="_blank" rel="noopener noreferrer" title="Open in a new tab"
+                            className="text-gray-400 hover:text-gray-200 leading-none text-sm px-1">{'↗'}</a>
+                    )}
+                >
+                    <div className="relative flex-1 min-h-0 overflow-y-auto">
+                        {loadError ? (
+                            <div className="absolute inset-0 flex items-center justify-center text-xs text-red-400 px-6 text-center">
+                                {'Failed to load documentation — close and reopen this dialog to retry.'}
                             </div>
-                        </div>
-                        <div className="relative flex-1 min-h-0 overflow-y-auto">
-                            {loadError ? (
-                                <div className="absolute inset-0 flex items-center justify-center text-xs text-red-400 px-6 text-center">
-                                    {'Failed to load documentation — close and reopen this dialog to retry.'}
-                                </div>
-                            ) : !docsReady ? (
-                                <div className="absolute inset-0 flex items-center justify-center text-xs text-gray-500 animate-pulse">
-                                    {'Loading documentation…'}
-                                </div>
-                            ) : (() => {
-                                const DocsApp = window.App;
-                                return <DocsApp key={hash} inline initialHash={hash} active={open} />;
-                            })()}
-                        </div>
+                        ) : !docsReady ? (
+                            <div className="absolute inset-0 flex items-center justify-center text-xs text-gray-500 animate-pulse">
+                                {'Loading documentation…'}
+                            </div>
+                        ) : (() => {
+                            const DocsApp = window.App;
+                            return <DocsApp key={hash} inline initialHash={hash} active={open} />;
+                        })()}
                     </div>
-                </div>
+                </DialogFrame>
             );
         }
 
@@ -145,8 +197,8 @@
         // current document exactly as Export would write it, without
         // triggering a download — a quick way to eyeball or copy the raw
         // MaterialX. `xml` is computed once by the caller when the dialog
-        // opens (not on every render). Same backdrop/Esc/stopPropagation
-        // contract as KeybindsHelp/DocsDialog above.
+        // opens (not on every render). Chrome comes from the shared
+        // DialogFrame (see above).
         function XmlDialog({ xml, open, onClose }) {
             const [copied, setCopied] = React.useState(false);
             const copyTimerRef = React.useRef(null);
@@ -202,34 +254,31 @@
             };
 
             return (
-                <div className="absolute inset-0 z-50 flex items-center justify-center bg-gray-950/70"
-                    onMouseDown={onClose}>
-                    <div className="bg-gray-800/95 backdrop-blur border border-gray-600 rounded-lg shadow-2xl w-[38rem] max-w-[90%] max-h-[80vh] overflow-hidden flex flex-col"
-                        onMouseDown={(e) => e.stopPropagation()}>
-                        <div className="flex items-center justify-between px-4 py-2.5 border-b border-gray-700 bg-gray-900/70">
-                            <span className="text-[13px] font-bold text-gray-100">Document</span>
-                            <div className="flex items-center gap-2">
-                                <button
-                                    onClick={copyXml}
-                                    title="Copy the XML to the clipboard"
-                                    className={'h-6 inline-flex items-center gap-1 text-[11px] px-2 rounded border backdrop-blur transition-colors '
-                                        + (copied
-                                            ? 'bg-green-600/70 border-green-500 text-white'
-                                            : 'bg-gray-800/80 border-gray-600 text-gray-300 hover:bg-gray-700/80')}
-                                >
-                                    <MtlxIcon name={copied ? 'copy-check' : 'copy'} className="w-3.5 h-3.5" />
-                                    <span>{copied ? 'Copied' : 'Copy'}</span>
-                                </button>
-                                <button onClick={onClose} title="Close" className="text-gray-400 hover:text-gray-200 leading-none text-lg px-1">{'×'}</button>
-                            </div>
-                        </div>
-                        <pre className="flex-1 min-h-0 overflow-auto custom-scrollbar font-mono text-[11px] leading-relaxed text-gray-300 px-4 py-3 whitespace-pre-wrap break-words">
-                            {highlighted != null
-                                ? <code className="hljs" dangerouslySetInnerHTML={{ __html: highlighted }} />
-                                : xml}
-                        </pre>
-                    </div>
-                </div>
+                <DialogFrame
+                    open={open}
+                    title="Document"
+                    onClose={onClose}
+                    panelClassName="bg-gray-800/95 backdrop-blur border border-gray-600 rounded-lg shadow-2xl w-[38rem] max-w-[90%] max-h-[80vh] overflow-hidden flex flex-col"
+                    headerRight={
+                        <button
+                            onClick={copyXml}
+                            title="Copy the XML to the clipboard"
+                            className={'h-6 inline-flex items-center gap-1 text-[11px] px-2 rounded border backdrop-blur transition-colors '
+                                + (copied
+                                    ? 'bg-green-600/70 border-green-500 text-white'
+                                    : 'bg-gray-800/80 border-gray-600 text-gray-300 hover:bg-gray-700/80')}
+                        >
+                            <MtlxIcon name={copied ? 'copy-check' : 'copy'} className="w-3.5 h-3.5" />
+                            <span>{copied ? 'Copied' : 'Copy'}</span>
+                        </button>
+                    }
+                >
+                    <pre className="flex-1 min-h-0 overflow-auto custom-scrollbar font-mono text-[11px] leading-relaxed text-gray-300 px-4 py-3 whitespace-pre-wrap break-words">
+                        {highlighted != null
+                            ? <code className="hljs" dangerouslySetInnerHTML={{ __html: highlighted }} />
+                            : xml}
+                    </pre>
+                </DialogFrame>
             );
         }
 
@@ -250,35 +299,32 @@
             useEscapeToClose(onClose, open);
             if (!open) return null;
             return (
-                <div className="absolute inset-0 z-50 flex items-center justify-center bg-gray-950/70"
-                    onMouseDown={onClose}>
-                    <div className="bg-gray-800/95 backdrop-blur border border-gray-600 rounded-lg shadow-2xl w-[26rem] max-w-[90%] max-h-[80%] overflow-hidden flex flex-col"
-                        onMouseDown={(e) => e.stopPropagation()}>
-                        <div className="flex items-center justify-between px-4 py-2.5 border-b border-gray-700 bg-gray-900/70">
-                            <span className="text-[13px] font-bold text-gray-100">Validate</span>
-                            <button onClick={onClose} title="Close" className="text-gray-400 hover:text-gray-200 leading-none text-lg px-1">{'×'}</button>
-                        </div>
-                        <div className="overflow-y-auto custom-scrollbar px-4 py-3 text-[12px]">
-                            {!status && <div className="text-gray-400 animate-pulse">Validating{'…'}</div>}
-                            {status && status.kind === 'valid' && (
-                                <div className="text-green-400 font-bold">{'✓ Document is valid'}</div>
-                            )}
-                            {status && status.kind === 'invalid' && (
-                                <div>
-                                    <div className="text-red-400 font-bold mb-2">{'✗ Validation failed'}</div>
-                                    {status.issues && status.issues.length > 0 && (
-                                        <ul className="list-disc list-inside space-y-1 text-gray-300 font-mono text-[11px]">
-                                            {status.issues.map((s, i) => <li key={i}>{s}</li>)}
-                                        </ul>
-                                    )}
-                                </div>
-                            )}
-                            {status && status.kind === 'unavailable' && (
-                                <div className="text-gray-400">Validation is not available in this build.</div>
-                            )}
-                        </div>
+                <DialogFrame
+                    open={open}
+                    title="Validate"
+                    onClose={onClose}
+                    panelClassName="bg-gray-800/95 backdrop-blur border border-gray-600 rounded-lg shadow-2xl w-[26rem] max-w-[90%] max-h-[80%] overflow-hidden flex flex-col"
+                >
+                    <div className="overflow-y-auto custom-scrollbar px-4 py-3 text-[12px]">
+                        {!status && <div className="text-gray-400 animate-pulse">Validating{'…'}</div>}
+                        {status && status.kind === 'valid' && (
+                            <div className="text-green-400 font-bold">{'✓ Document is valid'}</div>
+                        )}
+                        {status && status.kind === 'invalid' && (
+                            <div>
+                                <div className="text-red-400 font-bold mb-2">{'✗ Validation failed'}</div>
+                                {status.issues && status.issues.length > 0 && (
+                                    <ul className="list-disc list-inside space-y-1 text-gray-300 font-mono text-[11px]">
+                                        {status.issues.map((s, i) => <li key={i}>{s}</li>)}
+                                    </ul>
+                                )}
+                            </div>
+                        )}
+                        {status && status.kind === 'unavailable' && (
+                            <div className="text-gray-400">Validation is not available in this build.</div>
+                        )}
                     </div>
-                </div>
+                </DialogFrame>
             );
         }
 
@@ -342,74 +388,72 @@
             };
 
             return (
-                <div className="absolute inset-0 z-50 flex items-center justify-center bg-gray-950/70"
-                    onMouseDown={busy ? undefined : onClose}>
-                    <div className="bg-gray-800/95 backdrop-blur border border-gray-600 rounded-lg shadow-2xl w-[26rem] max-w-[90%] max-h-[80%] overflow-hidden flex flex-col"
-                        onMouseDown={(e) => e.stopPropagation()}>
-                        <div className="flex items-center justify-between px-4 py-2.5 border-b border-gray-700 bg-gray-900/70">
-                            <span className="text-[13px] font-bold text-gray-100">Export</span>
-                            <button onClick={onClose} disabled={busy} title="Close"
-                                className="text-gray-400 hover:text-gray-200 leading-none text-lg px-1 disabled:opacity-40">{'×'}</button>
-                        </div>
-                        <div className="overflow-y-auto custom-scrollbar px-4 py-3 space-y-3 text-[12px]">
-                            <label className="block space-y-1">
-                                <span className="text-gray-400">File name</span>
-                                <input
-                                    type="text"
-                                    value={name}
-                                    autoFocus
-                                    spellCheck={false}
-                                    onChange={(e) => setName(e.target.value)}
-                                    onKeyDown={(e) => { if (e.key === 'Enter' && trimmedName && !busy) doExport(); }}
-                                    className="w-full bg-gray-900 border border-gray-600 rounded px-2 py-1 text-gray-200 font-mono"
-                                />
+                <DialogFrame
+                    open={open}
+                    title="Export"
+                    onClose={onClose}
+                    closeDisabled={busy}
+                    backdropCloseDisabled={busy}
+                    panelClassName="bg-gray-800/95 backdrop-blur border border-gray-600 rounded-lg shadow-2xl w-[26rem] max-w-[90%] max-h-[80%] overflow-hidden flex flex-col"
+                >
+                    <div className="overflow-y-auto custom-scrollbar px-4 py-3 space-y-3 text-[12px]">
+                        <label className="block space-y-1">
+                            <span className="text-gray-400">File name</span>
+                            <input
+                                type="text"
+                                value={name}
+                                autoFocus
+                                spellCheck={false}
+                                onChange={(e) => setName(e.target.value)}
+                                onKeyDown={(e) => { if (e.key === 'Enter' && trimmedName && !busy) doExport(); }}
+                                className="w-full bg-gray-900 border border-gray-600 rounded px-2 py-1 text-gray-200 font-mono"
+                            />
+                        </label>
+                        <div className="space-y-1.5">
+                            <label className="flex items-center gap-2 cursor-pointer">
+                                <input type="radio" name="export-format" checked={format === 'mtlx'}
+                                    onChange={() => setFormat('mtlx')} className="accent-blue-500" />
+                                <span className="text-gray-200">MaterialX document (.mtlx)</span>
                             </label>
-                            <div className="space-y-1.5">
-                                <label className="flex items-center gap-2 cursor-pointer">
-                                    <input type="radio" name="export-format" checked={format === 'mtlx'}
-                                        onChange={() => setFormat('mtlx')} className="accent-blue-500" />
-                                    <span className="text-gray-200">MaterialX document (.mtlx)</span>
-                                </label>
-                                <label className={'flex items-center gap-2 ' + (resolved.length === 0 ? 'cursor-not-allowed' : 'cursor-pointer')}
-                                    title={zipDisabledTitle}>
-                                    <input type="radio" name="export-format" checked={format === 'zip'}
-                                        disabled={resolved.length === 0}
-                                        onChange={() => setFormat('zip')} className="accent-blue-500" />
-                                    <span className={resolved.length === 0 ? 'text-gray-500' : 'text-gray-200'}>
-                                        ZIP with textures (.zip)
-                                    </span>
-                                </label>
+                            <label className={'flex items-center gap-2 ' + (resolved.length === 0 ? 'cursor-not-allowed' : 'cursor-pointer')}
+                                title={zipDisabledTitle}>
+                                <input type="radio" name="export-format" checked={format === 'zip'}
+                                    disabled={resolved.length === 0}
+                                    onChange={() => setFormat('zip')} className="accent-blue-500" />
+                                <span className={resolved.length === 0 ? 'text-gray-500' : 'text-gray-200'}>
+                                    ZIP with textures (.zip)
+                                </span>
+                            </label>
+                        </div>
+                        {resolved.length > 0 && (
+                            <div className="text-gray-500 text-[11px]">
+                                {resolved.length} texture{resolved.length === 1 ? '' : 's'} will be packaged with the .zip.
                             </div>
-                            {resolved.length > 0 && (
-                                <div className="text-gray-500 text-[11px]">
-                                    {resolved.length} texture{resolved.length === 1 ? '' : 's'} will be packaged with the .zip.
+                        )}
+                        {unresolved.length > 0 && (
+                            <div className="rounded border border-amber-700/60 bg-amber-900/20 px-2.5 py-2 space-y-1">
+                                <div className="text-amber-400 font-bold text-[11px]">
+                                    Not found in this session, will not be packaged:
                                 </div>
-                            )}
-                            {unresolved.length > 0 && (
-                                <div className="rounded border border-amber-700/60 bg-amber-900/20 px-2.5 py-2 space-y-1">
-                                    <div className="text-amber-400 font-bold text-[11px]">
-                                        Not found in this session, will not be packaged:
-                                    </div>
-                                    <ul className="list-disc list-inside space-y-0.5 text-amber-200/90 font-mono text-[11px]">
-                                        {unresolved.map((ref, i) => <li key={i}>{ref}</li>)}
-                                    </ul>
-                                </div>
-                            )}
-                        </div>
-                        <div className="flex justify-end gap-2 px-4 py-2.5 border-t border-gray-700 bg-gray-900/70">
-                            <button
-                                onClick={onClose}
-                                disabled={busy}
-                                className="h-7 text-[11px] px-2.5 rounded border bg-gray-800/80 border-gray-600 text-gray-300 hover:bg-gray-700/80 transition-colors disabled:opacity-40"
-                            >Cancel</button>
-                            <button
-                                onClick={doExport}
-                                disabled={busy || !trimmedName}
-                                className="h-7 text-[11px] px-2.5 rounded border bg-blue-600/70 border-blue-500 text-white hover:bg-blue-500/70 transition-colors disabled:opacity-40"
-                            >{busy ? 'Exporting…' : 'Export'}</button>
-                        </div>
+                                <ul className="list-disc list-inside space-y-0.5 text-amber-200/90 font-mono text-[11px]">
+                                    {unresolved.map((ref, i) => <li key={i}>{ref}</li>)}
+                                </ul>
+                            </div>
+                        )}
                     </div>
-                </div>
+                    <div className="flex justify-end gap-2 px-4 py-2.5 border-t border-gray-700 bg-gray-900/70">
+                        <button
+                            onClick={onClose}
+                            disabled={busy}
+                            className={BTN_SECONDARY + ' disabled:opacity-40'}
+                        >Cancel</button>
+                        <button
+                            onClick={doExport}
+                            disabled={busy || !trimmedName}
+                            className={BTN_PRIMARY + ' disabled:opacity-40'}
+                        >{busy ? 'Exporting…' : 'Export'}</button>
+                    </div>
+                </DialogFrame>
             );
         }
 
@@ -457,46 +501,44 @@
         // "caller does the async work" split. `busy` (driven by the
         // caller while it fetches) disables every row and shows a spinner
         // on whichever one triggered it (`busyPath`) so the user gets
-        // feedback without the dialog needing its own network code. Same
-        // backdrop/Esc/stopPropagation contract as the other dialogs.
+        // feedback without the dialog needing its own network code. Chrome
+        // comes from the shared DialogFrame (see above).
         function PresetsDialog({ open, onClose, onPick, busy, busyPath }) {
             useEscapeToClose(onClose, open && !busy);
             if (!open) return null;
             return (
-                <div className="absolute inset-0 z-50 flex items-center justify-center bg-gray-950/70"
-                    onMouseDown={busy ? undefined : onClose}>
-                    <div className="bg-gray-800/95 backdrop-blur border border-gray-600 rounded-lg shadow-2xl w-[28rem] max-w-[90%] max-h-[80%] overflow-hidden flex flex-col"
-                        onMouseDown={(e) => e.stopPropagation()}>
-                        <div className="flex items-center justify-between px-4 py-2.5 border-b border-gray-700 bg-gray-900/70">
-                            <span className="text-[13px] font-bold text-gray-100">Presets</span>
-                            <button onClick={onClose} disabled={busy} title="Close"
-                                className="text-gray-400 hover:text-gray-200 leading-none text-lg px-1 disabled:opacity-40">{'×'}</button>
-                        </div>
-                        <div className="overflow-y-auto custom-scrollbar px-2 py-2 text-[12px]">
-                            {MTLX_PRESETS.map((preset) => {
-                                const rowBusy = busy && busyPath === preset.path;
-                                return (
-                                    <button
-                                        key={preset.path}
-                                        onClick={() => onPick(preset)}
-                                        disabled={busy}
-                                        title={preset.path}
-                                        className={'w-full text-left px-2.5 py-2 rounded flex items-center justify-between gap-2 transition-colors '
-                                            + (busy ? 'cursor-not-allowed opacity-60' : 'hover:bg-gray-700/70 cursor-pointer')}
-                                    >
-                                        <span className="min-w-0">
-                                            <span className="block text-gray-100 font-medium truncate">{preset.label}</span>
-                                            <span className="block text-gray-400 text-[11px] truncate">{preset.desc}</span>
-                                        </span>
-                                        {rowBusy && (
-                                            <span className="shrink-0 w-3.5 h-3.5 rounded-full border-2 border-gray-500 border-t-blue-400 animate-spin" />
-                                        )}
-                                    </button>
-                                );
-                            })}
-                        </div>
+                <DialogFrame
+                    open={open}
+                    title="Presets"
+                    onClose={onClose}
+                    closeDisabled={busy}
+                    backdropCloseDisabled={busy}
+                    panelClassName="bg-gray-800/95 backdrop-blur border border-gray-600 rounded-lg shadow-2xl w-[28rem] max-w-[90%] max-h-[80%] overflow-hidden flex flex-col"
+                >
+                    <div className="overflow-y-auto custom-scrollbar px-2 py-2 text-[12px]">
+                        {MTLX_PRESETS.map((preset) => {
+                            const rowBusy = busy && busyPath === preset.path;
+                            return (
+                                <button
+                                    key={preset.path}
+                                    onClick={() => onPick(preset)}
+                                    disabled={busy}
+                                    title={preset.path}
+                                    className={'w-full text-left px-2.5 py-2 rounded flex items-center justify-between gap-2 transition-colors '
+                                        + (busy ? 'cursor-not-allowed opacity-60' : 'hover:bg-gray-700/70 cursor-pointer')}
+                                >
+                                    <span className="min-w-0">
+                                        <span className="block text-gray-100 font-medium truncate">{preset.label}</span>
+                                        <span className="block text-gray-400 text-[11px] truncate">{preset.desc}</span>
+                                    </span>
+                                    {rowBusy && (
+                                        <span className="shrink-0 w-3.5 h-3.5 rounded-full border-2 border-gray-500 border-t-blue-400 animate-spin" />
+                                    )}
+                                </button>
+                            );
+                        })}
                     </div>
-                </div>
+                </DialogFrame>
             );
         }
 

--- a/js/graph/preview.jsx
+++ b/js/graph/preview.jsx
@@ -390,32 +390,30 @@
             // one view carries over to the other. Falls back to 'shaderball'
             // (this preview's long-standing hardcoded default) rather than
             // node-preview.jsx's 'sphere' when nothing is stored yet.
-            const [geom, setGeom] = React.useState(() => {
-                const valid = ['shaderball', 'sphere', 'cube'];
-                try {
-                    const g = localStorage.getItem('mtlx_preview_geom');
-                    return valid.indexOf(g) !== -1 ? g : 'shaderball';
-                } catch (e) { return 'shaderball'; }
-            });
-            const pickGeom = (g) => {
-                try { localStorage.setItem('mtlx_preview_geom', g); } catch (e) { /* best-effort */ }
-                setGeom(g);
-            };
-            // Auto-orbit + env-background toggles, applied live via the view
-            // handle (the SAME ref the parent passes in and reads elsewhere
-            // — see previewViewRef in graph-app.jsx) and re-read fresh at
-            // creation time so they survive a geometry-triggered rebuild.
-            const [rotating, toggleRotating] = useViewToggle(viewRef, 'setAutoRotate', false);
-            const [envBg, toggleEnvBg] = useViewToggle(viewRef, 'setEnvBackground', false);
-            const [envAvail, setEnvAvail] = React.useState(false);
-            const [viewEpoch, setViewEpoch] = React.useState(0);
-            const [isFullscreen, toggleFullscreenView] = useFullscreen(viewportRef);
+            // Preview geometry (persisted, shared 'mtlx_preview_geom' key —
+            // usePersistedGeom, js/shared/mtlx-ui.jsx) since it's the
+            // identical setting in spirit as the docs previewer's — a
+            // value picked in one view carries over to the other — but
+            // falls back to 'shaderball' (this preview's long-standing
+            // hardcoded default) rather than node-preview.jsx's 'sphere'
+            // when nothing is stored yet. Auto-orbit + env-background
+            // toggles, the view-epoch bump, fullscreen and the screenshot
+            // action (useViewportControls, same file) are applied live via
+            // the view handle (the SAME ref the parent passes in and reads
+            // elsewhere — see previewViewRef in graph-app.jsx) and re-read
+            // fresh at creation time so they survive a geometry-triggered
+            // rebuild.
+            const [geom, pickGeom] = usePersistedGeom('shaderball');
+            const {
+                rotating, toggleRotating,
+                envBg, toggleEnvBg,
+                envAvail, setEnvAvail,
+                viewEpoch, setViewEpoch,
+                isFullscreen, toggleFullscreen: toggleFullscreenView,
+                takeScreenshot: takeScreenshotRaw,
+            } = useViewportControls(viewRef, viewportRef, () => label + '_' + geom);
             const takeScreenshot = () => {
-                const view = viewRef && viewRef.current;
-                if (!view || !view.snapshot) return;
-                try {
-                    downloadSnapshot(view, label + '_' + geom);
-                } catch (e) { /* best-effort */ }
+                try { takeScreenshotRaw(); } catch (e) { /* best-effort */ }
             };
 
             // Component-lifetime handle to the CURRENTLY LIVE, GL-compiled
@@ -468,8 +466,8 @@
                         // very frame that node should first appear in. Same
                         // double-rAF-defer idiom as changeScope (graph-app.jsx)
                         // — the graph's commit paints first, the regen follows.
-                        await new Promise((r) => requestAnimationFrame(r));
-                        await new Promise((r) => requestAnimationFrame(r));
+                        await nextFrame();
+                        await nextFrame();
                         // Re-check staleness: another run may have started
                         // (and this effect's cleanup set mounted = false)
                         // while we were yielding across those two frames.
@@ -860,9 +858,10 @@
                             // running against the live view -- the OLD
                             // material keeps rendering/orbiting underneath,
                             // so this is a small corner badge rather than a
-                            // full overlay: there's no checker/blank flash
-                            // to paper over anymore (that was the old
-                            // lastFrame snapshot's job, deleted above).
+                            // full overlay: swapping materials on the SAME
+                            // live shell means there's no checker/blank
+                            // flash to paper over anymore, unlike the older
+                            // teardown-and-rebuild approach this replaced.
                             <div className="absolute top-1 right-1 z-10 text-[10px] px-1.5 py-0.5 rounded bg-gray-900/80 text-gray-300 pointer-events-none">{'Updating\u2026'}</div>
                         )}
                         <LoadingOverlay

--- a/js/mtlx-engine.js
+++ b/js/mtlx-engine.js
@@ -350,6 +350,18 @@ const mxElType = (el) => mxSafe(() => String(el.getType()), '');
 const mxElName = (el) => mxSafe(() => el.getName(), '');
 const mxElAttr = (el, name) => mxSafe(() => el.getAttribute(name), '');
 const mxElHasAttr = (el, name) => mxSafe(() => el.hasAttribute(name), false);
+// Exception-safe single-attribute writes — the wasm binding can throw on
+// a detached/invalid element, which mxSafe swallows into a `false` return.
+const mxSetAttr = (el, name, value) => mxSafe(() => { el.setAttribute(name, value); return true; }, false);
+const mxRemoveAttr = (el, name) => mxSafe(() => { el.removeAttribute(name); return true; }, false);
+// Tag an element's colorspace, preferring the typed setColorSpace()
+// binding when present and falling back to the raw attribute otherwise —
+// not every element's wasm binding exposes the typed setter.
+const mxSetColorspace = (el, cs) => mxSafe(() => {
+    if (typeof el.setColorSpace === 'function') el.setColorSpace(cs);
+    else el.setAttribute('colorspace', cs);
+    return true;
+}, false);
 
 // Shortest chain of `convert` hops fromType->toType using ONLY the
 // conversions the loaded library actually defines. This matters because
@@ -438,7 +450,7 @@ const ensureTypedInput = (doc, node, inputName, wantedType) => {
                 // meaningless on an instance and noisy in exports.
                 for (const attr of ['uimin', 'uimax', 'uisoftmin', 'uisoftmax', 'uistep',
                     'uiname', 'uifolder', 'uiadvanced', 'doc', 'enum', 'enumvalues']) {
-                    mxSafe(() => { inp.removeAttribute(attr); return true; }, false);
+                    mxRemoveAttr(inp, attr);
                 }
             }
         }
@@ -453,11 +465,11 @@ const ensureTypedInput = (doc, node, inputName, wantedType) => {
             return true;
         }, false);
         if (mxElType(inp) !== wantedType) {
-            mxSafe(() => { inp.setAttribute('type', wantedType); return true; }, false);
+            mxSetAttr(inp, 'type', wantedType);
         }
         // A copied default VALUE is malformed for the corrected type —
         // drop it; callers connect or re-value anyway.
-        mxSafe(() => { inp.removeAttribute('value'); return true; }, false);
+        mxRemoveAttr(inp, 'value');
     }
     if (inp && wantedType && mxElType(inp) !== wantedType) {
         console.warn('ensureTypedInput: "' + inputName + '" is "' + mxElType(inp) + '" (wanted "' + wantedType + '"), path=' + how);
@@ -504,7 +516,7 @@ const stripValuesFromConnectedInputs = (doc, maxDepth) => {
                 // bindings") as a non-empty one, and mxElAttr's ''
                 // fallback can't tell "absent" from "present but empty".
                 if (connected && mxElHasAttr(child, 'value')) {
-                    const removed = mxSafe(() => { child.removeAttribute('value'); return true; }, false);
+                    const removed = mxRemoveAttr(child, 'value');
                     if (removed) stripped++;
                 }
             }
@@ -514,6 +526,11 @@ const stripValuesFromConnectedInputs = (doc, maxDepth) => {
     walk(doc, 0);
     return stripped;
 };
+
+// Resolves on the next paint — callers awaiting this yield to the
+// browser instead of blocking it, letting a queued DOM/state update
+// actually paint before continuing.
+const nextFrame = () => new Promise((r) => requestAnimationFrame(r));
 
 // ------------------------------------------------------------------
 // Drag & drop ingestion pipeline — shared by node-graph.html and
@@ -631,6 +648,17 @@ const resolveIncludes = async (xml, fileMap, fromDir, visited) => {
     }
     parts.push(xml.slice(last));
     return parts.join('');
+};
+
+// Read a dropped file entry and resolve its xi:includes against the rest
+// of `map`. Callers need BOTH strings back: the graph editor validates the
+// RAW as-authored text (noteDocXml) while parsing consumes the RESOLVED
+// text, so this returns both rather than picking one.
+const readMtlxText = async (entry, path, map) => {
+    const raw = await entry.text();
+    const dir = path.indexOf('/') >= 0 ? path.slice(0, path.lastIndexOf('/')) : '';
+    const resolved = /<xi:include\b/.test(raw) ? await resolveIncludes(raw, map, dir) : raw;
+    return { raw, resolved };
 };
 
 // Session-lifetime texture cache, keyed by file identity (not by
@@ -3441,8 +3469,9 @@ Object.assign(window, {
     parseUniforms, stripVersion, encodeDisplay,
     mxErr, mxWriteValue, vecToArray,
     mxSafe, mxElName, mxElCat, mxElType, mxElAttr,
+    mxSetAttr, mxRemoveAttr, mxSetColorspace, nextFrame,
     findConvertChain, ensureTypedInput, stripValuesFromConnectedInputs,
-    normPath, readDroppedItems, expandZips, findFileForRef, resolveIncludes,
+    normPath, readDroppedItems, expandZips, findFileForRef, resolveIncludes, readMtlxText,
     TEXTURE_CACHE, textureCacheKey, bindDroppedTextures,
     collectMxUniforms, mxValueToThreeUniform,
     linToSrgb, srgbToLin, rgbToHex, hexToRgb,

--- a/js/node-preview.jsx
+++ b/js/node-preview.jsx
@@ -84,49 +84,40 @@
             React.useEffect(() => {
                 setOverrides((prev) => (Object.keys(prev).length ? {} : prev));
             }, [identKey]);
-            // Preview geometry (persisted): 'sphere' | 'cube' | 'shaderball'.
-            const [geom, setGeom] = React.useState(() => {
-                // Normalize: a stale persisted value that's no longer a valid
-                // option would render the geometry dropdown empty.
-                const valid = ['shaderball', 'sphere', 'cube'];
-                try {
-                    const g = localStorage.getItem('mtlx_preview_geom');
-                    return valid.indexOf(g) !== -1 ? g : 'sphere';
-                } catch (e) { return 'sphere'; }
-            });
-            const pickGeom = (g) => {
-                try { localStorage.setItem('mtlx_preview_geom', g); } catch (e) { /* best-effort */ }
-                setGeom(g);
-            };
             // Live render-view handle (turntable toggle, env background,
             // snapshot). Set by the preview effect, cleared on dispose.
             const viewRef = React.useRef(null);
-            // Auto-orbit rotation. OFF by default — the model starts still;
-            // the rotate button switches the camera turntable on/off, applied
-            // live via the render view (survives regens because creation
-            // options read the current value from a fresh effect closure).
-            const [rotating, toggleRotating] = useViewToggle(viewRef, 'setAutoRotate', false);
-            const controlsRef = React.useRef(null);
             // Fullscreen: the viewport CONTAINER goes fullscreen so the
             // geometry/pause controls overlay stays usable; the canvas is
             // h-full and the engine's ResizeObserver handles the buffer.
             const viewportRef = React.useRef(null);
-            const [isFullscreen, toggleFullscreenView] = useFullscreen(viewportRef);
-            // Environment map as visible background (mirrors the material
-            // viewer). Applied live via the view; regens re-apply it because
-            // the creation options read the current value (the effect re-runs
-            // with a fresh closure). Only offered when the view actually has
-            // an environment (lit previews) — see envAvail below.
-            const [envBg, toggleEnvBg] = useViewToggle(viewRef, 'setEnvBackground', false);
-            const [envAvail, setEnvAvail] = React.useState(false);
-            const [viewEpoch, setViewEpoch] = React.useState(0);
-            // PNG snapshot named after the node + geometry.
+            // Preview geometry (persisted, shared 'mtlx_preview_geom' key —
+            // usePersistedGeom, js/shared/mtlx-ui.jsx) and the rest of the
+            // viewport-controls cluster (useViewportControls, same file):
+            // auto-orbit rotation OFF by default — the model starts still,
+            // the rotate button switches the camera turntable on/off;
+            // env-background toggle (mirrors the material viewer), only
+            // offered once envAvail flips true for a lit preview; the
+            // view-epoch bump ViewportControls' Environment dialog watches
+            // to re-apply rotation/exposure/session override onto a fresh
+            // view after a rebuild; and fullscreen. All applied live via
+            // the render view and re-read fresh at creation time so they
+            // survive a geometry/string/colorspace regen. Shared with
+            // viewer-app.jsx / graph/preview.jsx.
+            const [geom, pickGeom] = usePersistedGeom('sphere');
+            const {
+                rotating, toggleRotating,
+                envBg, toggleEnvBg,
+                envAvail, setEnvAvail,
+                viewEpoch, setViewEpoch,
+                isFullscreen, toggleFullscreen: toggleFullscreenView,
+                takeScreenshot: takeScreenshotRaw,
+            } = useViewportControls(viewRef, viewportRef, () => nodeName + '_' + geom);
+            // PNG snapshot named after the node + geometry — best-effort,
+            // same as before (the hook's takeScreenshot has no internal
+            // try/catch).
             const takeScreenshot = () => {
-                const view = viewRef.current;
-                if (!view || !view.snapshot) return;
-                try {
-                    downloadSnapshot(view, nodeName + '_' + geom);
-                } catch (e) { /* best-effort */ }
+                try { takeScreenshotRaw(); } catch (e) { /* best-effort */ }
             };
             // Metadata for the .mtlx export (node element type, kind).
             const exportMetaRef = React.useRef(null);
@@ -521,13 +512,6 @@
                         let renderable;
                         let needsLighting = false;
 
-                        // Connect an input to the preview node, tapping a
-                        // specific output when the node is multi-output.
-                        const connectToPreview = (input, srcNode) => {
-                            input.setNodeName(srcNode);
-                            if (outputName) input.setAttribute('output', outputName);
-                        };
-
                         // findConvertChain(doc, fromType, toType) now lives in
                         // js/mtlx-engine.js (loaded before this script) and is
                         // used here as a window global.
@@ -560,8 +544,7 @@
                                         // exists (empty value is valid) and tag it;
                                         // the CMS bakes the transform at codegen.
                                         const inp = ensureTypedInput(doc, nodeInst, inputName, 'filename');
-                                        if (typeof inp.setColorSpace === 'function') inp.setColorSpace(String(value));
-                                        else inp.setAttribute('colorspace', String(value));
+                                        mxSetColorspace(inp, String(value));
                                         continue;
                                     }
                                     const inp = ensureTypedInput(doc, nodeInst, inputName, type || 'string');
@@ -580,6 +563,24 @@
                         // page's own inputs are always on the in-scope `doc`
                         // above, so `addTypedInput` is a thin alias binding it.
                         const addTypedInput = (node, name2, type2) => ensureTypedInput(doc, node, name2, type2);
+                        // Create/fetch a typed input and wire it: point it at
+                        // srcName (optionally tapping a specific output via
+                        // opts.output — for multi-output taps, e.g. a
+                        // preview_node's selected output), then strip
+                        // whatever value addTypedInput/ensureTypedInput may
+                        // have copied from the nodedef default onto the
+                        // fresh input — a connected input must never also
+                        // carry one. Folds the addTypedInput -> setNodeName
+                        // -> [setAttribute('output', ...)] -> strip-value
+                        // idiom that used to be repeated at every wiring
+                        // site below. Returns the input.
+                        const connectTypedInput = (node, name2, type2, srcName, opts) => {
+                            const inp = addTypedInput(node, name2, type2);
+                            inp.setNodeName(srcName);
+                            if (opts && opts.output) inp.setAttribute('output', opts.output);
+                            mxRemoveAttr(inp, 'value');
+                            return inp;
+                        };
 
                         if (kind === 'surface') {
                             renderable = doc.addNode(nodeName, 'preview_surface', 'surfaceshader');
@@ -594,12 +595,7 @@
                             applyOverrides(previewInstance);
                             createdNodes.push(previewInstance);
                             renderable = doc.addNode('surface', 'preview_surface', 'surfaceshader');
-                            const bsdfInp = addTypedInput(renderable, 'bsdf', 'BSDF');
-                            bsdfInp.setNodeName('preview_bsdf');
-                            // Item 9: addTypedInput may have copied the
-                            // nodedef default VALUE onto this fresh input —
-                            // strip it now that it's connected.
-                            mxSafe(() => { bsdfInp.removeAttribute('value'); return true; }, false);
+                            connectTypedInput(renderable, 'bsdf', 'BSDF', 'preview_bsdf');
                             createdNodes.push(renderable);
                             needsLighting = true;
                         } else if (kind === 'edf') {
@@ -608,12 +604,7 @@
                             applyOverrides(previewInstance);
                             createdNodes.push(previewInstance);
                             renderable = doc.addNode('surface', 'preview_surface', 'surfaceshader');
-                            const edfInp = addTypedInput(renderable, 'edf', 'EDF');
-                            edfInp.setNodeName('preview_edf');
-                            // Item 9: addTypedInput may have copied the
-                            // nodedef default VALUE onto this fresh input —
-                            // strip it now that it's connected.
-                            mxSafe(() => { edfInp.removeAttribute('value'); return true; }, false);
+                            connectTypedInput(renderable, 'edf', 'EDF', 'preview_edf');
                             createdNodes.push(renderable);
                             needsLighting = true;
                         } else if (kind === 'translation') {
@@ -635,21 +626,10 @@
                                 const iName = oName.slice(-4) === '_out' ? oName.slice(0, -4) : oName;
                                 const oT = out.getType ? out.getType() : 'color3';
                                 const oTypeStr = (oT && oT.getName) ? oT.getName() : String(oT);
-                                const inp = addTypedInput(renderable, iName, oTypeStr);
-                                inp.setNodeName('preview_node');
-                                inp.setAttribute('output', oName);
-                                // Item 9: addTypedInput (ensureTypedInput) may have
-                                // copied the nodedef default VALUE onto this fresh
-                                // input — a connected input must not also carry one.
-                                mxSafe(() => { inp.removeAttribute('value'); return true; }, false);
+                                connectTypedInput(renderable, iName, oTypeStr, 'preview_node', { output: oName });
                             }
                             const mat = doc.addNode('surfacematerial', 'preview_material', 'material');
-                            const matInp = addTypedInput(mat, 'surfaceshader', 'surfaceshader');
-                            matInp.setNodeName('preview_surface');
-                            // Item 9: addTypedInput may have copied the
-                            // nodedef default VALUE onto this fresh input —
-                            // strip it now that it's connected.
-                            mxSafe(() => { matInp.removeAttribute('value'); return true; }, false);
+                            connectTypedInput(mat, 'surfaceshader', 'surfaceshader', 'preview_surface');
                             createdNodes.push(mat);
                             needsLighting = true;
                         } else if (kind === 'color') {
@@ -679,13 +659,11 @@
                                     // (which taps 'preview_surface' by name)
                                     // picks it up unchanged.
                                     const conv = doc.addNode('convert', isLast ? 'preview_surface' : 'preview_convert' + (i || ''), toType);
-                                    const inp = addTypedInput(conv, 'in', prevType);
-                                    if (srcIsPreviewNode) connectToPreview(inp, 'preview_node');
-                                    else inp.setNodeName(srcName);
-                                    // Item 9: addTypedInput may have copied the
-                                    // nodedef default VALUE onto `inp` — strip it
-                                    // now that it's connected, either branch above.
-                                    mxSafe(() => { inp.removeAttribute('value'); return true; }, false);
+                                    // The first hop taps the preview node (and,
+                                    // for multi-output nodes, carries the
+                                    // `output` selection); later hops chain
+                                    // convert→convert.
+                                    connectTypedInput(conv, 'in', prevType, srcName, srcIsPreviewNode ? { output: outputName } : undefined);
                                     createdNodes.push(conv);
                                     srcName = isLast ? 'preview_surface' : 'preview_convert' + (i || '');
                                     srcIsPreviewNode = false;
@@ -708,16 +686,10 @@
                                 let prevType = outType;
                                 chain.forEach((toType, i) => {
                                     const conv = doc.addNode('convert', 'preview_convert' + (i || ''), toType);
-                                    const inp = addTypedInput(conv, 'in', prevType);
                                     // The FIRST hop taps the preview node (and, for
                                     // multi-output nodes, carries the `output`
                                     // selection); later hops chain convert→convert.
-                                    if (srcIsPreviewNode) connectToPreview(inp, 'preview_node');
-                                    else inp.setNodeName(srcName);
-                                    // Item 9: addTypedInput may have copied the
-                                    // nodedef default VALUE onto `inp` — strip it
-                                    // now that it's connected, either branch above.
-                                    mxSafe(() => { inp.removeAttribute('value'); return true; }, false);
+                                    connectTypedInput(conv, 'in', prevType, srcName, srcIsPreviewNode ? { output: outputName } : undefined);
                                     createdNodes.push(conv);
                                     srcName = 'preview_convert' + (i || '');
                                     srcIsPreviewNode = false;
@@ -731,16 +703,10 @@
                                 // the nodedef's declared float, so NO nodedef matches
                                 // the node instance → "Could not find a nodedef for
                                 // node 'preview_surface'" for every color-kind node.
-                                const emiss = addTypedInput(renderable, 'emission_color', 'color3');
                                 // No convert chain: emission_color taps preview_node
                                 // directly and must carry the `output` selection
                                 // itself for multi-output color3 taps.
-                                if (srcIsPreviewNode) connectToPreview(emiss, 'preview_node');
-                                else emiss.setNodeName(srcName);
-                                // Item 9: addTypedInput may have copied the
-                                // nodedef default VALUE onto `emiss` — strip it
-                                // now that it's connected, either branch above.
-                                mxSafe(() => { emiss.removeAttribute('value'); return true; }, false);
+                                connectTypedInput(renderable, 'emission_color', 'color3', srcName, srcIsPreviewNode ? { output: outputName } : undefined);
                             }
                         } else {
                             const shown = (types || []).join(', ') || 'unknown';
@@ -755,12 +721,7 @@
                         if (kind !== 'translation') {
                             try {
                                 const mat0 = doc.addNode('surfacematerial', 'preview_material', 'material');
-                                const mat0Inp = addTypedInput(mat0, 'surfaceshader', 'surfaceshader');
-                                mat0Inp.setNodeName('preview_surface');
-                                // Item 9: addTypedInput may have copied the
-                                // nodedef default VALUE onto this fresh input —
-                                // strip it now that it's connected.
-                                mxSafe(() => { mat0Inp.removeAttribute('value'); return true; }, false);
+                                connectTypedInput(mat0, 'surfaceshader', 'surfaceshader', 'preview_surface');
                                 createdNodes.push(mat0);
                             } catch (matErr) { /* export falls back to wrapper-less doc */ }
                         }
@@ -885,7 +846,6 @@
                         viewRef.current = view;
                         setViewEpoch((n) => n + 1);
                         setEnvAvail(!!(view.hasEnvBackground && view.hasEnvBackground()));
-                        controlsRef.current = view.controls;
                         const { uniforms, introspected } = view;
 
                         // ---- Dynamic parameter UI ----
@@ -1175,7 +1135,6 @@
 
                 return () => {
                     mounted = false;
-                    controlsRef.current = null;
                     if (viewRef.current === viewHandle) viewRef.current = null;
                     if (viewHandle) viewHandle.dispose();
                 };
@@ -1535,12 +1494,6 @@
                 </div>
             );
         };
-
-        // Auto-generated port table for nodes with no spec documentation:
-        // reads inputs/outputs (name, type, default, enum) directly from the
-        // node's nodedefs in the loaded standard library. Clearly disclaimed
-        // as machine-generated, since it is NOT part of the official docs.
-
 
         // ---- public API ----
         Object.assign(window, { Node3DPreview });

--- a/js/shared/mtlx-ui.jsx
+++ b/js/shared/mtlx-ui.jsx
@@ -11,6 +11,13 @@
 // plain script, so it self-exports via a single Object.assign(window, {})
 // at the bottom.
 
+// Recurring Tailwind button class strings — pulled out because the exact
+// same string (verbatim, byte-for-byte) shows up in more than one file;
+// near-twin variants elsewhere (different opacity/sizing) are NOT this —
+// leave those as their own inline strings rather than forcing a match.
+const BTN_SECONDARY = 'h-7 text-[11px] px-2.5 rounded border bg-gray-800/80 border-gray-600 text-gray-300 hover:bg-gray-700/80 transition-colors';
+const BTN_PRIMARY = 'h-7 text-[11px] px-2.5 rounded border bg-blue-600/70 border-blue-500 text-white hover:bg-blue-500/70 transition-colors';
+
 // Adds a window keydown listener that calls onClose() on Escape, active
 // whenever `when` isn't exactly `false` (so callers can pass a boolean
 // "is this dialog open" flag directly). Mirrors the Esc-to-close pattern
@@ -62,7 +69,10 @@ const useViewToggle = (viewRef, method, initial) => {
 // `<baseName, sanitized>.png`. Silently no-ops if the view has no frame to
 // snapshot (falsy dataURL) — matches both original copies' behavior.
 // Callers that want an error surfaced (e.g. viewer-app's setError) wrap
-// the call in their own try/catch; view.snapshot() can throw.
+// the call in their own try/catch; view.snapshot() can throw. Unlike
+// downloadBlob below, view.snapshot() hands back a plain data: URL —
+// there's no object URL to revoke, so this deliberately has no setTimeout
+// cleanup step.
 const downloadSnapshot = (view, baseName) => {
     const url = view.snapshot();
     if (!url) return;
@@ -72,16 +82,78 @@ const downloadSnapshot = (view, baseName) => {
     a.click();
 };
 
-// Download an XML string as a .mtlx (or any) file: Blob -> object URL ->
-// synthetic anchor click -> delayed revoke (gives the download a moment
-// to start before the URL is freed).
-const downloadXml = (xml, filename) => {
-    const blob = new Blob([xml], { type: 'application/xml' });
+// Download a Blob as a file: object URL -> synthetic anchor click ->
+// delayed revoke (gives the download a moment to start before the URL is
+// freed).
+const downloadBlob = (blob, filename) => {
     const a = document.createElement('a');
     a.href = URL.createObjectURL(blob);
     a.download = filename;
     a.click();
     setTimeout(() => URL.revokeObjectURL(a.href), 5000);
+};
+
+// Download an XML string as a .mtlx (or any) file.
+const downloadXml = (xml, filename) => {
+    downloadBlob(new Blob([xml], { type: 'application/xml' }), filename);
+};
+
+// Bundles the viewport-control state cluster duplicated across the three
+// preview surfaces (viewer-app.jsx, node-preview.jsx, graph/preview.jsx):
+// rotate/env-background toggles (useViewToggle), env-availability +
+// view-epoch state (both consumed by ViewportControls' Environment
+// dialog), fullscreen (useFullscreen), and a screenshot action.
+// `getSnapshotBase` supplies the FULL PNG base name — each caller's own
+// `<name>_<geom>` convention (material name / node name / preview label)
+// — this hook has no opinion on geometry suffixes itself. Deliberately
+// has NO try/catch around takeScreenshot: the material viewer wraps its
+// own call in try/setError to surface failures to the user; the other
+// two callers swallow them at the call site, matching their original
+// copies.
+const useViewportControls = (viewRef, viewportRef, getSnapshotBase) => {
+    const [rotating, toggleRotating] = useViewToggle(viewRef, 'setAutoRotate', false);
+    const [envBg, toggleEnvBg] = useViewToggle(viewRef, 'setEnvBackground', false);
+    const [envAvail, setEnvAvail] = React.useState(false);
+    const [viewEpoch, setViewEpoch] = React.useState(0);
+    const [isFullscreen, toggleFullscreen] = useFullscreen(viewportRef);
+    const takeScreenshot = () => {
+        const view = viewRef.current;
+        // Null/snapshot-less view → silent no-op, reproducing all three
+        // pre-refactor call sites' guard.
+        if (!view || !view.snapshot) return;
+        downloadSnapshot(view, getSnapshotBase());
+    };
+    return {
+        rotating, toggleRotating,
+        envBg, toggleEnvBg,
+        envAvail, setEnvAvail,
+        viewEpoch, setViewEpoch,
+        isFullscreen, toggleFullscreen,
+        takeScreenshot,
+    };
+};
+
+// The `mtlx_preview_geom` localStorage read/validate/write pattern shared
+// by node-preview.jsx and graph/preview.jsx: on mount, read the stored
+// geometry choice and fall back to `defaultGeom` if it's missing or no
+// longer one of the valid options (guards against a stale persisted value
+// rendering the geometry dropdown empty). `pickGeom` writes a new choice
+// back to the SAME key (both previews intentionally share one setting,
+// best-effort — some browsers block localStorage entirely) and updates
+// state. Returns [geom, pickGeom].
+const usePersistedGeom = (defaultGeom) => {
+    const [geom, setGeom] = React.useState(() => {
+        const valid = ['shaderball', 'sphere', 'cube'];
+        try {
+            const g = localStorage.getItem('mtlx_preview_geom');
+            return valid.indexOf(g) !== -1 ? g : defaultGeom;
+        } catch (e) { return defaultGeom; }
+    });
+    const pickGeom = (g) => {
+        try { localStorage.setItem('mtlx_preview_geom', g); } catch (e) { /* best-effort */ }
+        setGeom(g);
+    };
+    return [geom, pickGeom];
 };
 
 // Hand a document off to the node graph editor: stash it (plus any loose
@@ -93,6 +165,19 @@ const openInGraphEditor = ({ xml, name, files }) => {
     window.__mtlxPendingImport = { xml, name, files: files || null };
     window.dispatchEvent(new CustomEvent('mtlx-load-document', { detail: window.__mtlxPendingImport }));
     window.location.hash = '#!graph';
+};
+
+// Filters a relPath -> File|Blob session map down to the loose
+// (non-.mtlx) companion files — the payload openInGraphEditor/
+// openInViewer above hand off ALONGSIDE a document's XML (textures etc.),
+// as opposed to the .mtlx itself. Duplicated verbatim in viewer-app.jsx's
+// sendToEditor and graph-app.jsx's sendToViewer before this extraction.
+const looseFilesFrom = (fileMap) => {
+    const files = {};
+    Object.keys(fileMap || {}).forEach((k) => {
+        if (!/\.mtlx$/i.test(k)) files[k] = fileMap[k];
+    });
+    return files;
 };
 
 // Hand a document off to the material viewer — the graph editor's "Send to
@@ -848,8 +933,11 @@ class PreviewErrorBoundary extends React.Component {
 }
 
 Object.assign(window, {
+    BTN_SECONDARY, BTN_PRIMARY,
     useEscapeToClose, useFullscreen, useViewToggle,
-    downloadSnapshot, downloadXml, openInGraphEditor, openInViewer,
+    downloadSnapshot, downloadBlob, downloadXml,
+    useViewportControls, usePersistedGeom,
+    openInGraphEditor, openInViewer, looseFilesFrom,
     useWindowFileDrop, LoadingOverlay, ViewportControls,
     ColorSwatch, PreviewErrorBoundary,
 });

--- a/js/viewer-app.jsx
+++ b/js/viewer-app.jsx
@@ -21,10 +21,10 @@
             'https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/' +
             'v1.39.5/resources/Materials/Examples/OpenPbr/open_pbr_default.mtlx';
 
-        // normPath, readDroppedItems, expandZips, findFileForRef and
-        // resolveIncludes now live in js/mtlx-engine.js (loaded before this
-        // script) and are used here as window globals like the rest of the
-        // shared engine API.
+        // normPath, readDroppedItems, expandZips, findFileForRef,
+        // resolveIncludes and readMtlxText now live in js/mtlx-engine.js
+        // (loaded before this script) and are used here as window globals
+        // like the rest of the shared engine API.
 
         // ---- Document loading ---------------------------------------------
 
@@ -138,31 +138,37 @@
             const loadedRef = React.useRef(null); // { mx, gen, genContext, lightData, doc, renderables }
 
             // --- Viewport controls (mirror the node previewer's) ---
-            // Camera auto-rotation pause: applied live on the view; also passed
-            // at creation so it survives geometry/material regens.
-            // OFF by default: the model starts still; the rotate button
-            // switches the camera turntable on/off (applied live, and passed
-            // at creation so it survives material/geometry regens).
-            const [rotating, toggleRotating] = useViewToggle(viewRef, 'setAutoRotate', false);
-            // Environment map shown as the visible background (IBL is always on).
-            const [envBg, toggleEnvBg] = useViewToggle(viewRef, 'setEnvBackground', false);
-            // Bumped every time a new view is assigned into viewRef.current
-            // below (view creation effect) — ViewportControls' Environment
-            // dialog watches this to re-apply rotation/exposure/session
-            // override onto the fresh view after a rebuild.
-            const [viewEpoch, setViewEpoch] = React.useState(0);
-            // Fullscreen: the CONTAINER div goes fullscreen (not the canvas),
-            // so the overlaid viewport controls stay visible. The engine's
-            // ResizeObserver resizes the render buffer automatically.
+            // Shared with node-preview.jsx / graph/preview.jsx via
+            // useViewportControls (js/shared/mtlx-ui.jsx): camera
+            // auto-rotation pause (OFF by default — the model starts
+            // still), the environment-background toggle (IBL is always
+            // on), the view-epoch bump ViewportControls' Environment
+            // dialog watches to re-apply rotation/exposure/session
+            // override onto a fresh view after a rebuild, and fullscreen
+            // (the CONTAINER div goes fullscreen, not the canvas, so the
+            // overlaid viewport controls stay visible — the engine's
+            // ResizeObserver resizes the render buffer automatically).
             const viewportRef = React.useRef(null);
-            const [isFullscreen, onToggleFullscreen] = useFullscreen(viewportRef);
-            // PNG snapshot of the current frame, named after material + geometry.
-            const takeScreenshot = () => {
-                const view = viewRef.current;
-                if (!view || !view.snapshot) return;
+            // PNG snapshot base name — material + geometry, exactly as
+            // before; read fresh by the hook on every screenshot.
+            const getSnapshotBase = () => {
                 const matName = (renderables[chosenMat] && renderables[chosenMat].name) || 'material';
+                return matName + '_' + geom;
+            };
+            const {
+                rotating, toggleRotating,
+                envBg, toggleEnvBg,
+                viewEpoch, setViewEpoch,
+                isFullscreen, toggleFullscreen: onToggleFullscreen,
+                takeScreenshot: takeScreenshotRaw,
+            } = useViewportControls(viewRef, viewportRef, getSnapshotBase);
+            // The hook's takeScreenshot has no internal try/catch (shared
+            // with the previewers, which swallow a failed snapshot
+            // silently) — the viewer instead surfaces it as an error
+            // banner, so that wrapping stays local to this call site.
+            const takeScreenshot = () => {
                 try {
-                    downloadSnapshot(view, matName + '_' + geom);
+                    takeScreenshotRaw();
                 } catch (e) {
                     setError('Save PNG preview failed: ' + String(e && e.message || e));
                 }
@@ -186,10 +192,7 @@
                     console.warn('Send to Editor: failed to serialize the document', e);
                     return;
                 }
-                const files = {};
-                Object.keys(fileMapRef.current || {}).forEach((k) => {
-                    if (!/\.mtlx$/i.test(k)) files[k] = fileMapRef.current[k];
-                });
+                const files = looseFilesFrom(fileMapRef.current || {});
                 const name = (chosenMtlx || 'material').replace(/\.mtlx$/i, '').split('/').pop();
                 openInGraphEditor({ xml, name, files });
             };
@@ -393,11 +396,11 @@
                 setBusy(true); // stays on through the render effect below
                 setStatus('Parsing ' + path + ' \u2026');
                 try {
-                    let xml = await map[path].text();
-                    if (/<xi:include\b/.test(xml)) {
-                        const dir = path.indexOf('/') >= 0 ? path.slice(0, path.lastIndexOf('/')) : '';
-                        xml = await resolveIncludes(xml, map, dir);
-                    }
+                    // readMtlxText resolves xi:includes for us; only the
+                    // resolved text is parsed here (the raw half of its
+                    // return is for callers that need the as-authored text,
+                    // e.g. the graph editor's own load path — unused here).
+                    const { resolved: xml } = await readMtlxText(map[path], path, map);
                     const loaded = await loadMtlxDocument(xml);
                     loadedRef.current = loaded;
                     setRenderables(loaded.renderables);

--- a/vscode_extension/media/bootstrap.js
+++ b/vscode_extension/media/bootstrap.js
@@ -318,107 +318,106 @@
     var lastDocName = null;
     var lastBlobMap = null;
 
-    // NOTE: this is NOT the only postMessage traffic this page can see —
-    // the site's own graph-editor docs dialog embeds
-    // index.html?embed=1#/... in an <iframe>, and code under js/docs/
-    // posts messages for that iframe's own close/resize signaling. Those
-    // have a different shape (no `.type === 'mtlx-open'`) and target the
-    // iframe's parent window rather than this top-level webview document
-    // — but the type check below is kept regardless, both as
-    // defense-in-depth and because a future site change could add other
-    // message shapes at this level.
-    window.addEventListener('message', function (event) {
-        var msg = event.data;
-        if (!msg) return;
+    // One function per window 'message' type this webview handles; the
+    // listener registered below (after these declarations) is reduced to
+    // a dispatch over them. Split out of what was previously one large
+    // inline handler purely for readability — every closure capture
+    // (pendingFetches, pendingSave, lastDocName/lastBlobMap, vscodeApi,
+    // ...) and every early-return guard is unchanged from before the
+    // split.
 
-        // 'mtlx-fetch-result': the extension host answering an
-        // 'mtlx-fetch' posted by the fetch() bridge above. Settle and
-        // forget the pending entry; unknown/duplicate ids are ignored.
-        if (msg.type === 'mtlx-fetch-result') {
-            var pending = pendingFetches[msg.id];
-            if (!pending) return;
-            delete pendingFetches[msg.id];
-            if (msg.ok && msg.bytesB64) {
-                pending.resolve(new Response(base64ToUint8(msg.bytesB64), {
-                    status: 200,
-                    headers: {
-                        'Content-Type': /\.wasm$/.test(pending.path)
-                            ? 'application/wasm'
-                            : 'application/octet-stream',
-                    },
-                }));
-            } else {
-                pending.fallback();
-            }
-            return;
+    // 'mtlx-fetch-result': the extension host answering an 'mtlx-fetch'
+    // posted by the fetch() bridge above. Settle and forget the pending
+    // entry; unknown/duplicate ids are ignored.
+    function handleFetchResult(msg) {
+        var pending = pendingFetches[msg.id];
+        if (!pending) return;
+        delete pendingFetches[msg.id];
+        if (msg.ok && msg.bytesB64) {
+            pending.resolve(new Response(base64ToUint8(msg.bytesB64), {
+                status: 200,
+                headers: {
+                    'Content-Type': /\.wasm$/.test(pending.path)
+                        ? 'application/wasm'
+                        : 'application/octet-stream',
+                },
+            }));
+        } else {
+            pending.fallback();
         }
+    }
 
-        // 'mtlx-save-result': the extension host answering an 'mtlx-save'
-        // posted by the Ctrl/Cmd+S handler below. Settle the one in-flight
-        // save (there is never more than one outstanding — the keydown
-        // handler doesn't post a new 'mtlx-save' until the previous one
-        // settles) and forget it; a stray/duplicate reply with nothing
-        // pending is ignored.
-        if (msg.type === 'mtlx-save-result') {
-            if (!pendingSave) return;
-            var settleSave = pendingSave;
-            pendingSave = null;
-            if (msg.ok) settleSave.resolve();
-            else settleSave.reject(new Error(msg.error || 'save failed'));
-            return;
-        }
+    // 'mtlx-save-result': the extension host answering an 'mtlx-save'
+    // posted by the Ctrl/Cmd+S handler below. Settle the one in-flight
+    // save (there is never more than one outstanding — the keydown
+    // handler doesn't post a new 'mtlx-save' until the previous one
+    // settles) and forget it; a stray/duplicate reply with nothing
+    // pending is ignored.
+    function handleSaveResult(msg) {
+        if (!pendingSave) return;
+        var settleSave = pendingSave;
+        pendingSave = null;
+        if (msg.ok) settleSave.resolve();
+        else settleSave.reject(new Error(msg.error || 'save failed'));
+    }
 
-        // 'mtlx-request-save': the extension host asking this webview to
-        // save, posted by editorProvider.js's saveActiveGraph() in
-        // response to the materialxPlayground.saveGraph command (the
-        // contributed Ctrl+S keybinding — see the comment above
-        // requestGraphSave() for why that's the primary path now).
-        // Reuses the exact same function the in-page keydown fallback
-        // calls, guard and all.
-        if (msg.type === 'mtlx-request-save') {
-            requestGraphSave();
-            return;
-        }
+    // 'mtlx-request-save': the extension host asking this webview to
+    // save, posted by editorProvider.js's saveActiveGraph() in response
+    // to the materialxPlayground.saveGraph command (the contributed
+    // Ctrl+S keybinding — see the comment above requestGraphSave() for
+    // why that's the primary path now). Reuses the exact same function
+    // the in-page keydown fallback calls, guard and all.
+    function handleRequestSave() {
+        requestGraphSave();
+    }
 
-        // 'mtlx-request-undo' / 'mtlx-request-redo': the extension host
-        // asking this webview to undo/redo, posted by editorProvider.js's
-        // undoActiveGraph()/redoActiveGraph() in response to the
-        // materialxPlayground.undoGraph/redoGraph commands (the contributed
-        // Ctrl+Z/Ctrl+Shift+Z/Ctrl+Y keybindings). Same primary-path
-        // rationale as Ctrl+S above — the workbench keybinding service, not
-        // this page, is the reliable responder for a chord VS Code also
-        // wants — but these keybindings additionally SHADOW VS Code's own
-        // text-document undo/redo while our editor is active. Undo/redo now
-        // defer to VS Code's own NATIVE document undo/redo (requested via
-        // 'mtlx-native-undo'/'mtlx-native-redo', handled host-side in
-        // editorProvider.js) rather than a separate JS-side graph undo
-        // stack: the document buffer is kept continuously in sync via
-        // window.__mtlxNotifyEdit ('mtlx-sync', see above), so the native
-        // stack already reflects every graph edit. The guards below (graph
-        // view visible, not focused in a text field) still matter because
-        // the contributed keybinding fires unconditionally regardless of
-        // webview-internal DOM focus.
-        if (msg.type === 'mtlx-request-undo' || msg.type === 'mtlx-request-redo') {
-            // No-op unless the Graph view is the visible/mounted one —
-            // same guard requestGraphSave() uses.
-            if (location.hash.indexOf('#!graph') !== 0) return;
-            var isUndo = msg.type === 'mtlx-request-undo';
-            // No-op when focus is in an editable element: a text field's
-            // native undo already handled the chord in-page (e.g. a label
-            // being typed into), so this contributed keybinding firing on
-            // top of it must not ALSO undo a graph edit.
-            var active = document.activeElement;
-            var isEditable = active && (
-                active.isContentEditable
-                || /^(INPUT|TEXTAREA|SELECT)$/.test(active.tagName || '')
-            );
-            if (isEditable) return;
-            vscodeApi.postMessage({ type: isUndo ? 'mtlx-native-undo' : 'mtlx-native-redo' });
-            return;
-        }
+    // 'mtlx-request-undo' / 'mtlx-request-redo': the extension host
+    // asking this webview to undo/redo, posted by editorProvider.js's
+    // undoActiveGraph()/redoActiveGraph() in response to the
+    // materialxPlayground.undoGraph/redoGraph commands (the contributed
+    // Ctrl+Z/Ctrl+Shift+Z/Ctrl+Y keybindings). Same primary-path
+    // rationale as Ctrl+S above — the workbench keybinding service, not
+    // this page, is the reliable responder for a chord VS Code also
+    // wants — but these keybindings additionally SHADOW VS Code's own
+    // text-document undo/redo while our editor is active. Undo/redo now
+    // defer to VS Code's own NATIVE document undo/redo (requested via
+    // 'mtlx-native-undo'/'mtlx-native-redo', handled host-side in
+    // editorProvider.js) rather than a separate JS-side graph undo
+    // stack: the document buffer is kept continuously in sync via
+    // window.__mtlxNotifyEdit ('mtlx-sync', see above), so the native
+    // stack already reflects every graph edit. The guards below (graph
+    // view visible, not focused in a text field) still matter because
+    // the contributed keybinding fires unconditionally regardless of
+    // webview-internal DOM focus.
+    function handleRequestUndoRedo(msg) {
+        // No-op unless the Graph view is the visible/mounted one —
+        // same guard requestGraphSave() uses.
+        if (location.hash.indexOf('#!graph') !== 0) return;
+        var isUndo = msg.type === 'mtlx-request-undo';
+        // No-op when focus is in an editable element: a text field's
+        // native undo already handled the chord in-page (e.g. a label
+        // being typed into), so this contributed keybinding firing on
+        // top of it must not ALSO undo a graph edit.
+        var active = document.activeElement;
+        var isEditable = active && (
+            active.isContentEditable
+            || /^(INPUT|TEXTAREA|SELECT)$/.test(active.tagName || '')
+        );
+        if (isEditable) return;
+        vscodeApi.postMessage({ type: isUndo ? 'mtlx-native-undo' : 'mtlx-native-redo' });
+    }
 
-        if (msg.type !== 'mtlx-open') return;
-
+    // 'mtlx-open': editorProvider.js posts { type: 'mtlx-open', mode,
+    // name, xml, filesB64 } (resolveCustomTextEditor's sendUpdate()) once
+    // on initial load and again on every debounced text-document change
+    // (live reload), or { type: 'mtlx-open', mode: 'docs', hash } for a
+    // docs-panel (re)navigation. lastDocName/lastBlobMap are remembered
+    // here (module-scoped, not function-local) so the hashchange listener
+    // further down (Graph -> Viewer sync on view switch) can hand the
+    // Viewer the same name/texture-blob context the Graph editor itself
+    // was loaded with, even though that sync fires long after this
+    // function returns and the original payload is out of scope.
+    function handleOpen(msg) {
         var mode = msg.mode;
         var name = msg.name;
         var xml = msg.xml;
@@ -486,11 +485,39 @@
         } else if (mode === 'docs') {
             // No document payload contract for the docs view (it has no
             // per-file state to import) — just make sure the hash agrees.
-            // A reused docs panel (the materialxPlayground.openDocs command's
-            // singleton) is re-navigated this way; msg.hash is always
-            // '#!docs' in practice today (the command only ever sends that).
+            // A reused docs panel (the materialxPlayground.openDocs
+            // command's singleton) is re-navigated this way. msg.hash is
+            // NOT always '#!docs' in practice: the hover "Open
+            // Interactive Documentation" deep link (extension.js builds
+            // the hash, editorProvider.js's openDocsPanel forwards it as
+            // this same 'mtlx-open'/mode:'docs' message) routinely sends
+            // '#/<category>?sig=…' through this exact path — the
+            // '#!docs' fallback below only fires when msg.hash itself is
+            // falsy (a no-arg/category-less open: Command Palette,
+            // explorer context menu, or a reused panel with nothing more
+            // specific to show).
             location.hash = msg.hash || '#!docs';
         }
+    }
+
+    // NOTE: this is NOT the only postMessage traffic this page can see —
+    // the site's own graph-editor docs dialog embeds
+    // index.html?embed=1#/... in an <iframe>, and code under js/docs/
+    // posts messages for that iframe's own close/resize signaling. Those
+    // have a different shape (no `.type === 'mtlx-open'`) and target the
+    // iframe's parent window rather than this top-level webview document
+    // — but the type check below is kept regardless, both as
+    // defense-in-depth and because a future site change could add other
+    // message shapes at this level.
+    window.addEventListener('message', function (event) {
+        var msg = event.data;
+        if (!msg) return;
+        if (msg.type === 'mtlx-fetch-result') { handleFetchResult(msg); return; }
+        if (msg.type === 'mtlx-save-result') { handleSaveResult(msg); return; }
+        if (msg.type === 'mtlx-request-save') { handleRequestSave(msg); return; }
+        if (msg.type === 'mtlx-request-undo' || msg.type === 'mtlx-request-redo') { handleRequestUndoRedo(msg); return; }
+        if (msg.type !== 'mtlx-open') return;
+        handleOpen(msg);
     }, false);
 
     // ------------------------------------------------------------------

--- a/vscode_extension/src/docScanner.js
+++ b/vscode_extension/src/docScanner.js
@@ -28,6 +28,7 @@
 'use strict';
 
 const vscode = require('vscode');
+const { errMsg } = require('./util');
 
 const MAX_DOCS = 12; // guard only, matches loadPreset's MAX_DOCS — xi:include chains in practice nest at most one deep
 const MAX_BYTES = 64 * 1024 * 1024; // total payload cap across all included docs + textures
@@ -59,6 +60,17 @@ function isUnsafeRef(ref) {
     return false;
 }
 
+// Double-quote-only `name="value"` attribute extraction, shared by the
+// three fileprefix/value lookups in extractFilenameRefs below. MUST stay
+// double-quote-only — a deliberate mirror of js/graph-app.jsx's own
+// extractFilenameRefs (see this file's banner), which never bothers with
+// single-quoted attributes for these particular fields. Returns the
+// captured value, or null if `tag` has no such (double-quoted) attribute.
+function attrDq(tag, name) {
+    const m = new RegExp('\\b' + name + '\\s*=\\s*"([^"]*)"').exec(tag);
+    return m ? m[1] : null;
+}
+
 // Port of js/graph-app.jsx's extractFilenameRefs (~line 1650): splits the
 // doc into "scopes" (each <nodegraph>'s body, plus everything outside any
 // nodegraph), each carrying its own accumulated fileprefix (root
@@ -67,14 +79,14 @@ function isUnsafeRef(ref) {
 // scope's <input type="filename" value="..."> tags.
 function extractFilenameRefs(xml) {
     const rootAttrs = (/<materialx\b([^>]*)>/.exec(xml) || [])[1] || '';
-    const rootPrefix = (/\bfileprefix\s*=\s*"([^"]*)"/.exec(rootAttrs) || [])[1] || '';
+    const rootPrefix = attrDq(rootAttrs, 'fileprefix') || '';
     const scopes = [];
     let cursor = 0;
     const NG = /<nodegraph\b([^>]*)>([\s\S]*?)<\/nodegraph>/g;
     let ngm;
     while ((ngm = NG.exec(xml)) !== null) {
         scopes.push({ text: xml.slice(cursor, ngm.index), prefix: rootPrefix });
-        const ngPrefix = (/\bfileprefix\s*=\s*"([^"]*)"/.exec(ngm[1]) || [])[1] || '';
+        const ngPrefix = attrDq(ngm[1], 'fileprefix') || '';
         scopes.push({ text: ngm[2], prefix: rootPrefix + ngPrefix });
         cursor = ngm.index + ngm[0].length;
     }
@@ -84,8 +96,7 @@ function extractFilenameRefs(xml) {
         const tags = scope.text.match(/<input\b[^>]*>/g) || [];
         for (const tag of tags) {
             if (!/\btype\s*=\s*"filename"/.test(tag)) continue;
-            const m = /\bvalue\s*=\s*"([^"]*)"/.exec(tag);
-            const raw = m && m[1];
+            const raw = attrDq(tag, 'value');
             if (!raw) continue;
             refs.push(scope.prefix + raw);
         }
@@ -137,7 +148,7 @@ async function scan(documentUri, xmlText) {
                 files[item.mapKey] = bytes;
                 xml = Buffer.from(bytes).toString('utf8');
             } catch (e) {
-                warnings.push('Could not read included document "' + item.mapKey + '": ' + (e && e.message ? e.message : String(e)));
+                warnings.push('Could not read included document "' + item.mapKey + '": ' + errMsg(e));
                 continue;
             }
         }
@@ -161,7 +172,7 @@ async function scan(documentUri, xmlText) {
             try {
                 incUri = vscode.Uri.joinPath(item.dirUri, href);
             } catch (e) {
-                warnings.push('Could not resolve xi:include href "' + href + '": ' + (e && e.message ? e.message : String(e)));
+                warnings.push('Could not resolve xi:include href "' + href + '": ' + errMsg(e));
                 continue;
             }
             const visitKey = incUri.toString();
@@ -202,7 +213,7 @@ async function scan(documentUri, xmlText) {
             try {
                 refUri = vscode.Uri.joinPath(dirUri, ref);
             } catch (e) {
-                warnings.push('Could not resolve texture ref "' + ref + '": ' + (e && e.message ? e.message : String(e)));
+                warnings.push('Could not resolve texture ref "' + ref + '": ' + errMsg(e));
                 continue;
             }
             try {
@@ -214,7 +225,7 @@ async function scan(documentUri, xmlText) {
                 }
                 files[ref] = bytes;
             } catch (e) {
-                warnings.push('Could not read texture "' + ref + '" (falls back to the checker in the viewer): ' + (e && e.message ? e.message : String(e)));
+                warnings.push('Could not read texture "' + ref + '" (falls back to the checker in the viewer): ' + errMsg(e));
             }
         }
     }

--- a/vscode_extension/src/editorProvider.js
+++ b/vscode_extension/src/editorProvider.js
@@ -11,6 +11,7 @@
 const vscode = require('vscode');
 const path = require('path');
 const docScanner = require('./docScanner');
+const { errMsg } = require('./util');
 
 // How long to wait after the last keystroke before rescanning + resending
 // the document to the webview. Keeps a fast typist from triggering a
@@ -80,6 +81,15 @@ function getSharedOutputChannel() {
     return sharedOutputChannel;
 }
 
+// Shared by every timestamped OutputChannel line this extension writes
+// (the 'mtlx-error' forward below, sendUpdate's per-warning log further
+// down, and extension.js's tier-2-unavailable log, which imports this) —
+// prepends a '[ISO timestamp] ' prefix so entries can be correlated
+// against other logs.
+function logLine(channel, text) {
+    channel.appendLine('[' + new Date().toISOString() + '] ' + text);
+}
+
 // Handles the two message types every MaterialX webview can send,
 // regardless of which command created it:
 //   - 'mtlx-fetch'  { id, path }: media/bootstrap.js's fetch() bridge
@@ -124,11 +134,11 @@ function wireCommonWebviewMessages(webview, repoRootUri, outputChannel) {
                 // bootstrap.js falls back to its native fetch on
                 // { ok: false }, so a read failure here is never worse
                 // than not having the bridge at all.
-                webview.postMessage({ type: 'mtlx-fetch-result', id, ok: false, error: err && err.message ? err.message : String(err) });
+                webview.postMessage({ type: 'mtlx-fetch-result', id, ok: false, error: errMsg(err) });
             }
         } else if (msg.type === 'mtlx-error') {
             const channel = outputChannel || getSharedOutputChannel();
-            channel.appendLine('[' + new Date().toISOString() + '] ' + String(msg.text || ''));
+            logLine(channel, String(msg.text || ''));
         }
     });
 }
@@ -309,7 +319,7 @@ class MaterialXEditorProvider {
                         // devtools console, which most users never open.
                         const channel = getSharedOutputChannel();
                         for (const warning of warnings) {
-                            channel.appendLine('[' + new Date().toISOString() + '] ' + document.fileName + ': ' + warning);
+                            logLine(channel, document.fileName + ': ' + warning);
                         }
                     }
                     webviewPanel.webview.postMessage({
@@ -322,7 +332,7 @@ class MaterialXEditorProvider {
                 } catch (err) {
                     vscode.window.showErrorMessage(
                         'MaterialX Playground: failed to load "' + path.basename(document.fileName) + '" — '
-                        + (err && err.message ? err.message : String(err))
+                        + errMsg(err)
                     );
                 }
             };
@@ -396,7 +406,7 @@ class MaterialXEditorProvider {
                         await document.save();
                         webviewPanel.webview.postMessage({ type: 'mtlx-save-result', ok: true });
                     } catch (err) {
-                        const message = err && err.message ? err.message : String(err);
+                        const message = errMsg(err);
                         vscode.window.showErrorMessage(
                             'MaterialX Playground: failed to save "' + path.basename(document.fileName) + '" — ' + message
                         );
@@ -440,7 +450,7 @@ class MaterialXEditorProvider {
                     } catch (err) {
                         vscode.window.showErrorMessage(
                             'MaterialX Playground: failed to sync "' + path.basename(document.fileName) + '" — '
-                            + (err && err.message ? err.message : String(err))
+                            + errMsg(err)
                         );
                     }
                     return;
@@ -468,7 +478,7 @@ class MaterialXEditorProvider {
                     } catch (err) {
                         vscode.window.showErrorMessage(
                             'MaterialX Playground: ' + (msg.type === 'mtlx-native-undo' ? 'undo' : 'redo') + ' failed — '
-                            + (err && err.message ? err.message : String(err))
+                            + errMsg(err)
                         );
                     }
                 }
@@ -513,7 +523,7 @@ class MaterialXEditorProvider {
             });
         } catch (err) {
             vscode.window.showErrorMessage(
-                'MaterialX Playground: failed to open the editor — ' + (err && err.message ? err.message : String(err))
+                'MaterialX Playground: failed to open the editor — ' + errMsg(err)
             );
         }
     }
@@ -533,10 +543,15 @@ class MaterialXEditorProvider {
             panel.onDidDispose(() => commonSub.dispose());
         } catch (err) {
             vscode.window.showErrorMessage(
-                'MaterialX Playground: failed to open node documentation — ' + (err && err.message ? err.message : String(err))
+                'MaterialX Playground: failed to open node documentation — ' + errMsg(err)
             );
         }
     }
 }
 
-module.exports = { MaterialXEditorProvider, wireCommonWebviewMessages, saveActiveGraph, undoActiveGraph, redoActiveGraph, openDocsPanel, getSharedOutputChannel };
+// wireCommonWebviewMessages is intentionally NOT exported — internal-only,
+// called by resolveCustomTextEditor/renderStaticHtml within this file. Kept
+// as a module-scope function (rather than folded into either call site) so
+// both webview-creation paths share the exact same fetch-bridge/error-
+// forwarding wiring; nothing outside this file needs to call it directly.
+module.exports = { MaterialXEditorProvider, saveActiveGraph, undoActiveGraph, redoActiveGraph, openDocsPanel, getSharedOutputChannel, logLine };

--- a/vscode_extension/src/extension.js
+++ b/vscode_extension/src/extension.js
@@ -10,9 +10,10 @@
 'use strict';
 
 const vscode = require('vscode');
-const { MaterialXEditorProvider, saveActiveGraph, undoActiveGraph, redoActiveGraph, openDocsPanel, getSharedOutputChannel } = require('./editorProvider');
+const { MaterialXEditorProvider, saveActiveGraph, undoActiveGraph, redoActiveGraph, openDocsPanel, getSharedOutputChannel, logLine } = require('./editorProvider');
 const validator = require('./validator');
 const hoverProvider = require('./hoverProvider');
+const { errMsg } = require('./util');
 
 // Diagnostics + status bar are created once in activate() but read/
 // written from the module-scope helpers below (toVsDiagnostics,
@@ -69,15 +70,19 @@ async function runValidation(document) {
     diagnosticCollection.set(document.uri, toVsDiagnostics(items));
     const warning = validator.consumeTier2Warning();
     if (warning) {
-        getSharedOutputChannel().appendLine('[' + new Date().toISOString() + '] MaterialX semantic validation (tier 2) is unavailable: ' + warning);
+        logLine(getSharedOutputChannel(), 'MaterialX semantic validation (tier 2) is unavailable: ' + warning);
     }
     updateStatusBar();
 }
 
 // Debounced per-document so a fast typist doesn't re-run tier 1/2 on
 // every keystroke, and so multiple open .mtlx tabs don't share (and
-// clobber) a single timer. Mirrors editorProvider.js's
-// RELOAD_DEBOUNCE_MS naming/pattern.
+// clobber) a single timer. Naming mirrors editorProvider.js's
+// RELOAD_DEBOUNCE_MS, but not the pattern: that file debounces one
+// active panel/document with a single closure-scoped timer, while this
+// one debounces however many .mtlx documents are open at once, so it
+// needs a timer PER document (the debounceTimers Map below), keyed by
+// uri.toString().
 const VALIDATE_DEBOUNCE_MS = 400;
 const debounceTimers = new Map(); // uri.toString() -> NodeJS.Timeout
 
@@ -141,7 +146,7 @@ function activate(context) {
             }
             await vscode.commands.executeCommand('vscode.openWith', uri, 'materialxPlayground.editor');
         } catch (err) {
-            vscode.window.showErrorMessage('MaterialX Playground: failed to open — ' + (err && err.message ? err.message : String(err)));
+            vscode.window.showErrorMessage('MaterialX Playground: failed to open — ' + errMsg(err));
         }
     };
 
@@ -197,7 +202,7 @@ function activate(context) {
                     : '#!docs';
                 await openDocsPanel(context, hash, vscode.ViewColumn.Active);
             } catch (err) {
-                vscode.window.showErrorMessage('MaterialX Playground: failed to open node documentation — ' + (err && err.message ? err.message : String(err)));
+                vscode.window.showErrorMessage('MaterialX Playground: failed to open node documentation — ' + errMsg(err));
             }
         })
     );

--- a/vscode_extension/src/mtlxNode.js
+++ b/vscode_extension/src/mtlxNode.js
@@ -20,6 +20,7 @@
 const fs = require('fs');
 const path = require('path');
 const { pathToFileURL } = require('url');
+const { errMsg } = require('./util');
 
 // Expected byte size of js/JsMaterialXGenShader.data, the packed
 // emscripten virtual-FS archive carrying the MaterialX standard
@@ -165,7 +166,7 @@ function getMxEnv(repoRoot) {
         (env) => env,
         (e) => {
             failed = true;
-            pendingError = e && e.message ? e.message : String(e);
+            pendingError = errMsg(e);
             return null;
         }
     );

--- a/vscode_extension/src/nodeSignature.js
+++ b/vscode_extension/src/nodeSignature.js
@@ -29,6 +29,8 @@
 //     compact hover-sized markdown rendering of a table's ports.
 'use strict';
 
+const { escapeRegExp } = require('./util');
+
 // ---------------------------------------------------------------------
 // Verbatim port of js/docs/port-tables.jsx's signature-label helper
 // cluster (~lines 247-356 there), trimmed of JSX/React context. See the
@@ -172,10 +174,6 @@ function extractAttrValue(tagText, attrName) {
     return m[2] !== undefined ? m[2] : m[3];
 }
 
-function escapeRegExpLiteral(s) {
-    return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
 function extractElementContext(text, nameStartOffset, tagName) {
     const FAIL = { type: null, inputs: [] };
     try {
@@ -235,7 +233,7 @@ function extractElementContext(text, nameStartOffset, tagName) {
         // of a huge element are still found).
         const childStart = gt + 1;
         const region = text.slice(childStart, Math.min(text.length, childStart + CHILDREN_SCAN_CAP));
-        const escapedTag = escapeRegExpLiteral(tagName);
+        const escapedTag = escapeRegExp(tagName);
         const closeMatch = new RegExp('</' + escapedTag + '\\b').exec(region);
         const nestedMatch = new RegExp('<' + escapedTag + '[\\s/>]').exec(region);
         let regionEnd = region.length;
@@ -413,6 +411,50 @@ function padCell(s, width) {
     return s + ' '.repeat(Math.max(0, width - s.length));
 }
 
+// Column widths: fit the content (and never narrower than the header
+// label), capped per column. Extracted out of renderPortsMarkdown so the
+// width-computation step can be read (and, per the module's own
+// verification checks, byte-compared) independently of line assembly —
+// behavior/output unchanged.
+function computeColumnWidths(cols, rows) {
+    const widths = cols.map((c, i) => {
+        const longest = rows.reduce((mx, r) => Math.max(mx, r[i].length), 0);
+        return Math.min(COL_WIDTH_CAPS[c], Math.max(COLUMN_LABELS[c].length, longest));
+    });
+    // Description (always the last column when present) additionally
+    // yields width when the other columns' ACTUAL widths would push
+    // the total past MAX_TABLE_WIDTH — with every cap maxed out this
+    // still leaves >= 34 chars, so the label-length floor below is
+    // purely defensive.
+    const descIdx = cols.indexOf('description');
+    if (descIdx !== -1) {
+        const othersTotal = widths.reduce((sum, w, i) => (i === descIdx ? sum : sum + w), 0);
+        const room = MAX_TABLE_WIDTH - othersTotal - CELL_SEPARATOR.length * (cols.length - 1);
+        widths[descIdx] = Math.max(COLUMN_LABELS.description.length, Math.min(widths[descIdx], room));
+    }
+    return widths;
+}
+
+// Header, ─/┼ separator, then data rows. A row's height is its tallest
+// wrapped cell; shorter cells pad with blank lines, and every rendered
+// line right-trims (padding on the LAST column is invisible, so don't
+// emit it). Returns the array of (unjoined) lines for the fenced code
+// block. Extracted out of renderPortsMarkdown alongside
+// computeColumnWidths above — output unchanged.
+function buildTableLines(cols, rows, widths) {
+    const tableLines = [];
+    tableLines.push(cols.map((c, i) => padCell(COLUMN_LABELS[c], widths[i])).join(CELL_SEPARATOR).replace(/ +$/, ''));
+    tableLines.push(widths.map((w) => '─'.repeat(w)).join('─┼─'));
+    for (const r of rows) {
+        const wrapped = r.map((cell, i) => wrapCell(cell, widths[i]));
+        const height = Math.max.apply(null, wrapped.map((ls) => ls.length));
+        for (let li = 0; li < height; li++) {
+            tableLines.push(wrapped.map((ls, i) => padCell(ls[li] || '', widths[i])).join(CELL_SEPARATOR).replace(/ +$/, ''));
+        }
+    }
+    return tableLines;
+}
+
 function renderPortsMarkdown(table) {
     try {
         if (!table || !table.ports) return '';
@@ -452,38 +494,8 @@ function renderPortsMarkdown(table) {
             return cols.map((c) => (c === 'port' ? cellText(pn, false) : cellText(row[c], c === 'description')));
         });
 
-        // Column widths: fit the content (and never narrower than the
-        // header label), capped per column.
-        const widths = cols.map((c, i) => {
-            const longest = rows.reduce((mx, r) => Math.max(mx, r[i].length), 0);
-            return Math.min(COL_WIDTH_CAPS[c], Math.max(COLUMN_LABELS[c].length, longest));
-        });
-        // Description (always the last column when present) additionally
-        // yields width when the other columns' ACTUAL widths would push
-        // the total past MAX_TABLE_WIDTH — with every cap maxed out this
-        // still leaves >= 34 chars, so the label-length floor below is
-        // purely defensive.
-        const descIdx = cols.indexOf('description');
-        if (descIdx !== -1) {
-            const othersTotal = widths.reduce((sum, w, i) => (i === descIdx ? sum : sum + w), 0);
-            const room = MAX_TABLE_WIDTH - othersTotal - CELL_SEPARATOR.length * (cols.length - 1);
-            widths[descIdx] = Math.max(COLUMN_LABELS.description.length, Math.min(widths[descIdx], room));
-        }
-
-        // Header, ─/┼ separator, then data rows. A row's height is its
-        // tallest wrapped cell; shorter cells pad with blank lines, and
-        // every rendered line right-trims (padding on the LAST column is
-        // invisible, so don't emit it).
-        const tableLines = [];
-        tableLines.push(cols.map((c, i) => padCell(COLUMN_LABELS[c], widths[i])).join(CELL_SEPARATOR).replace(/ +$/, ''));
-        tableLines.push(widths.map((w) => '─'.repeat(w)).join('─┼─'));
-        for (const r of rows) {
-            const wrapped = r.map((cell, i) => wrapCell(cell, widths[i]));
-            const height = Math.max.apply(null, wrapped.map((ls) => ls.length));
-            for (let li = 0; li < height; li++) {
-                tableLines.push(wrapped.map((ls, i) => padCell(ls[li] || '', widths[i])).join(CELL_SEPARATOR).replace(/ +$/, ''));
-            }
-        }
+        const widths = computeColumnWidths(cols, rows);
+        const tableLines = buildTableLines(cols, rows, widths);
         parts.push('```text\n' + tableLines.join('\n') + '\n```');
 
         const remaining = portNames.length - shown.length;

--- a/vscode_extension/src/util.js
+++ b/vscode_extension/src/util.js
@@ -1,0 +1,21 @@
+// util.js — pure-Node shared utilities. Must NOT require('vscode')
+// anywhere, so every module can use it — including the independently-
+// requireable pure-Node ones (validator.js, mtlxNode.js, nodeSignature.js,
+// specDocs.js, docScanner.js), which each enforce the same no-vscode rule
+// for their own reasons (see their file banners).
+'use strict';
+
+// Safe error-message extraction: some rejects/throws (esp. from non-Error
+// values) have no .message, so this is the one idiom used at every catch
+// site across the extension that needs a display string for `e`.
+function errMsg(e) {
+    return e && e.message ? e.message : String(e);
+}
+
+// Escapes a literal string for safe interpolation into a `new RegExp(...)`
+// pattern (regex metacharacters get a preceding backslash).
+function escapeRegExp(s) {
+    return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+module.exports = { errMsg, escapeRegExp };

--- a/vscode_extension/src/validator.js
+++ b/vscode_extension/src/validator.js
@@ -22,6 +22,7 @@
 'use strict';
 
 const mtlxNode = require('./mtlxNode');
+const { escapeRegExp } = require('./util');
 
 // ---------------------------------------------------------------------
 // Shared position mapping: precompute line-start offsets once per scan,
@@ -346,9 +347,6 @@ function scanXml(text) {
 // the document, so it can occasionally point at the wrong occurrence of
 // a common name. That's an accepted limitation of a boolean-only
 // validate() binding, not a bug to chase here.
-function escapeRegExp(s) {
-    return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
 
 // Finds `name = "candidate"` (or similar) and returns the char range of
 // just the candidate substring between the quotes, or null. FALLBACK


### PR DESCRIPTION
- mtlx-engine: shared mxSetAttr/mxRemoveAttr/mxSetColorspace/nextFrame/readMtlxText helpers; engine's own idioms folded onto them
- graph-app: ~90 exception-safe attribute wrappers collapsed; local writeConnSource unifies onConnect + pending-click connection writing; withPatchedInputs/viewportCenterFlow/writeFlowPos/elForFlowId fold repeated blocks; downloadBlob/looseFilesFrom/readMtlxText adopted
- mtlx-ui/dialogs: downloadBlob, BTN_* constants, useViewportControls + usePersistedGeom hooks (dedupes all three preview surfaces), shared DialogFrame for all six graph dialogs (keep-mounted docs dialog and busy gating preserved)
- viewer/node-preview/graph-preview/docs: hooks adopted; node-preview's 8 wiring sites folded into connectTypedInput; dead controlsRef removed; port-tables/docs-app file-local cleanups
- extension: new pure util.js (errMsg, escapeRegExp) consumed everywhere; bootstrap message listener split per message type; logLine helper; stale comments fixed (incl. wrong docs deep-link comment)