### PR TITLE
Enhance MaterialX Playground functionality:

### DIFF
--- a/js/site-header.js
+++ b/js/site-header.js
@@ -100,7 +100,23 @@
     // the editor is bound to a single opened .mtlx file — so drop the Home
     // tab from both the desktop and mobile nav copies below. No-op (same
     // NAV array) in the plain browser.
-    var navItems = window.__MTLX_VSCODE__ ? NAV.filter(function (t) { return t.id !== 'home'; }) : NAV;
+    //
+    // Additionally, inside the STANDALONE docs panel specifically (window.
+    // __MTLX_DOCS_ONLY__, set by vscode_extension/media/bootstrap.js from
+    // webview.html's data-docs-only attribute — see editorProvider.js's
+    // buildHtml) also drop the Viewer and Graph tabs, keeping only Docs:
+    // that panel isn't backed by a .mtlx document at all (it's the
+    // document-less "MaterialX: Open Node Documentation" command), so the
+    // file-bound Viewer/Graph views have nothing to show there. The
+    // file-backed MaterialX Playground custom editor never sets
+    // __MTLX_DOCS_ONLY__, so it keeps every tab exactly as before.
+    var navItems = window.__MTLX_VSCODE__
+        ? NAV.filter(function (t) {
+            if (t.id === 'home') return false;
+            if (window.__MTLX_DOCS_ONLY__ && (t.id === 'viewer' || t.id === 'graph')) return false;
+            return true;
+        })
+        : NAV;
 
     var tabs = navItems.map(function (item) {
         var active = item.id === activeId;

--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
     "commands": [
       {
         "command": "materialxPlayground.open",
-        "title": "MaterialX Playground: Open MaterialX Document"
+        "title": "MaterialX Playground: Open MaterialX Document",
+        "enablement": "resourceExtname == .mtlx"
       },
       {
         "command": "materialxPlayground.openDocs",
@@ -112,9 +113,23 @@
       }
     ],
     "menus": {
+      "commandPalette": [
+        {
+          "command": "materialxPlayground.open",
+          "when": "resourceExtname == .mtlx"
+        },
+        {
+          "command": "materialxPlayground.openDocs"
+        }
+      ],
       "explorer/context": [
         {
           "command": "materialxPlayground.open",
+          "when": "resourceExtname == .mtlx",
+          "group": "materialxPlayground"
+        },
+        {
+          "command": "materialxPlayground.openDocs",
           "when": "resourceExtname == .mtlx",
           "group": "materialxPlayground"
         }
@@ -122,6 +137,11 @@
       "editor/title/context": [
         {
           "command": "materialxPlayground.open",
+          "when": "resourceExtname == .mtlx",
+          "group": "materialxPlayground"
+        },
+        {
+          "command": "materialxPlayground.openDocs",
           "when": "resourceExtname == .mtlx",
           "group": "materialxPlayground"
         }
@@ -138,6 +158,24 @@
           ],
           "default": "viewer",
           "description": "Which MaterialX Playground view (the Material Viewer or the Node Graph Editor) is shown first when a .mtlx file is opened with the MaterialX Playground custom editor. The document is loaded into both views either way; this setting only picks which one is initially visible — use the header nav to switch to the other."
+        },
+        "materialx.openBehavior": {
+          "type": "string",
+          "enum": [
+            "splitRight",
+            "sameGroup"
+          ],
+          "default": "splitRight",
+          "enumDescriptions": [
+            "Open the playground beside the text editor for the same file, reusing an existing right-hand editor group on repeat opens instead of splitting again every time.",
+            "Open the playground in the active editor group (the previous behavior)."
+          ],
+          "description": "Where the MaterialX Playground opens when a text editor for the same .mtlx file is visible: \"splitRight\" opens it beside that editor, reusing an existing right-hand group rather than creating a new split each time; \"sameGroup\" opens it in the active editor group, replacing (or reusing) whatever tab is already there — the previous behavior."
+        },
+        "materialx.autoOpenPlayground": {
+          "type": "boolean",
+          "default": false,
+          "description": "Automatically open the MaterialX Playground beside the text editor whenever a .mtlx file is opened. Triggers once per file open — closing the playground won't re-trigger it until the file itself is closed and reopened."
         }
       }
     }

--- a/vscode_extension/README.md
+++ b/vscode_extension/README.md
@@ -32,15 +32,42 @@ dependencies — it runs directly out of a checkout of this repo.
 - **Open With…**: right-click a `.mtlx` file (in the editor tab or the
   Explorer) -> *Open With…* -> **MaterialX Playground**. Opens with the
   configured default view visible first (see Settings below).
-- **Explorer context menu / Command Palette**: right-click a `.mtlx` file
-  in the Explorer, or run from the Command Palette (`Ctrl+Shift+P`) with
-  a `.mtlx` file active:
+- **Explorer context menu / editor tab context menu / Command Palette**:
+  right-click a `.mtlx` file (in the Explorer or an editor tab), or run
+  from the Command Palette (`Ctrl+Shift+P`):
   - `Send to MaterialX Playground` — loads the file into both the
     Material Viewer and the Node Graph Editor at once; `materialx.defaultView`
     picks which one is shown first, and the header nav switches to the
-    other, already-loaded view.
+    other, already-loaded view. Only available for `.mtlx` files — the
+    Command Palette entry is hidden entirely unless a `.mtlx` file is
+    active, and the command itself is disabled outside that context. See
+    "Opening the playground" below for *where* it opens.
   - `MaterialX: Open Node Documentation` — opens the node-library docs
-    view on its own, with no file involved.
+    view on its own, with no file involved. Available from the Command
+    Palette at any time (no `.mtlx` file needed), and also from the
+    Explorer/editor-tab context menu on a `.mtlx` file, right alongside
+    `Send to MaterialX Playground`.
+
+### Opening the playground
+
+- **Placement** (`materialx.openBehavior`, default `"splitRight"`): when
+  a text editor for the same `.mtlx` file is already open and visible,
+  the playground opens **beside it**, reusing an existing right-hand
+  editor group on repeat opens instead of creating a fresh split every
+  time. Set this to `"sameGroup"` to instead always open in the active
+  editor group (the previous behavior). If there's no open text editor
+  for the file to split against (e.g. an Explorer right-click on a file
+  nothing has opened yet), or a playground tab for the file is already
+  open somewhere, the extension falls back sensibly — opening in the
+  active group, or revealing the existing playground tab, respectively —
+  regardless of this setting.
+- **Auto-open** (`materialx.autoOpenPlayground`, default `false`): when
+  enabled, opening (or switching to) a `.mtlx` file automatically opens
+  the playground beside it, without stealing keyboard focus from the text
+  editor. This fires once per file per "open": closing the playground tab
+  by hand does not pop it back open just by switching away from and back
+  to the same `.mtlx` editor — only closing and reopening the `.mtlx`
+  file itself re-arms it.
 
 ### Node Graph Editor: saving
 
@@ -184,6 +211,18 @@ editor.
   `.mtlx` file is opened. The document is loaded into both views either
   way; this only picks the initially visible one — use the header nav to
   switch to the other.
+- `materialx.openBehavior` (`"splitRight"` | `"sameGroup"`, default
+  `"splitRight"`) — where the playground opens when a text editor for the
+  same `.mtlx` file is visible: `"splitRight"` opens it beside that
+  editor, reusing an existing right-hand editor group instead of
+  splitting again on every open; `"sameGroup"` opens it in the active
+  editor group instead (the previous behavior). See "Opening the
+  playground" under Usage above for the fallback behavior when there's
+  nothing to split against.
+- `materialx.autoOpenPlayground` (boolean, default `false`) —
+  automatically open the playground beside the text editor whenever a
+  `.mtlx` file is opened. See "Opening the playground" under Usage above
+  for exactly when this re-triggers.
 
 ## Requirements
 

--- a/vscode_extension/media/bootstrap.js
+++ b/vscode_extension/media/bootstrap.js
@@ -250,6 +250,18 @@
         location.hash = initialHash;
     }
 
+    // Flags this webview as the document-less, standalone "MaterialX:
+    // Open Node Documentation" panel, as opposed to the file-backed
+    // custom editor — set synchronously here (document.currentScript is
+    // only valid while THIS script is still executing, same caveat as
+    // initialHash just above), so it's in place BEFORE js/site-header.js
+    // builds the header on first paint. '1' <-> true mirrors
+    // data-initial-hash's own string-attribute encoding. Consumed by
+    // js/site-header.js's nav-item filter, which additionally hides the
+    // Viewer/Graph tabs when this is set — the standalone docs panel has
+    // no .mtlx document behind it for those views to show.
+    window.__MTLX_DOCS_ONLY__ = (document.currentScript && document.currentScript.getAttribute('data-docs-only')) === '1';
+
     // ------------------------------------------------------------------
     // Link interception: <base href="${baseUri}"> (webview.html) makes
     // every relative href in the site resolve to a webview-resource URL,

--- a/vscode_extension/media/webview.html
+++ b/vscode_extension/media/webview.html
@@ -81,11 +81,13 @@
 
     <!-- Bootstrap: MUST be the first script to run, before the site's own
          boot (js/shell.jsx reads location.hash for routing). Sets the
-         initial hash from data-initial-hash, flags window.__MTLX_VSCODE__,
-         installs the in-page link interceptor, and wires up the
-         extension <-> webview postMessage contract. See
+         initial hash from data-initial-hash, flags window.__MTLX_VSCODE__
+         (and, from data-docs-only, window.__MTLX_DOCS_ONLY__ — read by
+         js/site-header.js to hide the file-bound Viewer/Graph tabs in the
+         standalone docs panel), installs the in-page link interceptor,
+         and wires up the extension <-> webview postMessage contract. See
          vscode_extension/media/bootstrap.js. -->
-    <script src="${bootstrapUri}" data-initial-hash="${initialHash}"></script>
+    <script src="${bootstrapUri}" data-initial-hash="${initialHash}" data-docs-only="${docsOnly}"></script>
 
     <title>MaterialX Playground</title>
     <link rel="icon" type="image/x-icon" href="favicon.ico">

--- a/vscode_extension/src/editorProvider.js
+++ b/vscode_extension/src/editorProvider.js
@@ -26,7 +26,16 @@ const RELOAD_DEBOUNCE_MS = 400;
 // initial hash and, for the static case, no document-payload wiring.
 // Returns the repo-root Uri so callers can hand it to
 // wireCommonWebviewMessages() without re-deriving it.
-async function buildHtml(context, webview, initialHash) {
+//
+// `docsOnly` is threaded straight through to a ${docsOnly} substitution
+// (mechanism mirrors ${initialHash} above it) so media/bootstrap.js can
+// set window.__MTLX_DOCS_ONLY__ before any site script runs — js/
+// site-header.js's nav-item filter reads that flag to hide the file-bound
+// Viewer/Graph tabs in the standalone docs panel, which has no .mtlx
+// document behind it at all. resolveCustomTextEditor passes false (the
+// file-backed editor keeps every tab); renderStaticHtml passes true (it
+// is only ever the docs panel).
+async function buildHtml(context, webview, initialHash, docsOnly) {
     // package.json now lives at the repo root, so packaging (vsce
     // package) bundles both the site's files (index.html, js/,
     // libraries/, ...) and vscode_extension/ into the same install
@@ -50,6 +59,7 @@ async function buildHtml(context, webview, initialHash) {
     html = html.split('${baseUri}').join(baseUri);
     html = html.split('${bootstrapUri}').join(bootstrapUri.toString());
     html = html.split('${initialHash}').join(initialHash);
+    html = html.split('${docsOnly}').join(docsOnly ? '1' : '');
 
     webview.html = html;
     return repoRootUri;
@@ -280,7 +290,10 @@ class MaterialXEditorProvider {
             const defaultView = vscode.workspace.getConfiguration('materialx').get('defaultView', 'viewer');
             const initialHash = defaultView === 'graph' ? '#!graph' : '#!viewer';
 
-            const repoRootUri = await buildHtml(this.context, webviewPanel.webview, initialHash);
+            // false: this IS the file-backed custom editor, so it keeps
+            // every tab (Docs + Viewer + Graph) — see buildHtml's comment
+            // on the docsOnly parameter above.
+            const repoRootUri = await buildHtml(this.context, webviewPanel.webview, initialHash, false);
 
             // Fetch bridge + error forwarding, shared with the docs
             // panel (see wireCommonWebviewMessages above).
@@ -538,7 +551,10 @@ class MaterialXEditorProvider {
     // much as the viewer/graph views do.
     static async renderStaticHtml(context, panel, initialHash) {
         try {
-            const repoRootUri = await buildHtml(context, panel.webview, initialHash);
+            // true: this is only ever the standalone docs panel (no .mtlx
+            // document backs it) — see buildHtml's comment on the
+            // docsOnly parameter above.
+            const repoRootUri = await buildHtml(context, panel.webview, initialHash, true);
             const commonSub = wireCommonWebviewMessages(panel.webview, repoRootUri);
             panel.onDidDispose(() => commonSub.dispose());
         } catch (err) {

--- a/vscode_extension/src/extension.js
+++ b/vscode_extension/src/extension.js
@@ -22,6 +22,16 @@ const { errMsg } = require('./util');
 let diagnosticCollection = null;
 let statusBarItem = null;
 
+// materialx.autoOpenPlayground bookkeeping (see maybeAutoOpen() in
+// activate()): which .mtlx files have already had the playground
+// auto-opened for them this extension-host session, keyed by
+// uri.toString(). Module scope (not activate()-local) because
+// vscode.workspace.onDidCloseTextDocument's re-arm handler and
+// vscode.window.onDidChangeActiveTextEditor's trigger handler both need
+// to see the same Set across the whole session, exactly like
+// diagnosticCollection/statusBarItem above.
+const autoOpenedUris = new Set();
+
 // validator.js's return shape ({ message, startLine, startChar, endLine,
 // endChar, severity: 'error' }) is plain objects, not vscode.Diagnostic
 // instances — validator.js/mtlxNode.js must stay independently loadable
@@ -137,17 +147,155 @@ function activate(context) {
         return null;
     };
 
-    const openInPlayground = async (uriArg) => {
+    // 'splitRight' placement for openInPlayground below (materialx.
+    // openBehavior, package.json contributes.configuration) — figures out
+    // WHERE to open the playground so it lands beside a text editor
+    // already open on the same file, then issues the `vscode.openWith`
+    // call itself. Returns true if it did so (placement handled — the
+    // caller must not also do its own plain open), false if there was
+    // nothing to split against or anything about the tab-group scan
+    // failed, in which case the caller falls back to opening in the
+    // active group. Never throws.
+    //
+    // vscode.window.tabGroups.all exposes every editor group with a
+    // numeric `viewColumn` and each tab's `input`, which is
+    // `vscode.TabInputText` (has `.uri`) for a plain text tab, or
+    // `vscode.TabInputCustom` (has both `.uri` and `.viewType`) for an
+    // already-open custom editor tab like ours.
+    const openBesideTextEditor = async (uri, preserveFocus) => {
+        try {
+            const uriStr = uri.toString();
+            let textGroupColumn = null; // viewColumn of the group holding a TEXT tab for this uri
+            let existingPlaygroundColumn = null; // viewColumn of a group already showing OUR editor for this uri
+
+            for (const group of vscode.window.tabGroups.all) {
+                for (const tab of group.tabs) {
+                    const input = tab.input;
+                    if (input instanceof vscode.TabInputText && input.uri.toString() === uriStr) {
+                        textGroupColumn = group.viewColumn;
+                    } else if (
+                        input instanceof vscode.TabInputCustom
+                        && input.viewType === 'materialxPlayground.editor'
+                        && input.uri.toString() === uriStr
+                    ) {
+                        existingPlaygroundColumn = group.viewColumn;
+                    }
+                }
+            }
+
+            // A playground tab for this exact file is already open
+            // somewhere — reveal it (openWith to the same resource +
+            // viewType reveals the existing tab rather than duplicating
+            // it) instead of splitting open a second copy elsewhere.
+            if (existingPlaygroundColumn !== null) {
+                await vscode.commands.executeCommand(
+                    'vscode.openWith', uri, 'materialxPlayground.editor',
+                    { viewColumn: existingPlaygroundColumn, preserveFocus }
+                );
+                return true;
+            }
+
+            // No open text editor for this file to split against at all
+            // (e.g. an Explorer right-click on a file nothing has opened
+            // yet) — nothing for 'splitRight' to do here.
+            if (textGroupColumn === null) return false;
+
+            const targetColumn = textGroupColumn + 1;
+            const rightGroupExists = vscode.window.tabGroups.all.some((g) => g.viewColumn === targetColumn);
+
+            if (rightGroupExists) {
+                // Reuse the existing right-hand group instead of splitting
+                // again — this is the whole point of 'splitRight': repeat
+                // opens land in the SAME group beside the text editor
+                // rather than each one creating a fresh split.
+                // vscode.ViewColumn.Beside would NOT give us this: it
+                // creates a brand-new group whenever the currently ACTIVE
+                // group happens to be the rightmost one
+                // (https://github.com/microsoft/vscode/issues/133260), so
+                // an explicit, already-known viewColumn is what makes the
+                // reuse deterministic here.
+                await vscode.commands.executeCommand(
+                    'vscode.openWith', uri, 'materialxPlayground.editor',
+                    { viewColumn: targetColumn, preserveFocus }
+                );
+                return true;
+            }
+
+            // No group to the right exists yet. vscode.ViewColumn.Beside
+            // always splits relative to whichever group is currently
+            // ACTIVE — not relative to textGroupColumn — and there is no
+            // API to say "create a new group at column N" directly. So:
+            // make the text editor's group the active one first (showing
+            // the document that's already open there is cheap — it does
+            // not reload anything), THEN ask for Beside, which now
+            // deterministically splits to the right of it.
+            const doc = vscode.workspace.textDocuments.find((d) => d.uri.toString() === uriStr)
+                || await vscode.workspace.openTextDocument(uri);
+            await vscode.window.showTextDocument(doc, { viewColumn: textGroupColumn, preserveFocus: false });
+            await vscode.commands.executeCommand(
+                'vscode.openWith', uri, 'materialxPlayground.editor',
+                { viewColumn: vscode.ViewColumn.Beside, preserveFocus }
+            );
+            return true;
+        } catch (err) {
+            // Placement is a nice-to-have — never let it break opening the
+            // playground at all. The caller falls back to its own plain
+            // open in the active group.
+            return false;
+        }
+    };
+
+    // `options.preserveFocus`, when set, is threaded down to whichever
+    // `vscode.openWith` call actually runs — used by maybeAutoOpen()
+    // below so an auto-opened playground doesn't steal keyboard focus
+    // from the text editor the user is actively typing in.
+    const openInPlayground = async (uriArg, { preserveFocus } = {}) => {
         try {
             const uri = resolveTargetUri(uriArg);
             if (!uri) {
                 vscode.window.showErrorMessage('MaterialX Playground: no .mtlx file to open (no active editor and no file selected).');
                 return;
             }
-            await vscode.commands.executeCommand('vscode.openWith', uri, 'materialxPlayground.editor');
+
+            const openBehavior = vscode.workspace.getConfiguration('materialx').get('openBehavior', 'splitRight');
+            if (openBehavior === 'splitRight') {
+                const placed = await openBesideTextEditor(uri, preserveFocus);
+                if (placed) return;
+                // Nothing to split against (or the scan itself failed) —
+                // fall through to the plain open below. Opening SOMEWHERE
+                // beats not opening at all.
+            }
+
+            // 'sameGroup', or a 'splitRight' fallback: today's plain open
+            // in the active group. `{ preserveFocus }` is only passed when
+            // the caller actually set it, so a bare `openInPlayground(uri)`
+            // call — every pre-existing call site — stays byte-identical
+            // to the original `executeCommand('vscode.openWith', uri,
+            // 'materialxPlayground.editor')` call with no third argument.
+            if (preserveFocus !== undefined) {
+                await vscode.commands.executeCommand('vscode.openWith', uri, 'materialxPlayground.editor', { preserveFocus });
+            } else {
+                await vscode.commands.executeCommand('vscode.openWith', uri, 'materialxPlayground.editor');
+            }
         } catch (err) {
             vscode.window.showErrorMessage('MaterialX Playground: failed to open — ' + errMsg(err));
         }
+    };
+
+    // materialx.autoOpenPlayground companion: the first time a .mtlx file
+    // becomes the active text editor (and on every subsequent FIRST time
+    // after the file is closed and reopened — see the re-arm comment on
+    // the onDidCloseTextDocument listener below), automatically open the
+    // playground beside it. preserveFocus: true is load-bearing here —
+    // the whole point is a side panel that appears without stealing
+    // keystrokes out from under whatever the user is actively typing.
+    const maybeAutoOpen = (editor) => {
+        if (!editor || !editor.document || editor.document.uri.scheme !== 'file' || editor.document.languageId !== 'mtlx') return;
+        if (!vscode.workspace.getConfiguration('materialx').get('autoOpenPlayground', false)) return;
+        const key = editor.document.uri.toString();
+        if (autoOpenedUris.has(key)) return;
+        autoOpenedUris.add(key);
+        openInPlayground(editor.document.uri, { preserveFocus: true });
     };
 
     context.subscriptions.push(
@@ -188,6 +336,21 @@ function activate(context) {
         // callers, older cached command URIs) behave exactly as before.
         vscode.commands.registerCommand('materialxPlayground.openDocs', async (category, sig) => {
             try {
+                // Context-menu invocations (the Explorer / editor tab
+                // title entries contributed for this command) pass the
+                // target vscode.Uri as the FIRST argument — same calling
+                // convention as materialxPlayground.open's uriArg — but
+                // this command has no file-backed behavior for a Uri to
+                // select: it always opens the same document-less node
+                // library browser. Treat any non-string first argument as
+                // "no category" rather than URL-encoding a Uri's string
+                // form into a bogus '#/<uri>' deep-link hash; a menu click
+                // then opens the plain library browser ('#!docs'), same
+                // as the Command Palette / no-arg case.
+                if (typeof category !== 'string') {
+                    category = undefined;
+                    sig = undefined;
+                }
                 // Shares the docs-panel singleton with the graph editor's
                 // "?" button (editorProvider.js's openDocsPanel, which the
                 // editor webview's message handler also calls) — no
@@ -205,6 +368,20 @@ function activate(context) {
                 vscode.window.showErrorMessage('MaterialX Playground: failed to open node documentation — ' + errMsg(err));
             }
         })
+    );
+
+    // materialx.autoOpenPlayground listeners (see maybeAutoOpen() above):
+    // trigger on every active-editor change, and re-arm per file only once
+    // that FILE is actually closed — not merely defocused by switching
+    // tabs. This distinction is load-bearing: without it, tabbing away
+    // from a .mtlx editor and back would look identical to "reopening the
+    // file" and pop the playground back open even after the user
+    // deliberately closed it, which would defeat the point of closing it
+    // at all. Deleting the key only on onDidCloseTextDocument means the
+    // auto-open is genuinely a per-"open" thing, not a per-"focus" thing.
+    context.subscriptions.push(
+        vscode.window.onDidChangeActiveTextEditor(maybeAutoOpen),
+        vscode.workspace.onDidCloseTextDocument((doc) => autoOpenedUris.delete(doc.uri.toString()))
     );
 
     // Live .mtlx diagnostics: validate anything already open, then keep
@@ -238,6 +415,15 @@ function activate(context) {
         }),
         vscode.window.onDidChangeActiveTextEditor(() => updateStatusBar())
     );
+
+    // activate() itself is triggered by the onLanguage:mtlx activation
+    // event (package.json activationEvents), which means a .mtlx file can
+    // already be the active editor by the time this function runs — i.e.
+    // BEFORE the onDidChangeActiveTextEditor listener registered above
+    // ever gets a chance to fire for it. Run the same auto-open check once
+    // more, by hand, against whatever's active right now, so that first
+    // file isn't skipped.
+    maybeAutoOpen(vscode.window.activeTextEditor);
 }
 
 function deactivate() {}


### PR DESCRIPTION
- Update navigation items to conditionally hide Viewer/Graph tabs in standalone docs panel.
- Add support for auto-opening the playground beside the text editor for .mtlx files.
- Improve command palette and context menu entries for .mtlx files.
- Document new settings for playground behavior in README.