### PR TITLE
Stop the graph editor from blanking the page on a render-phase throw

### DIFF
--- a/js/graph-app.jsx
+++ b/js/graph-app.jsx
@@ -3902,6 +3902,24 @@
             // geometry check closed it, not because the user minimized it
             // — drives the symmetric restore once room opens back up.
             const autoCollapsedLegendRef = React.useRef(false);
+            // The pill's own rendered width is effectively constant (fixed
+            // icon + "Map" label, no variable content) but subject to
+            // sub-pixel/font-settling jitter and to going to 0 while
+            // unmounted. Cached on the first good (non-zero) measurement
+            // and reused after that instead of re-reading the live rect on
+            // every pass — stage 2 must use fixed, known geometry, never a
+            // live rect that this same effect's own state changes can move
+            // (mounting/unmounting the pill via minimapBlocked below).
+            const pillWidthRef = React.useRef(0);
+            // Loop breaker (defense in depth, not a substitute for the
+            // fixes above): counts consecutive animation frames in which
+            // measure() actually changed some state. If real geometry has
+            // settled, this returns to 0 within a frame or two. If it
+            // hasn't past a small threshold, something is oscillating —
+            // stop adjusting and leave the layout as-is rather than let a
+            // no-deps effect spin forever (React error #185).
+            const consecutiveChangeFramesRef = React.useRef(0);
+            const loopBreakerTrippedRef = React.useRef(false);
             const [minimapBlocked, setMinimapBlocked] = React.useState(false);
             // The Map pill's own right-margin: 320 while the params
             // panel is expanded (mirrors minimapMarginRight), else just
@@ -3910,7 +3928,10 @@
             React.useLayoutEffect(() => {
                 const host = panelRef.current;
                 if (!host) return;
+                let rafId = null;
                 const measure = () => {
+                    if (loopBreakerTrippedRef.current) return;
+                    let changed = false;
                     const paneRect = host.getBoundingClientRect();
                     if (!paneRect.width) return;
                     const GAP = 8; // small breathing room, not a flush touch
@@ -3920,18 +3941,31 @@
                     const legendRightEdge = legendRect ? (legendRect.right - paneRect.left) : 0;
                     const minimapLeftEdge = paneRect.width - minimapMarginRight - 200 - GAP;
                     const blocked = minimapLeftEdge < legendRightEdge + GAP;
-                    setMinimapBlocked((prev) => (prev === blocked ? prev : blocked));
+                    setMinimapBlocked((prev) => {
+                        if (prev === blocked) return prev;
+                        changed = true;
+                        return blocked;
+                    });
 
                     // The pill's own margin (item 3): mirrors
                     // minimapMarginRight's 320 while expanded, else clears
                     // the collapsed chip's live width (8px + width + GAP).
+                    // Rounded to whole pixels at the source — the value
+                    // feeds an exact-equality change guard just below, and
+                    // getBoundingClientRect() returns sub-pixel floats that
+                    // can jitter render to render without the chip's actual
+                    // on-screen size changing at all.
                     const chipRect = (!paramsOpen && paramsChipRef.current)
                         ? paramsChipRef.current.getBoundingClientRect() : null;
                     const chipWidth = chipRect ? chipRect.width : 0;
-                    const pillMarginRightNow = (parsed && paramsOpen && !narrow)
+                    const pillMarginRightNow = Math.round((parsed && paramsOpen && !narrow)
                         ? 320
-                        : (parsed ? (8 + chipWidth + GAP) : 15);
-                    setPillMarginRight((prev) => (prev === pillMarginRightNow ? prev : pillMarginRightNow));
+                        : (parsed ? (8 + chipWidth + GAP) : 15));
+                    setPillMarginRight((prev) => {
+                        if (prev === pillMarginRightNow) return prev;
+                        changed = true;
+                        return pillMarginRightNow;
+                    });
 
                     // Stage 2: the collapsed pill vs. a HYPOTHETICALLY OPEN
                     // legend card. ALWAYS uses the card's known fixed
@@ -3949,33 +3983,72 @@
                     // production). One constant, shared by both directions,
                     // can't disagree with itself.
                     const legendOpenRightEdge = 8 + 320;
-                    const pillWidth = pillRef.current ? pillRef.current.getBoundingClientRect().width : 0;
-                    const pillLeftEdge = paneRect.width - pillMarginRightNow - pillWidth;
-                    const pillOverlap = !!pillRef.current && (pillLeftEdge < legendOpenRightEdge + GAP);
-                    // Comfortable clearance, not just "not overlapping"
-                    // — hysteresis so residual jitter at the collapse
-                    // threshold can't immediately re-trigger and oscillate.
-                    const pillClear = pillLeftEdge > legendOpenRightEdge + GAP + 16;
+                    // Skip stage 2 entirely while the pill isn't mounted —
+                    // there is nothing to measure, and treating a 0-width
+                    // phantom pill as "clear" was spuriously firing the
+                    // restore branch below. Leaves prevPillOverlapRef/
+                    // autoCollapsedLegendRef untouched; they pick back up
+                    // correctly once the pill remounts.
+                    if (pillRef.current) {
+                        const liveWidth = pillRef.current.getBoundingClientRect().width;
+                        if (liveWidth > 0) pillWidthRef.current = liveWidth;
+                        const pillWidth = pillWidthRef.current;
+                        const pillLeftEdge = paneRect.width - pillMarginRightNow - pillWidth;
+                        const pillOverlap = pillLeftEdge < legendOpenRightEdge + GAP;
+                        // Comfortable clearance, not just "not overlapping"
+                        // — hysteresis so residual jitter at the collapse
+                        // threshold can't immediately re-trigger and oscillate.
+                        const pillClear = pillLeftEdge > legendOpenRightEdge + GAP + 16;
 
-                    // Collapse: fires once on the crossing INTO overlap
-                    // (prevPillOverlapRef), remembering GEOMETRY closed it.
-                    // Restore: level-triggered on that same latch — safe since it self-clears.
-                    if (pillOverlap && !prevPillOverlapRef.current && legendOpen) {
-                        setLegendOpen(false);
-                        autoCollapsedLegendRef.current = true;
-                    } else if (pillClear && autoCollapsedLegendRef.current) {
-                        setLegendOpen(true);
-                        autoCollapsedLegendRef.current = false;
+                        // Collapse: fires once on the crossing INTO overlap
+                        // (prevPillOverlapRef), remembering GEOMETRY closed it.
+                        // Restore: level-triggered on that same latch — safe since it self-clears.
+                        if (pillOverlap && !prevPillOverlapRef.current && legendOpen) {
+                            setLegendOpen(false);
+                            autoCollapsedLegendRef.current = true;
+                            changed = true;
+                        } else if (pillClear && autoCollapsedLegendRef.current) {
+                            setLegendOpen(true);
+                            autoCollapsedLegendRef.current = false;
+                            changed = true;
+                        }
+                        prevPillOverlapRef.current = pillOverlap;
                     }
-                    prevPillOverlapRef.current = pillOverlap;
+
+                    if (changed) {
+                        consecutiveChangeFramesRef.current += 1;
+                        if (consecutiveChangeFramesRef.current > 5) {
+                            loopBreakerTrippedRef.current = true;
+                            console.warn('[graph] legend/minimap layout effect: '
+                                + consecutiveChangeFramesRef.current
+                                + ' consecutive frames changed state — stopping auto-adjustment '
+                                + '(loop breaker tripped) and leaving the current layout as-is.');
+                        }
+                    } else {
+                        consecutiveChangeFramesRef.current = 0;
+                    }
                 };
-                measure();
+                // Coalesced with rAF so at most one measurement runs per
+                // frame: this effect has no deps and reruns on every
+                // render, and panOnDrag={[1]}/selectionOnDrag mean a
+                // left-drag box-select re-renders every node per pointer
+                // tick — without coalescing, measure() (and any state
+                // change it makes) would run once per tick instead of once
+                // per frame.
+                const scheduleMeasure = () => {
+                    if (rafId != null) return;
+                    rafId = requestAnimationFrame(() => { rafId = null; measure(); });
+                };
+                scheduleMeasure();
                 // Covers pane resizes (params panel drag, preview panel
                 // toggle, window resize) without a React re-render — same
                 // rationale as the toolbar clusters' own ResizeObservers.
-                const ro = new ResizeObserver(measure);
+                const ro = new ResizeObserver(scheduleMeasure);
                 ro.observe(host);
-                return () => ro.disconnect();
+                return () => {
+                    ro.disconnect();
+                    if (rafId != null) cancelAnimationFrame(rafId);
+                };
                 // Intentionally no deps: paramsOpen/legendOpen/narrow/
                 // minimapOpen already trigger renders, so this re-runs
                 // whenever any change — math is microseconds, like the toolbar effects.
@@ -3997,15 +4070,49 @@
             // Box select also marks every edge touching the selected nodes
             // in React Flow's INTERNAL store (cloned objects — swallowing
             // the change events isn't enough). Edge selection in this app
-            // is exclusively the click-selected selectedEdgeId, so each
-            // such attempt bumps this epoch, forcing rfEdges below to
-            // re-emit fresh objects whose explicit selected:false
-            // overwrites the store's clones on the prop resync.
+            // is exclusively the click-selected selectedEdgeId plus the
+            // path-sampled selectedEdgeIds (below), so a RF-internal mark
+            // that disagrees with our own state bumps this epoch, forcing
+            // rfEdges below to re-emit fresh objects whose explicit
+            // selected flags overwrite the store's clones on the prop resync.
             const [edgeDeselectEpoch, setEdgeDeselectEpoch] = React.useState(0);
+            // The last set of edge ids a resync was already issued for —
+            // keyed by content, not time. The app is a controlled flow, so
+            // every resync round-trips through render; if RF reasserts the
+            // SAME disagreeing set right back (a ping-pong reaction to our
+            // own prop update, not new user input), bumping again would
+            // provoke another reassertion with no iteration cap (React
+            // error #185). A genuinely new disagreement has a different
+            // id set and so a different key, and isn't blocked by this.
+            const lastEdgeResyncKeyRef = React.useRef(null);
             const onEdgesChange = (changes) => {
-                if (changes.some((c) => c.type === 'select' && c.selected)) {
-                    setEdgeDeselectEpoch((n) => n + 1);
+                const incoming = changes.filter((c) => c.type === 'select' && c.selected).map((c) => c.id);
+                if (!incoming.length) return;
+                // Only a genuine disagreement needs correcting — RF's own
+                // touching-node auto-selection can legitimately differ
+                // from our own selection (click or path-sampled box), and
+                // agreement there is not a problem to resync away.
+                const disagreeing = incoming.filter((id) =>
+                    id !== selectedEdgeId && selectedEdgeIds.indexOf(id) === -1);
+                if (!disagreeing.length) {
+                    // RF agrees with us — settled, so a later disagreement
+                    // over these same ids is genuinely new, not a ping-pong.
+                    lastEdgeResyncKeyRef.current = null;
+                    return;
                 }
+                // Key on the disagreeing ids AND our own current selection.
+                // A ping-pong reassertion arrives while our selection is
+                // unchanged, so it keys identically and is blocked; a later
+                // interaction with a different selection keys differently
+                // and is allowed through. Keying on the ids alone would
+                // block that set from ever resyncing again for the life of
+                // the page, leaving RF's store stale.
+                const key = disagreeing.slice().sort().join(',')
+                    + '|' + (selectedEdgeId || '')
+                    + '|' + selectedEdgeIds.slice().sort().join(',');
+                if (lastEdgeResyncKeyRef.current === key) return;
+                lastEdgeResyncKeyRef.current = key;
+                setEdgeDeselectEpoch((n) => n + 1);
             };
 
             // What React Flow renders: the flow edges, with the selection

--- a/js/graph/node-component.jsx
+++ b/js/graph/node-component.jsx
@@ -13,6 +13,26 @@
         let __mtlxRenderCount = 0;
         let __mtlxRenderWindowStart = 0;
 
+        // Render-phase guard: graph-app.jsx's rebuild helpers already read
+        // `n.data.allInputs || n.data.inputs || []` defensively when
+        // re-deriving node data, but this component historically read
+        // data.inputs/outputs non-defensively — a malformed or missing
+        // array here would throw mid-render and (per shell.jsx's per-view
+        // error boundary) blank at least this view's slot. Degrade to an
+        // empty list instead, but warn once per node+field so a real
+        // upstream data bug doesn't go silently unnoticed.
+        const __mtlxWarnedPortLists = new Set();
+        function safePortList(list, nodeId, field) {
+            if (Array.isArray(list)) return list;
+            const key = nodeId + ':' + field;
+            if (!__mtlxWarnedPortLists.has(key)) {
+                __mtlxWarnedPortLists.add(key);
+                console.warn('[mtlx] MtlxGraphNode: node "' + nodeId + '" has a non-array '
+                    + field + ' (' + typeof list + ') — rendering it as empty.', list);
+            }
+            return [];
+        }
+
         // Node card: header + one 22px port row each (row height must
         // match nodeHeight() above). Interface input/output GRAPH BOUNDARY
         // pseudo-nodes use a dashed border, darker body, and diamond dot.
@@ -90,7 +110,7 @@
                         </div>
                     </div>
                     <div className="py-0.5">
-                        {data.inputs.map((inp) => (
+                        {safePortList(data.inputs, data.id, 'inputs').map((inp) => (
                             <div key={'in:' + inp.name}
                                 className={'relative flex items-center gap-1.5 px-2' + (inp.authored === false ? ' opacity-50' : '')}
                                 style={{ height: 22 }}
@@ -116,7 +136,7 @@
                             <div className="px-2 text-gray-500 truncate" style={{ height: 22, lineHeight: '22px' }}
                                 title={data.value}>= {data.value}</div>
                         )}
-                        {data.outputs.map((out) => (
+                        {safePortList(data.outputs, data.id, 'outputs').map((out) => (
                             <div key={'out:' + out.name} className="relative flex items-center justify-end gap-1.5 px-2" style={{ height: 22 }}>
                                 <span className="text-[9px]" style={{ color: typeColor(out.type) }}>{out.type}</span>
                                 <span className="text-gray-300 truncate">{out.name}</span>

--- a/js/graph/style.jsx
+++ b/js/graph/style.jsx
@@ -10,8 +10,20 @@
 
         const NODE_W = 240;
         // Must track MtlxGraphNode's real metrics (header ~34px, row 22px)
-        // or dagre's ranks drift apart from what actually renders.
-        const nodeHeight = (d) => 38 + (d.inputs.length + d.outputs.length) * 22 + 6;
+        // or dagre's ranks drift apart from what actually renders. Guarded:
+        // a malformed descriptor (non-array inputs/outputs) used to throw
+        // here mid-layout; fall back to 0 rows for the missing side and
+        // warn instead, so one bad node degrades the layout, not the page.
+        const nodeHeight = (d) => {
+            const inputsOk = Array.isArray(d && d.inputs);
+            const outputsOk = Array.isArray(d && d.outputs);
+            if (!inputsOk || !outputsOk) {
+                console.warn('[mtlx] nodeHeight: node "' + (d && d.id) + '" has non-array inputs/outputs — treating the missing side as empty.', d);
+            }
+            const inputCount = inputsOk ? d.inputs.length : 0;
+            const outputCount = outputsOk ? d.outputs.length : 0;
+            return 38 + (inputCount + outputCount) * 22 + 6;
+        };
 
         const layoutScope = (descs, edges) => {
             // Two return points (stored-position fast path vs. dagre) each
@@ -42,6 +54,16 @@
             const posOf = {};
             for (const d of descs) {
                 const n = g.node(d.id); // dagre positions are CENTERS
+                if (!n) {
+                    // dagre never assigned this id a position (e.g. it was
+                    // never g.setNode()'d, or the graph is otherwise out of
+                    // sync with descs). Skip it here — leaving posOf[d.id]
+                    // unset — and let toFlow()'s own guard supply a sane
+                    // default so the node still renders instead of React
+                    // Flow dereferencing an undefined position.
+                    console.warn('[mtlx] layoutScope: dagre produced no position for node "' + d.id + '" — leaving it for toFlow\'s default-position fallback.', d);
+                    continue;
+                }
                 posOf[d.id] = { x: n.x - NODE_W / 2, y: n.y - nodeHeight(d) / 2 };
             }
             if (MTLX_PERF_LOG) {
@@ -145,12 +167,25 @@
                 });
             });
             const posOf = layoutScope(shaped, edges);
-            const nodes = shaped.map((d) => ({
-                id: d.id,
-                type: 'mtlx',
-                position: posOf[d.id],
-                data: d,
-            }));
+            // A missing posOf[d.id] (layoutScope skipped it, or a
+            // stored-position document is missing an entry) would hand
+            // React Flow `position: undefined` — it derefs node.position.x
+            // during its own render, unmounting the root. Fall back to a
+            // small index-based grid (not all-zeros, so fallback nodes
+            // don't stack exactly on top of each other) and warn once.
+            const nodes = shaped.map((d, i) => {
+                let pos = posOf[d.id];
+                if (!pos) {
+                    console.warn('[mtlx] toFlow: no layout position for node "' + d.id + '" — using a default grid position so it still renders.', d);
+                    pos = { x: (i % 6) * (NODE_W + 40), y: Math.floor(i / 6) * 200 };
+                }
+                return {
+                    id: d.id,
+                    type: 'mtlx',
+                    position: pos,
+                    data: d,
+                };
+            });
             const rfEdges = edges.map(toRfEdge);
             return { nodes, edges: rfEdges };
         };

--- a/js/shared/ui-commons.js
+++ b/js/shared/ui-commons.js
@@ -84,3 +84,70 @@ const MtlxIcon = (props) => {
 };
 
 Object.assign(window, { MtlxIcon, MTLX_ICON_PATHS });
+
+// ------------------------------------------------------------------
+// Global error capture (browser-side). Until now there was no
+// window 'error'/'unhandledrejection' listener anywhere in js/ — the
+// only precedent is vscode_extension/media/bootstrap.js's postError(),
+// which forwards capped/truncated text to the extension host. This is
+// the same shape (a small cap, per-entry truncation), but LOCAL ONLY:
+// no network call, no telemetry — just an in-memory ring buffer that
+// js/shell.jsx's per-view error boundary (and anything else) can read
+// via mtlxDiagnosticsText() for its "Copy diagnostics" button. Always
+// also console.error, so nothing is hidden from normal devtools use.
+//
+// Lives here (not shell.jsx) because ui-commons.js is the first script
+// after React/Babel to run on every page (index.html, the tutorials
+// subsite's vendored copy, and the VS Code webview) — it must be
+// listening before mtlx-engine.js or shell.jsx even start loading.
+// ------------------------------------------------------------------
+const MTLX_ERROR_LOG_MAX = 20;
+const MTLX_ERROR_CHARS_MAX = 500;
+const __mtlxErrorLog = [];
+function mtlxRecordError(text) {
+    __mtlxErrorLog.push({
+        time: new Date().toISOString(),
+        text: String(text).slice(0, MTLX_ERROR_CHARS_MAX),
+    });
+    if (__mtlxErrorLog.length > MTLX_ERROR_LOG_MAX) __mtlxErrorLog.shift();
+}
+window.addEventListener('error', (event) => {
+    const where = event && event.filename ? ' (' + event.filename + ':' + event.lineno + ')' : '';
+    const err = event && event.error;
+    mtlxRecordError('Uncaught error: ' + ((err && (err.stack || err.message)) || (event && event.message) || 'Unknown error') + where);
+    console.error('[mtlx] Uncaught error:', err || (event && event.message));
+});
+window.addEventListener('unhandledrejection', (event) => {
+    const reason = event && event.reason;
+    mtlxRecordError('Unhandled rejection: ' + String((reason && (reason.stack || reason.message)) || reason));
+    console.error('[mtlx] Unhandled rejection:', reason);
+});
+
+// Formats the ring buffer (plus live page context) as plain text for a
+// "Copy diagnostics" button. `extra` is caller-supplied context, e.g. the
+// specific error/component stack an error boundary just caught — put
+// first since it's almost always the most relevant line.
+function mtlxDiagnosticsText(extra) {
+    const lines = ['MaterialX Playground diagnostics', 'Time: ' + new Date().toISOString()];
+    if (extra) lines.push('', String(extra));
+    lines.push(
+        '',
+        'URL: ' + location.href,
+        'Hash: ' + (location.hash || '(none)'),
+        'User agent: ' + navigator.userAgent,
+        'Viewport: ' + window.innerWidth + 'x' + window.innerHeight,
+    );
+    if (window.__mtlxVersion) lines.push('MaterialX version: ' + window.__mtlxVersion);
+    if (__mtlxErrorLog.length) {
+        lines.push('', 'Recent captured errors (' + __mtlxErrorLog.length + '):');
+        __mtlxErrorLog.forEach((e) => lines.push('[' + e.time + '] ' + e.text));
+    } else {
+        lines.push('', 'No other errors captured this session.');
+    }
+    return lines.join('\n');
+}
+
+Object.assign(window, {
+    mtlxRecordError, mtlxDiagnosticsText,
+    mtlxGetErrorLog: () => __mtlxErrorLog.slice(),
+});

--- a/js/shell.jsx
+++ b/js/shell.jsx
@@ -205,6 +205,99 @@ async function loadViewDeps(viewName) {
 }
 
 // ------------------------------------------------------------------
+// Per-view error boundary. PreviewErrorBoundary (js/shared/mtlx-ui.jsx)
+// already documents the problem: "The site ships production React with
+// no error boundaries — one render throw anywhere unmounts the ENTIRE
+// app." That one only wraps the docs page's 3D preview. This is the
+// shell-level counterpart, one per view, so a throw anywhere inside a
+// view's own tree degrades to a recoverable card in that view's slot
+// instead of taking down #root (and with it every other view, and the
+// hash router that lives inside the same tree — see shell.jsx's module
+// comment). Defined HERE rather than in mtlx-ui.jsx, deliberately: that
+// file is a lazy per-view dependency loaded only after a view first
+// activates, so a boundary living there wouldn't exist yet for the very
+// first throw.
+//
+// Catches render-phase and commit-phase throws (including layout/passive
+// effects) — the class of bug that caused the production crash this is
+// mitigating. It does NOT catch throws from DOM event handlers; React 18
+// never routes those through boundaries at all, which is what
+// ui-commons.js's window 'error'/'unhandledrejection' listener is for.
+// Both funnel into the same mtlxRecordError() ring buffer, so "Copy
+// diagnostics" here can surface either kind.
+class ViewErrorBoundary extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = { error: null, info: null, copied: false };
+        this.handleReload = () => window.location.reload();
+        this.handleCopy = () => {
+            const text = this.diagnosticsText();
+            const copy = window.copyTextToClipboard
+                || ((s) => (navigator.clipboard ? navigator.clipboard.writeText(s) : Promise.reject(new Error('Clipboard unavailable'))));
+            Promise.resolve(copy(text)).then(() => {
+                this.setState({ copied: true });
+                clearTimeout(this._copiedTimer);
+                this._copiedTimer = setTimeout(() => this.setState({ copied: false }), 1500);
+            }, (err) => console.error('[mtlx] Copy diagnostics failed:', err));
+        };
+    }
+    static getDerivedStateFromError(error) { return { error }; }
+    componentDidCatch(error, info) {
+        this.setState({ info });
+        // Also feed the global ring buffer (ui-commons.js) — the same
+        // trail "Copy diagnostics" reads from a live window.onerror catch,
+        // so a render-phase crash and a later event-handler crash both
+        // show up together.
+        if (window.mtlxRecordError) {
+            window.mtlxRecordError('View "' + (this.props.view || '?') + '" render crash: '
+                + String((error && (error.stack || error.message)) || error)
+                + (info && info.componentStack ? '\nComponent stack:' + info.componentStack : ''));
+        }
+        console.error('[mtlx] ViewErrorBoundary caught an error in view "' + (this.props.view || '?') + '":', error, info);
+    }
+    componentWillUnmount() { clearTimeout(this._copiedTimer); }
+    diagnosticsText() {
+        const { error, info } = this.state;
+        const detail = 'Crashed view: ' + (this.props.view || '?')
+            + '\nError: ' + String((error && (error.stack || error.message)) || error)
+            + (info && info.componentStack ? '\nComponent stack:' + info.componentStack : '');
+        return window.mtlxDiagnosticsText ? window.mtlxDiagnosticsText(detail) : detail;
+    }
+    render() {
+        if (this.state.error) {
+            const { error, info } = this.state;
+            return (
+                <div className="flex flex-col items-center justify-center h-40 gap-3 text-red-400 text-sm text-center px-4">
+                    <span>This view crashed: {String((error && error.message) || error)}</span>
+                    {info && info.componentStack && (
+                        <pre className="max-w-full max-h-24 overflow-auto text-left text-[10px] leading-snug text-gray-500 bg-gray-950/50 border border-gray-800 rounded p-2 whitespace-pre-wrap">
+                            {info.componentStack.trim()}
+                        </pre>
+                    )}
+                    <div className="flex items-center gap-2">
+                        <button
+                            type="button"
+                            onClick={this.handleReload}
+                            className="text-xs px-3 py-1.5 rounded-lg border bg-gray-800 border-gray-600 text-gray-200 hover:bg-gray-700 transition-colors"
+                        >
+                            Reload page
+                        </button>
+                        <button
+                            type="button"
+                            onClick={this.handleCopy}
+                            className="text-xs px-3 py-1.5 rounded-lg border bg-gray-800 border-gray-600 text-gray-200 hover:bg-gray-700 transition-colors"
+                        >
+                            {this.state.copied ? 'Copied!' : 'Copy diagnostics'}
+                        </button>
+                    </div>
+                </div>
+            );
+        }
+        return this.props.children;
+    }
+}
+
+// ------------------------------------------------------------------
 // Shell component
 // ------------------------------------------------------------------
 function Shell() {
@@ -340,7 +433,14 @@ function Shell() {
                 </div>
             );
         } else if (st.status === 'ready' && window[dep.globalName]) {
-            const rendered = React.createElement(window[dep.globalName], { active: isActive });
+            // Wrapped so a render/effect-phase throw anywhere inside this
+            // view degrades to a card in this slot instead of unmounting
+            // #root (see ViewErrorBoundary's comment above).
+            const rendered = (
+                <ViewErrorBoundary view={view}>
+                    {React.createElement(window[dep.globalName], { active: isActive })}
+                </ViewErrorBoundary>
+            );
             if (view === 'home') {
                 // Mirrors the viewer wrapper contract: HomeApp handles its
                 // own inner max-width/centering, this just matches the


### PR DESCRIPTION
The Node Graph Editor could blank the whole page (React error #185, "Maximum update depth exceeded"): two infinite setState loops threw during render, and with no error boundary covering the graph editor, React 18 unmounted the entire app.

- Fixes the legend/minimap layout effect (missing `pillRef.current` guard on `pillClear`, subpixel float compared with `===`, now coalesced per frame) and `onEdgesChange` (bumped a resync epoch React Flow could assert straight back, with no iteration cap; now only on genuine disagreement).
- Adds a loop breaker after 5 consecutive state-changing frames, plus `ViewErrorBoundary` around every view and global error capture so any future throw degrades to a recoverable error card instead of a blank page.
