### PR TITLE
Design language alignment: Node Specs, Viewer, Compare and the parameter editors

### DIFF
--- a/embed/gen/mtlx-ui.js
+++ b/embed/gen/mtlx-ui.js
@@ -11,8 +11,8 @@
 // Recurring Tailwind button strings, pulled out because the exact same
 // string (verbatim) repeats across files. Near-twin variants elsewhere
 // (different opacity/sizing) are NOT this — leave those inline.
-const BTN_SECONDARY = 'h-7 inline-flex items-center justify-center text-[11px] px-2.5 rounded border bg-gray-800/80 border-gray-600 text-gray-300 hover:bg-gray-700/80 transition-colors';
-const BTN_PRIMARY = 'h-7 inline-flex items-center justify-center text-[11px] px-2.5 rounded border bg-blue-600/70 border-blue-500 text-white hover:bg-blue-500/70 transition-colors';
+const BTN_SECONDARY = 'h-7 inline-flex items-center justify-center text-[11px] px-2.5 rounded-md border bg-gray-800/80 border-gray-600 text-gray-300 hover:bg-gray-700/80 transition-colors';
+const BTN_PRIMARY = 'h-7 inline-flex items-center justify-center text-[11px] px-2.5 rounded-md border bg-blue-600/70 border-blue-500 text-white hover:bg-blue-500/70 transition-colors';
 // Graph editor toolbar button style. `whitespace-nowrap shrink-0` matters:
 // js/graph-app.jsx's label-collapse measurement needs buttons that don't
 // flex-shrink, so overflow is visible to it instead of silently absorbed.
@@ -22,6 +22,11 @@ const BTN_TOOLBAR = 'h-7 inline-flex items-center gap-1 text-[11px] px-2 rounded
 // the button never changes size between states. No backdrop-blur: the
 // menu bar it sits on is opaque, so there is nothing to blur.
 const BTN_MENUBAR = 'h-7 inline-flex items-center gap-1 text-[11px] px-2 rounded border border-transparent bg-transparent text-gray-300 hover:bg-gray-700/80 hover:border-gray-600 transition-colors whitespace-nowrap shrink-0';
+// Labeled overlay pills for the tool HUDs (viewer/compare) and the
+// collapsed-sidebar pills: deliberately 11px normal weight, not the
+// bolder PILL_ACTION, to match the sidebar's own labeled pills.
+const HUD_PILL = 'h-7 inline-flex items-center gap-1.5 text-[11px] px-2 rounded-lg border border-gray-600/50 bg-gray-900/70 backdrop-blur text-gray-300 hover:bg-gray-700 hover:border-gray-600 hover:text-gray-100 transition-colors whitespace-nowrap';
+const HUD_PILL_ACTIVE = 'h-7 inline-flex items-center gap-1.5 text-[11px] px-2 rounded-lg border border-blue-500 bg-blue-600/80 backdrop-blur text-white transition-colors whitespace-nowrap';
 
 // Formats a caught value for display: an Error's .message, or the value
 // itself stringified (some rejections/throws aren't Error instances).
@@ -1049,13 +1054,14 @@ const EnvDialog = ({
   onExposureChange,
   onImportFile,
   onReset,
+  envFileName,
+  onClearEnv,
   importError,
   placement,
   edgeRef
 }) => {
   const popRef = React.useRef(null);
   const [pos, setPos] = React.useState(null);
-  const fileInputRef = React.useRef(null);
   // Key-light extraction toggle: window.getKeyLightEnabled/setKeyLightEnabled
   // live in js/mtlx-engine.js and may be absent (standalone/older builds),
   // so the control degrades to disabled rather than throwing.
@@ -1165,27 +1171,22 @@ const EnvDialog = ({
     value: linearToEv(exposure),
     onChange: e => onExposureChange(evToLinear(e.target.value)),
     className: "w-full accent-blue-500"
-  })), /*#__PURE__*/React.createElement("div", {
-    className: "flex items-center gap-1.5 pt-1 border-t border-gray-700"
-  }, /*#__PURE__*/React.createElement("button", {
-    onClick: () => fileInputRef.current && fileInputRef.current.click(),
-    className: "flex-1 h-6 rounded border bg-gray-800/80 border-gray-600 text-gray-300 hover:bg-gray-700/80 transition-colors"
-  }, "Import\u2026"), /*#__PURE__*/React.createElement("button", {
-    onClick: onReset,
-    className: "flex-1 h-6 rounded border bg-gray-800/80 border-gray-600 text-gray-300 hover:bg-gray-700/80 transition-colors"
-  }, "Reset"), /*#__PURE__*/React.createElement("input", {
-    ref: fileInputRef,
-    type: "file",
+  })), /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement(FilePickerField, {
+    value: envFileName,
+    placeholder: "Default environment",
     accept: ".hdr,.exr",
-    className: "hidden",
-    onChange: e => {
-      const f = e.target.files && e.target.files[0];
-      e.target.value = '';
+    icon: "file",
+    onFiles: files => {
+      const f = files && files[0];
       if (f) onImportFile(f);
-    }
+    },
+    onClear: onClearEnv
   })), importError && /*#__PURE__*/React.createElement("div", {
     className: "text-red-400"
-  }, importError)), fullscreenPortalRoot());
+  }, importError), /*#__PURE__*/React.createElement("button", {
+    onClick: onReset,
+    className: "w-full h-6 rounded border bg-gray-800/80 border-gray-600 text-gray-300 hover:bg-gray-700/80 transition-colors"
+  }, "Reset")), fullscreenPortalRoot());
 };
 
 // Friendly labels for the preview-geometry dropdown's raw values (which
@@ -1409,6 +1410,107 @@ function GeometryTile({
     className: "text-[11px] leading-tight text-center min-h-[26px] flex items-center"
   }, label));
 }
+
+// Joined file-picker row (read-only path display + a Choose button), one
+// field-height (~26px) control matching the graph sidebar's field rows.
+// `onChoose` drives a caller's own file dialog; else a hidden file input.
+// `editable`/`onCommit` swap the path area for a real text input; `onClear`
+// adds an x button inside the field when `value` is non-empty.
+function FilePickerField({
+  value,
+  placeholder = 'No file selected',
+  accept,
+  multiple,
+  onFiles,
+  onChoose,
+  editable,
+  onCommit,
+  onClear,
+  disabled,
+  buttonLabel = 'Choose...',
+  icon,
+  // Mono typography is opt-in: only the graph editor's and node specs'
+  // parameter-editing rows want it. Everyone else gets the app's sans.
+  mono = false
+}) {
+  const buttonCls = 'inline-flex items-center gap-1 border border-l-0 border-gray-700 rounded-r-md bg-gray-800 hover:bg-gray-700 text-[11px] px-2 text-gray-300 whitespace-nowrap' + (mono ? ' font-mono' : '');
+  const [draft, setDraft] = React.useState(value || '');
+  // A ref (not state) so blurring alone never re-triggers the seed
+  // effect below -- only an actual `value` change should re-seed.
+  const focusedRef = React.useRef(false);
+  React.useEffect(() => {
+    if (!focusedRef.current) setDraft(value || '');
+  }, [value]);
+  const commit = () => {
+    if (draft !== (value || '') && onCommit) onCommit(draft);
+  };
+  const showClear = !!onClear && !!value;
+  const fieldBase = 'bg-gray-900 border border-gray-700 rounded-l-md px-2 text-[11px] text-gray-300 h-full w-full' + (mono ? ' font-mono' : '') + (showClear ? ' pr-6' : '');
+  return /*#__PURE__*/React.createElement("div", {
+    className: "flex h-[26px]"
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "relative min-w-0 flex-1"
+  }, editable ? /*#__PURE__*/React.createElement("input", {
+    type: "text",
+    value: draft,
+    placeholder: placeholder,
+    disabled: disabled,
+    onFocus: () => {
+      focusedRef.current = true;
+    },
+    onChange: e => setDraft(e.target.value),
+    onBlur: () => {
+      focusedRef.current = false;
+      commit();
+    },
+    onKeyDown: e => {
+      if (e.key === 'Enter') {
+        e.currentTarget.blur();
+      }
+    },
+    className: fieldBase + ' placeholder-gray-500 focus:outline-none'
+  }) : /*#__PURE__*/React.createElement("div", {
+    title: value,
+    className: fieldBase + ' flex items-center'
+  }, /*#__PURE__*/React.createElement("span", {
+    className: "truncate"
+  }, value || /*#__PURE__*/React.createElement("span", {
+    className: "text-gray-500"
+  }, placeholder))), showClear && /*#__PURE__*/React.createElement("button", {
+    type: "button",
+    title: "Clear",
+    disabled: disabled,
+    onClick: onClear,
+    className: "absolute right-1.5 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-200"
+  }, /*#__PURE__*/React.createElement(MtlxIcon, {
+    name: "x",
+    className: "w-3 h-3"
+  }))), onChoose ? /*#__PURE__*/React.createElement("button", {
+    type: "button",
+    onClick: onChoose,
+    disabled: disabled,
+    className: buttonCls + (disabled ? ' opacity-50 cursor-not-allowed' : '')
+  }, icon && /*#__PURE__*/React.createElement(MtlxIcon, {
+    name: icon,
+    className: "w-3.5 h-3.5"
+  }), buttonLabel) : /*#__PURE__*/React.createElement("label", {
+    className: buttonCls + ' cursor-pointer' + (disabled ? ' opacity-50 pointer-events-none' : '')
+  }, icon && /*#__PURE__*/React.createElement(MtlxIcon, {
+    name: icon,
+    className: "w-3.5 h-3.5"
+  }), buttonLabel, /*#__PURE__*/React.createElement("input", {
+    type: "file",
+    accept: accept,
+    multiple: multiple,
+    className: "hidden",
+    disabled: disabled,
+    onChange: e => {
+      if (onFiles) onFiles(e.target.files);
+      // Clear so re-picking the SAME file still fires a change event.
+      e.target.value = '';
+    }
+  })));
+}
 const ViewportControls = ({
   geomList = ['shaderball', 'shaderball-scene', 'shaderball-mtlx', 'sphere', 'cube', 'cloth'],
   geom,
@@ -1467,6 +1569,8 @@ const ViewportControls = ({
   const [envRotation, setEnvRotation] = React.useState(0); // degrees, 0-360
   const [envExposure, setEnvExposure] = React.useState(1.0);
   const [envImportError, setEnvImportError] = React.useState(null);
+  // Imported environment's filename, shown by EnvDialog's FilePickerField.
+  const [envFileName, setEnvFileName] = React.useState('');
   const [settingsOpen, setSettingsOpen] = React.useState(false);
 
   // Re-apply rotation/exposure to the current view on every (re)build
@@ -1490,9 +1594,19 @@ const ViewportControls = ({
       // one) via the engine's LIVE_VIEWS registry — no need to also
       // call viewRef.current.setEnvironment here.
       window.setEnvOverride(env);
+      setEnvFileName(file.name);
     } catch (e) {
       setEnvImportError(errMsg(e));
     }
+  };
+
+  // FilePickerField's own x button: clears the imported environment back
+  // to the default WITHOUT touching rotation/exposure -- that stays the
+  // Reset button's job below.
+  const handleClearEnv = () => {
+    window.setEnvOverride(null);
+    setEnvImportError(null);
+    setEnvFileName('');
   };
   const handleReset = () => {
     // setEnvOverride(null) broadcasts the default environment to every
@@ -1500,6 +1614,7 @@ const ViewportControls = ({
     // needed here.
     window.setEnvOverride(null);
     setEnvImportError(null);
+    setEnvFileName('');
     setEnvRotation(0);
     setEnvExposure(1.0);
     if (viewRef && viewRef.current) {
@@ -1594,6 +1709,8 @@ const ViewportControls = ({
           },
           onImportFile: handleImportFile,
           onReset: handleReset,
+          envFileName: envFileName,
+          onClearEnv: handleClearEnv,
           importError: envImportError
         })) : null;
       case 'screenshot':
@@ -2160,7 +2277,8 @@ const MtlxSelect = ({
   popMaxHeight,
   theme,
   commitFocus = 'trigger',
-  ariaLabel
+  ariaLabel,
+  align
 }) => {
   const [open, setOpen] = React.useState(false);
   const [pos, setPos] = React.useState(null);
@@ -2421,7 +2539,14 @@ const MtlxSelect = ({
   // its own chrome from size/variant, and className is appended for
   // positioning/flex sizing/margins on top of that.
   const chrome = 'rounded ' + (SELECT_SIZE_CLS[size] || SELECT_SIZE_CLS.sm) + ' ' + (SELECT_VARIANT_CLS[variant] || SELECT_VARIANT_CLS.toolbar);
-  const triggerClassName = [chrome, 'inline-flex items-center gap-1', block && 'w-full justify-between', fontCls, disabled && 'opacity-50 pointer-events-none', className].filter(Boolean).join(' ');
+  // Default (no `align`, i.e. today's every call site): `justify-between`
+  // across icon/label/chevron splits the free width into two roughly
+  // equal gaps, which visually centers the label once an icon is
+  // present -- that's the reported "centered" look. `align="left"`
+  // drops justify-between so icon+label pack flush left; the chevron
+  // gets ml-auto below to stay pinned at the right edge instead.
+  const alignLeft = align === 'left';
+  const triggerClassName = [chrome, 'inline-flex items-center gap-1', block && (alignLeft ? 'w-full' : 'justify-between'), fontCls, disabled && 'opacity-50 pointer-events-none', className].filter(Boolean).join(' ');
 
   // Chrome color/background/border comes from theme custom properties,
   // always applied now that className no longer replaces the trigger's
@@ -2508,7 +2633,7 @@ const MtlxSelect = ({
       style: o.badge.tone === 'warn' ? {
         color: MXS_BADGE_WARN
       } : undefined,
-      className: 'flex-none text-[9px] uppercase tracking-wide px-1 py-0.5 rounded border ' + SELECT_BADGE_TONE_CLS[o.badge.tone]
+      className: 'flex-none font-sans text-[9px] uppercase tracking-wide px-1 py-0.5 rounded border ' + SELECT_BADGE_TONE_CLS[o.badge.tone]
     }, o.badge.text));
   })) : null;
   return /*#__PURE__*/React.createElement(React.Fragment, null, /*#__PURE__*/React.createElement("button", {
@@ -2537,7 +2662,7 @@ const MtlxSelect = ({
     }
   }, triggerLabel), /*#__PURE__*/React.createElement(MtlxIcon, {
     name: "chevron-down",
-    className: "w-3 h-3 flex-none opacity-70"
+    className: 'w-3 h-3 flex-none opacity-70' + (alignLeft ? ' ml-auto' : '')
   })), popover && ReactDOM.createPortal(popover, fullscreenPortalRoot()));
 };
 
@@ -2971,6 +3096,8 @@ Object.assign(window, {
   PreviewErrorBoundary,
   fullscreenPortalRoot,
   BTN_MENUBAR,
+  HUD_PILL,
+  HUD_PILL_ACTIVE,
   DialogFrame,
   PresetsDialog,
   SettingsDialog,
@@ -2987,6 +3114,7 @@ Object.assign(window, {
   Chip,
   SectionCard,
   GeometryTile,
+  FilePickerField,
   EV_MIN,
   EV_MAX,
   EV_STEP,

--- a/embed/gen/viewer-app.js
+++ b/embed/gen/viewer-app.js
@@ -713,15 +713,18 @@ function MaterialViewerApp({
       setStatus(IN_VSCODE ? null : "Couldn't reach GitHub for the default material. Drop a .mtlx anywhere on the page, or pick a Preset from the toolbar.");
     });
   }, []);
-  const onPickFiles = e => {
+  const onPickFileList = fileList => {
     const map = {};
-    for (const f of Array.from(e.target.files || [])) {
+    for (const f of Array.from(fileList || [])) {
       // webkitdirectory inputs carry relative paths
       map[f.webkitRelativePath || f.name] = f;
     }
-    e.target.value = '';
     setPresetPick('');
     ingest(map);
+  };
+  const onPickFiles = e => {
+    onPickFileList(e.target.files);
+    e.target.value = '';
   };
   const loadDocument = async (path, mapArg, versionArg) => {
     const map = mapArg || fileMapRef.current;
@@ -852,6 +855,78 @@ function MaterialViewerApp({
       }
     };
   }, [renderables, chosenMat, geom]);
+
+  // Backs the Scene card's transparency-forcing toggle (browser
+  // only): local mirror of the engine's persisted value, replacing
+  // the old HUD settings popover's only built-in block.
+  const [forceTransparency, setForceTransparency] = React.useState(() => !!(window.getForceTransparency && window.getForceTransparency()));
+
+  // Environment card state (browser only): envBg stays the
+  // existing hook state above; rotation/exposure live here since
+  // the HUD's env cluster is gone in the browser.
+  const [envUI, setEnvUI] = React.useState({
+    rotation: 0,
+    exposure: 1
+  });
+  const [envImportError, setEnvImportError] = React.useState(null);
+  const [envFileName, setEnvFileName] = React.useState('');
+  const setEnvRotationDeg = v => {
+    setEnvUI(s => ({
+      ...s,
+      rotation: v
+    }));
+    if (viewRef.current && viewRef.current.setEnvRotation) viewRef.current.setEnvRotation(v * Math.PI / 180);
+  };
+  const setEnvExposureVal = v => {
+    setEnvUI(s => ({
+      ...s,
+      exposure: v
+    }));
+    if (viewRef.current && viewRef.current.setEnvExposure) viewRef.current.setEnvExposure(v);
+  };
+  const importEnv = async file => {
+    setEnvImportError(null);
+    try {
+      const env = await loadEnvironmentFromFile(file);
+      setEnvOverride(env);
+      setEnvFileName(file.name);
+    } catch (e) {
+      setEnvImportError(errMsg(e));
+    }
+  };
+  // Clears an imported environment back to the default WITHOUT
+  // touching rotation/exposure: that stays the Reset button's job.
+  const clearEnvOverride = () => {
+    setEnvOverride(null);
+    setEnvImportError(null);
+    setEnvFileName('');
+  };
+  const resetEnv = () => {
+    setEnvOverride(null);
+    setEnvImportError(null);
+    setEnvFileName('');
+    setEnvUI({
+      rotation: 0,
+      exposure: 1
+    });
+    if (viewRef.current) {
+      if (viewRef.current.setEnvRotation) viewRef.current.setEnvRotation(0);
+      if (viewRef.current.setEnvExposure) viewRef.current.setEnvExposure(1.0);
+    }
+  };
+  const envSummary = envUI.rotation === 0 && envUI.exposure === 1 ? 'Default' : Math.round(envUI.rotation) + '°, ' + formatEv(linearToEv(envUI.exposure));
+
+  // Re-applies the sidebar's env sliders to a freshly (re)built
+  // view; chromeless has no sidebar, so this no-ops there and the
+  // render effect's own controlled-prop application stands alone.
+  React.useEffect(() => {
+    if (chromeless) return;
+    const v = viewRef.current;
+    if (!v) return;
+    if (v.setEnvRotation) v.setEnvRotation(envUI.rotation * Math.PI / 180);
+    if (v.setEnvExposure) v.setEnvExposure(envUI.exposure);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [viewEpoch]);
   const fileCount = Object.keys(fileMap).length;
   const texCount = Object.keys(fileMap).filter(k => IMG_EXT.test(k)).length;
 
@@ -882,6 +957,10 @@ function MaterialViewerApp({
   // hidden when there's nothing to switch between.
   const showMaterial = showCtl('material') && renderables.length > 1;
   const anyCtlVisible = Object.values(ctlFlags).some(Boolean) || showMaterial;
+  // Non-chromeless HUD cluster layout: geometry/env/settings moved
+  // into the sidebar's Scene/Environment cards in the browser, so
+  // only IN_VSCODE (no sidebar there) keeps those in its clusters.
+  const hudClusters = IN_VSCODE ? [['geom', 'rotate', 'cameraReset', 'env'], ['screenshot', 'shaderCode', 'sendToGraph'], ['presets', 'settings', 'fullscreen']] : [['rotate', 'cameraReset'], ['screenshot', 'shaderCode', 'sendToGraph'], ['presets', 'fullscreen']];
   // Page-transparency CSS: requested AND resolved away from the
   // room. Belt-and-suspenders alongside resolveViewerGeom's own
   // guard above, in case geom ever drifts back to the room.
@@ -896,8 +975,9 @@ function MaterialViewerApp({
 
   // 28px HUD chip classes, shared by ViewportControls' built-in
   // slots (via buttonClassName) and the custom sendToGraph/
-  // presets/shaderCode buttons below.
-  const hudChipClass = active => `h-7 w-7 inline-flex items-center justify-center rounded border transition-colors ${active ? 'bg-blue-600/80 border-blue-500 text-white' : 'bg-gray-800/80 border-gray-600 text-gray-300 hover:bg-gray-700/80'}`;
+  // presets/shaderCode buttons below. VS Code stays icon-only and
+  // square; the browser HUD grows labels via HUD_PILL/HUD_PILL_ACTIVE.
+  const hudChipClass = active => IN_VSCODE ? `h-7 w-7 justify-center inline-flex items-center rounded-lg border transition-colors ${active ? 'bg-blue-600/80 border-blue-500 text-white' : 'border-gray-600/50 bg-gray-900/70 text-gray-400 hover:bg-gray-700 hover:border-gray-600 hover:text-gray-100'}` : active ? HUD_PILL_ACTIVE : HUD_PILL;
 
   // Files sidebar body: Document/Materials/Textures cards, split
   // out so the docked panel's own JSX (below) stays flat.
@@ -909,33 +989,32 @@ function MaterialViewerApp({
     summary: docBasename,
     defaultOpen: true
   }, /*#__PURE__*/React.createElement("div", {
-    className: `rounded-lg border-2 border-dashed p-4 text-center transition-colors ${dragOver ? 'border-blue-500 bg-blue-950/30' : 'border-gray-600 bg-gray-800'}`
-  }, /*#__PURE__*/React.createElement(MtlxIcon, {
-    name: "file-upload",
-    className: "w-8 h-8 block mx-auto mb-2 text-gray-400"
-  }), /*#__PURE__*/React.createElement("div", {
-    className: "text-sm text-gray-300 font-medium"
-  }, "Drop .mtlx, textures, a folder or a .zip"), /*#__PURE__*/React.createElement("div", {
-    className: "text-xs text-gray-500 mt-1"
-  }, "anywhere on the page, or"), /*#__PURE__*/React.createElement("div", {
-    className: "flex items-center justify-center gap-2 mt-3 flex-wrap"
-  }, /*#__PURE__*/React.createElement("label", {
-    className: BTN_SECONDARY + ' cursor-pointer'
-  }, "Choose files", /*#__PURE__*/React.createElement("input", {
-    type: "file",
+    className: "flex items-center gap-1"
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "flex-1 min-w-0"
+  }, /*#__PURE__*/React.createElement(FilePickerField, {
+    value: currentMtlxPath ? docBasename : '',
+    placeholder: "No document loaded",
     multiple: true,
-    className: "hidden",
-    onChange: onPickFiles
+    icon: "files",
+    accept: ".mtlx,.zip,.png,.jpg,.jpeg,.webp,.gif,.bmp,.tga,.exr,.hdr,.tif,.tiff",
+    onFiles: onPickFileList
   })), /*#__PURE__*/React.createElement("label", {
-    className: BTN_SECONDARY + ' cursor-pointer'
-  }, "Choose folder", /*#__PURE__*/React.createElement("input", {
+    title: "Choose a folder",
+    className: "h-[26px] w-[26px] shrink-0 inline-flex items-center justify-center border border-gray-700 rounded-md bg-gray-800 hover:bg-gray-700 text-gray-300 cursor-pointer"
+  }, /*#__PURE__*/React.createElement(MtlxIcon, {
+    name: "folder",
+    className: "w-3.5 h-3.5"
+  }), /*#__PURE__*/React.createElement("input", {
     type: "file",
     webkitdirectory: "",
     directory: "",
     multiple: true,
     className: "hidden",
     onChange: onPickFiles
-  })))), chosenMtlx && /*#__PURE__*/React.createElement("div", {
+  }))), /*#__PURE__*/React.createElement("div", {
+    className: "text-xs text-gray-500"
+  }, "or drag-and-drop anywhere on the page"), chosenMtlx && /*#__PURE__*/React.createElement("div", {
     className: "text-xs text-gray-500"
   }, mtlxPaths.length, " .mtlx, ", texCount, " image", texCount === 1 ? '' : 's'), /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement("div", {
     className: "flex items-center justify-between gap-2"
@@ -995,7 +1074,8 @@ function MaterialViewerApp({
   }))), renderables.length > 1 && /*#__PURE__*/React.createElement(SectionCard, {
     icon: "color-swatch",
     title: "Materials",
-    summary: currentMaterialName
+    summary: currentMaterialName,
+    defaultOpen: true
   }, /*#__PURE__*/React.createElement(MtlxSelect, {
     value: chosenMat,
     options: renderables.map((r, i) => ({
@@ -1006,10 +1086,92 @@ function MaterialViewerApp({
     size: "lg",
     variant: "field",
     block: true
-  })), texReport && texReport.missing.length > 0 && /*#__PURE__*/React.createElement(SectionCard, {
+  })), /*#__PURE__*/React.createElement(SectionCard, {
+    icon: "cube",
+    title: "Scene",
+    summary: GEOM_LABELS[geom] || geom,
+    defaultOpen: true
+  }, /*#__PURE__*/React.createElement("div", {
+    className: "grid grid-cols-2 gap-2"
+  }, VIEWER_GEOM_NAMES.map(g => /*#__PURE__*/React.createElement(GeometryTile, {
+    key: g,
+    label: GEOM_LABELS[g] || g,
+    icon: GEOM_ICONS[g],
+    selected: geom === g,
+    onClick: () => setGeom(g),
+    badge: g === 'shaderball-scene' ? 'Default' : undefined
+  })))), /*#__PURE__*/React.createElement(SectionCard, {
+    icon: "sun",
+    title: "Environment",
+    summary: envSummary,
+    defaultOpen: true,
+    dense: true
+  }, /*#__PURE__*/React.createElement(SliderField, {
+    label: "Environment rotation",
+    unit: "deg",
+    value: envUI.rotation,
+    min: 0,
+    max: 360,
+    step: 1,
+    onSlider: v => setEnvRotationDeg(Number(v)),
+    onNumber: v => setEnvRotationDeg(Number(v))
+  }), /*#__PURE__*/React.createElement(SliderField, {
+    label: "Exposure",
+    unit: "EV",
+    value: linearToEv(envUI.exposure),
+    min: EV_MIN,
+    max: EV_MAX,
+    step: EV_STEP,
+    onSlider: v => setEnvExposureVal(evToLinear(v)),
+    onNumber: v => setEnvExposureVal(evToLinear(v))
+  }), /*#__PURE__*/React.createElement("label", {
+    className: "flex items-center justify-between cursor-pointer"
+  }, /*#__PURE__*/React.createElement("span", {
+    className: "text-xs font-medium text-gray-400"
+  }, "Show environment as background"), /*#__PURE__*/React.createElement(Toggle, {
+    checked: envBg,
+    onChange: () => toggleEnvBg()
+  })), /*#__PURE__*/React.createElement(FilePickerField, {
+    value: envFileName,
+    placeholder: "Default environment",
+    accept: ".hdr,.exr",
+    icon: "file",
+    onFiles: files => {
+      const f = files && files[0];
+      if (f) importEnv(f);
+    },
+    onClear: clearEnvOverride
+  }), envImportError && /*#__PURE__*/React.createElement("div", {
+    className: "text-xs text-red-400"
+  }, envImportError), /*#__PURE__*/React.createElement("button", {
+    onClick: resetEnv,
+    title: "Also clears an imported .hdr/.exr and restores the default environment",
+    className: BTN_SECONDARY + ' w-full'
+  }, "Reset")), /*#__PURE__*/React.createElement(SectionCard, {
+    icon: "settings-cog",
+    title: "Rendering",
+    summary: forceTransparency ? 'Transparency forced' : 'Default',
+    defaultOpen: true
+  }, /*#__PURE__*/React.createElement("label", {
+    className: "flex items-center justify-between cursor-pointer",
+    title: forceTransparency ? 'Disable forced transparency' : 'Enable forced transparency'
+  }, /*#__PURE__*/React.createElement("span", {
+    className: "inline-flex items-center gap-1.5 text-xs font-medium text-gray-400"
+  }, "Force Transparency", /*#__PURE__*/React.createElement("span", {
+    className: "text-[9px] uppercase tracking-wide px-1 py-0.5 rounded bg-amber-600/30 border border-amber-500/50 text-amber-300"
+  }, "Experimental")), /*#__PURE__*/React.createElement(Toggle, {
+    checked: forceTransparency,
+    onChange: next => {
+      setForceTransparency(next);
+      window.setForceTransparency && window.setForceTransparency(next);
+    }
+  })), /*#__PURE__*/React.createElement("div", {
+    className: "mt-1 text-[11px] text-gray-400"
+  }, "Render opacity/transmission with real alpha blending in previews. When off, previews match the standard MaterialX viewer (opaque). Applies immediately to open previews.")), texReport && texReport.missing.length > 0 && /*#__PURE__*/React.createElement(SectionCard, {
     icon: "alert-triangle",
     title: "Textures",
-    summary: texReport.missing.length + ' unresolved'
+    summary: texReport.missing.length + ' unresolved',
+    defaultOpen: true
   }, /*#__PURE__*/React.createElement("div", {
     className: "space-y-2"
   }, texReport.missing.map((m, i) => /*#__PURE__*/React.createElement("div", {
@@ -1086,7 +1248,7 @@ function MaterialViewerApp({
     onToggleFullscreen: onToggleFullscreen,
     showFullscreen: ctlFlags.fullscreen
   }) : /*#__PURE__*/React.createElement(ViewportControls, {
-    containerClassName: "absolute top-2 right-2 z-10 flex items-center gap-2.5",
+    containerClassName: IN_VSCODE ? 'absolute top-2 right-2 z-10 flex items-center gap-2.5' : 'absolute top-2 right-2 z-10 flex items-center gap-2.5 flex-wrap justify-end max-w-[calc(100%-5rem)]',
     clusterClassName: "flex items-center gap-1",
     selectSize: "md",
     buttonClassName: hudChipClass,
@@ -1094,8 +1256,11 @@ function MaterialViewerApp({
     onGeomChange: setGeom,
     geomBadges: {
       'shaderball-scene': 'Default'
-    },
-    showGeomSelect: showCtl('geometry'),
+    }
+    // Geometry now lives in the sidebar's Scene card in the
+    // browser; VS Code has no sidebar, so it keeps the select.
+    ,
+    showGeomSelect: IN_VSCODE,
     rotating: rotating,
     onToggleRotating: toggleRotating
     // Engine no-ops auto-rotate for the full scene, and the
@@ -1104,19 +1269,25 @@ function MaterialViewerApp({
     ,
     showRotate: showCtl('rotate') && geom !== 'shaderball-scene',
     showBackgroundToggle: geom !== 'shaderball-scene',
-    onCameraReset: showCtl('reset') ? handleCameraReset : undefined,
-    envAvail: showCtl('env'),
+    onCameraReset: showCtl('reset') ? handleCameraReset : undefined
+    // Env cluster moved into the sidebar's Environment card in
+    // the browser; VS Code keeps the HUD's own env popover.
+    ,
+    envAvail: IN_VSCODE,
     envBg: envBg,
     onToggleEnvBg: toggleEnvBg,
     viewRef: viewRef,
     viewEpoch: viewEpoch,
     onScreenshot: takeScreenshot,
-    showScreenshot: showCtl('screenshot'),
-    showSettings: showCtl('settings'),
+    showScreenshot: showCtl('screenshot')
+    // Settings cog's only content (the transparency
+    // toggle) moved into the sidebar's Scene card.
+    ,
+    showSettings: IN_VSCODE,
     isFullscreen: isFullscreen,
     onToggleFullscreen: showCtl('fullscreen') ? onToggleFullscreen : undefined,
-    showLabels: false,
-    clusters: [['geom', 'rotate', 'cameraReset', 'env'], ['screenshot', 'shaderCode', 'sendToGraph'], ['presets', 'settings', 'fullscreen']],
+    showLabels: !IN_VSCODE,
+    clusters: hudClusters,
     slots: {
       // Graph and viewer are always in sync in the
       // extension (one opened .mtlx file), so this
@@ -1126,11 +1297,13 @@ function MaterialViewerApp({
         onClick: sendToEditor,
         title: "Open this material in the Node Graph Editor",
         disabled: !renderables.length,
-        className: hudChipClass(false) + ' disabled:opacity-40'
+        className: hudChipClass(false)
       }, /*#__PURE__*/React.createElement(MtlxIcon, {
         name: "transfer",
         className: "w-3.5 h-3.5"
-      })) : null,
+      }), !IN_VSCODE && /*#__PURE__*/React.createElement("span", {
+        className: "ml-1.5 whitespace-nowrap"
+      }, "Send to Editor")) : null,
       // Presets: browser-only (VS Code is bound to the open file).
       presets: !IN_VSCODE ? /*#__PURE__*/React.createElement("button", {
         key: "presets",
@@ -1140,7 +1313,9 @@ function MaterialViewerApp({
       }, /*#__PURE__*/React.createElement(MtlxIcon, {
         name: "presets",
         className: "w-3.5 h-3.5"
-      })) : null,
+      }), !IN_VSCODE && /*#__PURE__*/React.createElement("span", {
+        className: "ml-1.5 whitespace-nowrap"
+      }, "Presets")) : null,
       // Not VS Code-gated: generating shader source
       // applies to the single opened file too.
       shaderCode: /*#__PURE__*/React.createElement("button", {
@@ -1148,11 +1323,13 @@ function MaterialViewerApp({
         onClick: () => setShaderExportOpen(true),
         title: "Generate this material's shader source for a chosen target language (GLSL, OSL, MDL, ...)",
         disabled: !renderables.length,
-        className: hudChipClass(false) + ' disabled:opacity-40'
+        className: hudChipClass(false)
       }, /*#__PURE__*/React.createElement(MtlxIcon, {
         name: "file-code",
         className: "w-3.5 h-3.5"
-      }))
+      }), !IN_VSCODE && /*#__PURE__*/React.createElement("span", {
+        className: "ml-1.5 whitespace-nowrap"
+      }, "Shader Code"))
     }
   }, (isFullscreen || IN_VSCODE) && renderables.length > 1 && !chromeless && /*#__PURE__*/React.createElement(MtlxSelect, {
     value: chosenMat,
@@ -1187,21 +1364,30 @@ function MaterialViewerApp({
       className: "absolute bottom-2 left-2 z-10 pointer-events-none flex items-center gap-2 px-2 py-1 rounded-full bg-black/60 text-[11px] text-white/90"
     }, /*#__PURE__*/React.createElement("span", {
       className: "w-1.5 h-1.5 rounded-full bg-green-400 shrink-0"
-    }), /*#__PURE__*/React.createElement("span", null, segments.join(' | ')));
+    }), segments.map((seg, i) => {
+      const isVersion = i === segments.length - 1 && seg.charAt(0) === 'v';
+      return /*#__PURE__*/React.createElement(React.Fragment, {
+        key: i
+      }, i > 0 && /*#__PURE__*/React.createElement("span", {
+        className: "text-white/40"
+      }, "/"), /*#__PURE__*/React.createElement("span", {
+        className: isVersion ? 'font-mono' : undefined
+      }, seg));
+    }));
   })()))), !IN_VSCODE && status && !busy && /*#__PURE__*/React.createElement("div", {
     className: "absolute top-2 left-1/2 -translate-x-1/2 z-30 max-w-[min(42rem,85%)] bg-gray-800/90 backdrop-blur border border-gray-600 text-gray-300 text-sm rounded-lg px-4 py-2 break-words shadow-lg"
   }, status), !IN_VSCODE && error && /*#__PURE__*/React.createElement("div", {
     className: "absolute top-12 left-1/2 -translate-x-1/2 z-30 max-w-[min(42rem,85%)] bg-red-950/90 border border-red-800/60 text-red-200 text-sm rounded-lg px-4 py-2.5 break-words shadow-lg"
   }, error), !IN_VSCODE && !chromeless && !sidebarOpen && /*#__PURE__*/React.createElement("button", {
     onClick: () => setSidebarOpen(true),
-    title: "Expand the files panel",
-    className: "absolute top-2 left-2 z-30 h-7 inline-flex items-center gap-1.5 text-[11px] px-2 rounded border bg-gray-800/80 backdrop-blur border-gray-600 text-gray-300 hover:bg-gray-700/80 transition-colors"
+    title: "Expand the viewer panel",
+    className: 'absolute top-2 left-2 z-30 ' + HUD_PILL
   }, /*#__PURE__*/React.createElement(MtlxIcon, {
     name: "chevrons-right",
     className: "w-4 h-4"
   }), /*#__PURE__*/React.createElement("span", {
     className: "max-w-[5rem] md:max-w-[8rem] truncate"
-  }, "Files")));
+  }, "Viewer")));
   return (
     /*#__PURE__*/
     // IN_VSCODE: height chain fills the webview. Browser: a
@@ -1224,9 +1410,9 @@ function MaterialViewerApp({
       className: "flex-none flex items-center px-3 py-2 border-b border-gray-700"
     }, /*#__PURE__*/React.createElement("span", {
       className: "text-[13px] font-semibold text-gray-200"
-    }, "Files"), /*#__PURE__*/React.createElement("button", {
+    }, "Viewer"), /*#__PURE__*/React.createElement("button", {
       onClick: () => setSidebarOpen(false),
-      title: "Collapse the files panel",
+      title: "Collapse the viewer panel",
       className: "flex-none ml-auto text-gray-400 hover:text-gray-200 px-1 leading-none text-sm"
     }, /*#__PURE__*/React.createElement(MtlxIcon, {
       name: "chevrons-left",

--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
             }
         })();
     </script>
-    <script>window.__MTLX_BUILD = 'ad471e6b4bbf56e8';</script>
+    <script>window.__MTLX_BUILD = 'c2fe03ec25dbf3b3';</script>
     <!-- Build-id probe. Lives here, beside the stamp, deliberately: every
          other script (shell.jsx, mtlx-assets.js) is separately cached and
          may itself be the stale file this is meant to detect. -->

--- a/js/compare-app.jsx
+++ b/js/compare-app.jsx
@@ -15,6 +15,12 @@ const COMPARE_SIDEBAR_INSET = 320;
 // markers on document labels/pills across the stage and sidebar cards.
 const SLOT_COLORS = { A: '#60a5fa', B: '#fbbf24' };
 
+// Example pair: the Standard Surface carpaint preset vs a repo-local doc
+// that feeds the same values through the stdlib translation graph into
+// open_pbr_surface (see materials/standard_surface_carpaint_to_openpbr.mtlx).
+const EXAMPLE_PAIR_A_PATH = 'StandardSurface/standard_surface_carpaint.mtlx';
+const EXAMPLE_PAIR_B_URL = 'materials/standard_surface_carpaint_to_openpbr.mtlx';
+
 // Empty-stage grid backdrop: same 40px/gray-500 tokens as the builder's
 // HeroGrid, but masked with a radial fade (the pane is a bounded box, not
 // a page edge) so it dissolves before the pane borders instead of cutting off.
@@ -179,13 +185,16 @@ const useCompareSlot = () => {
         }
     };
 
-    const onPickFiles = (e) => {
+    const onPickFileList = (fileList) => {
         const map = {};
-        for (const f of Array.from(e.target.files || [])) {
+        for (const f of Array.from(fileList || [])) {
             map[f.webkitRelativePath || f.name] = f;
         }
-        e.target.value = '';
         ingest(map);
+    };
+    const onPickFiles = (e) => {
+        onPickFileList(e.target.files);
+        e.target.value = '';
     };
 
     return {
@@ -195,7 +204,7 @@ const useCompareSlot = () => {
         busy, setBusy, status, setStatus, error, setError,
         texReport, setTexReport,
         viewRef, canvasRef, viewEpoch, setViewEpoch, loadedRef,
-        ingest, onPickFiles, loadDocument,
+        ingest, onPickFiles, onPickFileList, loadDocument,
     };
 };
 
@@ -441,9 +450,14 @@ function MaterialCompareApp({ active = true } = {}) {
     const [geom, setGeom] = React.useState('shaderball-scene');
     const [envUI, setEnvUI] = React.useState({ rotation: 0, exposure: 1, bg: true });
     const [envImportError, setEnvImportError] = React.useState(null);
+    const [envFileName, setEnvFileName] = React.useState('');
+    // Backs the Rendering card's transparency-forcing toggle: local mirror
+    // of the engine's persisted value, same as viewer-app.jsx's own state.
+    const [forceTransparency, setForceTransparency] = React.useState(
+        () => !!(window.getForceTransparency && window.getForceTransparency())
+    );
     const envUIRef = React.useRef(envUI);
     envUIRef.current = envUI;
-    const envFileInputRef = React.useRef(null);
     const heatmapCanvasRef = React.useRef(null);
     const gpuDiffCanvasRef = React.useRef(null);
     const gpuDiffViewRef = React.useRef(null);
@@ -469,6 +483,65 @@ function MaterialCompareApp({ active = true } = {}) {
     const slotB = useCompareSlot();
     useCompareRenderEffect(slotA, 'A', geom, envUIRef, activeRef, displayModeRef, effShowDiffRef, slotB.viewRef, swipeDiffPosRef);
     useCompareRenderEffect(slotB, 'B', geom, envUIRef, activeRef, displayModeRef, effShowDiffRef, slotA.viewRef, swipeDiffPosRef);
+
+    // Curated-preset pick per slot (mirrors viewer-app.jsx's presetPick),
+    // plus a busy flag covering the fetch phase only: ingest()/loadDocument
+    // own slot.busy from there, same split as loadLocalIntoSlot below.
+    const [presetPick, setPresetPick] = React.useState({ A: '', B: '' });
+    const [presetBusy, setPresetBusy] = React.useState({ A: false, B: false });
+
+    // Fetches a curated example (js/shared/mtlx-ui.jsx's fetchPresetFiles)
+    // and hands it to the slot like a drag-drop, same recipe as
+    // viewer-app.jsx's loadPreset.
+    const loadPresetIntoSlot = async (slot, slotKey, preset) => {
+        setPresetBusy((s) => ({ ...s, [slotKey]: true }));
+        slot.setError(null);
+        slot.setBusy(true);
+        slot.setStatus('Fetching ' + preset.label + '...');
+        try {
+            const { map, rootKey } = await fetchPresetFiles(preset);
+            slot.setStatus(null);
+            await slot.ingest(map, rootKey); // ingest reaches loadDocument, which owns busy from there
+            setPresetPick((s) => ({ ...s, [slotKey]: preset.path }));
+        } catch (e) {
+            slot.setStatus(null);
+            slot.setBusy(false);
+            slot.setError('Could not load preset: ' + errMsg(e));
+        } finally {
+            setPresetBusy((s) => ({ ...s, [slotKey]: false }));
+        }
+    };
+
+    // Fetches a repo-local .mtlx (not a curated preset, no manifest crawl)
+    // and hands it to the slot the same way a single-file drop would.
+    const loadLocalIntoSlot = async (slot, url) => {
+        slot.setError(null);
+        slot.setBusy(true);
+        slot.setStatus('Fetching example...');
+        try {
+            const res = await fetch(url);
+            if (!res.ok) throw new Error('HTTP ' + res.status);
+            const blob = await res.blob();
+            const name = url.split('/').pop();
+            slot.setStatus(null);
+            await slot.ingest({ [name]: blob }, name);
+        } catch (e) {
+            slot.setStatus(null);
+            slot.setBusy(false);
+            slot.setError('Could not load the example: ' + errMsg(e));
+        }
+    };
+
+    // Empty-stage "Load an example pair" button: Document A gets the
+    // curated carpaint preset, Document B gets the repo-local translation
+    // doc. Fired concurrently, not awaited here, so each slot's own
+    // busy/error state tracks its own fetch independently.
+    const loadExamplePair = () => {
+        const preset = window.MTLX_PRESETS && window.MTLX_PRESETS.find((p) => p.path === EXAMPLE_PAIR_A_PATH);
+        if (preset) loadPresetIntoSlot(slotA, 'A', preset);
+        loadLocalIntoSlot(slotB, EXAMPLE_PAIR_B_URL);
+    };
+
     useCameraSync(() => [slotA.viewRef.current, slotB.viewRef.current], slotA.viewEpoch + slotB.viewEpoch);
     const [isFullscreen, toggleFullscreen] = useFullscreen(stageContentRef);
 
@@ -578,14 +651,24 @@ function MaterialCompareApp({ active = true } = {}) {
             const env = await loadEnvironmentFromFile(file);
             // Broadcasts to both live views via the engine's LIVE_VIEWS registry.
             setEnvOverride(env);
+            setEnvFileName(file.name);
             statsDirtyRef.current = true; diffDirtyRef.current = true;
         } catch (e) {
             setEnvImportError(errMsg(e));
         }
     };
+    // Clears an imported environment back to the default WITHOUT touching
+    // rotation/exposure: that stays the Reset button's job.
+    const clearEnvOverride = () => {
+        setEnvOverride(null);
+        setEnvImportError(null);
+        setEnvFileName('');
+        statsDirtyRef.current = true; diffDirtyRef.current = true;
+    };
     const resetEnv = () => {
         setEnvOverride(null);
         setEnvImportError(null);
+        setEnvFileName('');
         setEnvUI({ rotation: 0, exposure: 1, bg: true });
         [slotA.viewRef.current, slotB.viewRef.current].forEach((v) => {
             if (!v) return;
@@ -800,11 +883,7 @@ function MaterialCompareApp({ active = true } = {}) {
 
     // 28px HUD chip classes for the stage's ViewportControls (camera reset,
     // fullscreen), matching viewer-app.jsx's own hudChipClass.
-    const hudChipClass = (active) => `h-7 w-7 inline-flex items-center justify-center rounded border transition-colors ${
-        active
-            ? 'bg-blue-600/80 border-blue-500 text-white'
-            : 'bg-gray-800/80 border-gray-600 text-gray-300 hover:bg-gray-700/80'
-    }`;
+    const hudChipClass = (active) => active ? HUD_PILL_ACTIVE : HUD_PILL;
 
     const docName = (slot, fallback) => {
         if (slot.renderables.length) {
@@ -952,14 +1031,23 @@ function MaterialCompareApp({ active = true } = {}) {
                         />
                     </div>
                 </div>
-                <div className="flex items-center gap-2 flex-wrap">
-                    <label className={BTN_SECONDARY + ' cursor-pointer'}>
-                        Choose files
-                        <input type="file" multiple className="hidden" onChange={slot.onPickFiles} />
-                    </label>
-                    <label className={BTN_SECONDARY + ' cursor-pointer'}>
-                        Choose folder
-                        <input type="file" webkitdirectory="" directory="" multiple className="hidden" onChange={slot.onPickFiles} />
+                <div className="flex items-center gap-1">
+                    <div className="flex-1 min-w-0">
+                        <FilePickerField
+                            value={slot.chosenMtlx ? docBasename : ''}
+                            placeholder="No document loaded"
+                            multiple
+                            icon="files"
+                            accept=".mtlx,.zip,.png,.jpg,.jpeg,.webp,.gif,.bmp,.tga,.exr,.hdr,.tif,.tiff"
+                            onFiles={(files) => { setPresetPick((s) => ({ ...s, [slotKey]: '' })); slot.onPickFileList(files); }}
+                        />
+                    </div>
+                    <label
+                        title="Choose a folder"
+                        className="h-[26px] w-[26px] shrink-0 inline-flex items-center justify-center border border-gray-700 rounded-md bg-gray-800 hover:bg-gray-700 text-gray-300 cursor-pointer"
+                    >
+                        <MtlxIcon name="folder" className="w-3.5 h-3.5" />
+                        <input type="file" webkitdirectory="" directory="" multiple className="hidden" onChange={(e) => { setPresetPick((s) => ({ ...s, [slotKey]: '' })); slot.onPickFiles(e); }} />
                     </label>
                 </div>
                 <div className="text-xs text-gray-500">{dropHint}</div>
@@ -973,6 +1061,26 @@ function MaterialCompareApp({ active = true } = {}) {
                         variant="field"
                         block
                     />
+                )}
+                {window.MTLX_PRESETS && window.MTLX_PRESETS_BASE && (
+                    <div>
+                        <FieldLabel label="Or pick a curated example" />
+                        <MtlxSelect
+                            value={presetPick[slotKey]}
+                            options={window.MTLX_PRESETS.map((p) => ({ value: p.path, label: p.label }))}
+                            placeholder="Choose a curated example"
+                            disabled={presetBusy[slotKey] || slot.busy}
+                            onChange={(path) => {
+                                setPresetPick((s) => ({ ...s, [slotKey]: path }));
+                                if (!path) return;
+                                const preset = window.MTLX_PRESETS.find((p) => p.path === path);
+                                if (preset) loadPresetIntoSlot(slot, slotKey, preset);
+                            }}
+                            size="lg"
+                            variant="field"
+                            block
+                        />
+                    </div>
                 )}
                 {slot.renderables.length > 1 && (
                     <MtlxSelect
@@ -1053,7 +1161,7 @@ function MaterialCompareApp({ active = true } = {}) {
                             <span className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[11px] bg-black/60 text-white/90">
                                 <SlotDot color={SLOT_COLORS.A} />
                                 {docName(slotA, 'Document A')}
-                                {versionsDiffer && <span className="ml-1.5 text-white/50">{versionTag(slotA.renderedVersion)}</span>}
+                                {versionsDiffer && <span className="ml-1.5 font-mono text-white/50">{versionTag(slotA.renderedVersion)}</span>}
                             </span>
                         </div>
                     )}
@@ -1066,11 +1174,25 @@ function MaterialCompareApp({ active = true } = {}) {
                             <span className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[11px] bg-black/60 text-white/90">
                                 <SlotDot color={SLOT_COLORS.B} />
                                 {docName(slotB, 'Document B')}
-                                {versionsDiffer && <span className="ml-1.5 text-white/50">{versionTag(slotB.renderedVersion)}</span>}
+                                {versionsDiffer && <span className="ml-1.5 font-mono text-white/50">{versionTag(slotB.renderedVersion)}</span>}
                             </span>
                         </div>
                     )}
                 </div>
+
+                {!slotA.chosenMtlx && !slotB.chosenMtlx && !slotA.busy && !slotB.busy && (
+                    <div className="absolute inset-x-0 z-20 flex justify-center" style={{ top: 'calc(50% + 2.5rem)' }}>
+                        <button
+                            type="button"
+                            onClick={loadExamplePair}
+                            title="Carpaint (Standard Surface) vs the same values translated to OpenPBR"
+                            className={PILL_ACTION + ' pointer-events-auto'}
+                        >
+                            <MtlxIcon name="sparkles" className="w-3.5 h-3.5" />
+                            Load an example pair
+                        </button>
+                    </div>
+                )}
 
                 {displayMode === 'side' && (
                     effShowDiff ? (
@@ -1169,7 +1291,7 @@ function MaterialCompareApp({ active = true } = {}) {
                     envAvail={false}
                     showScreenshot={false}
                     showSettings={false}
-                    showLabels={false}
+                    showLabels={true}
                     onCameraReset={resetCompareCameras}
                     isFullscreen={isFullscreen}
                     onToggleFullscreen={toggleFullscreen}
@@ -1177,7 +1299,9 @@ function MaterialCompareApp({ active = true } = {}) {
                     buttonClassName={hudChipClass}
                 />
                 <div className="absolute bottom-2 left-2 z-20 pointer-events-none flex items-center gap-2 px-2 py-1 rounded-full bg-black/60 text-[11px] text-white/90">
-                    <span>{modeLabel + ' | ' + (GEOM_LABELS[geom] || geom)}</span>
+                    <span>{modeLabel}</span>
+                    <span className="text-white/40">/</span>
+                    <span>{GEOM_LABELS[geom] || geom}</span>
                 </div>
               </div>
             </div>
@@ -1194,17 +1318,17 @@ function MaterialCompareApp({ active = true } = {}) {
                         ><MtlxIcon name="chevrons-left" className="w-4 h-4" /></button>
                     </div>
                     <div className="flex-1 overflow-y-auto custom-scrollbar p-3.5 space-y-4">
-                        {renderSlotSection(slotA, 'A', 'Document A', 'or drop on the left half')}
-                        {renderSlotSection(slotB, 'B', 'Document B', 'or drop on the right half')}
+                        {renderSlotSection(slotA, 'A', 'Document A', 'or drag-and-drop on the left half')}
+                        {renderSlotSection(slotB, 'B', 'Document B', 'or drag-and-drop on the right half')}
 
                         <SectionCard icon="layout-columns" title="Display" summary={modeLabel} defaultOpen>
-                            <div className="flex rounded border border-gray-600 overflow-hidden text-[11px]">
+                            <div className="flex rounded-lg border border-gray-700 overflow-hidden text-[11px]">
                                 {[['side', 'Side by side'], ['slider', 'Swipe'], ['diff', 'Difference']].map(([id, label]) => (
                                     <button
                                         key={id}
                                         onClick={() => setDisplayMode(id)}
                                         className={'flex-1 px-2 py-1.5 transition-colors ' + (displayMode === id
-                                            ? 'bg-blue-600/80 text-white'
+                                            ? 'bg-blue-500/[0.12] text-blue-300'
                                             : 'bg-gray-800/80 text-gray-300 hover:bg-gray-700/80')}
                                     >
                                         {label}
@@ -1230,9 +1354,9 @@ function MaterialCompareApp({ active = true } = {}) {
                                     onClick={switchViews}
                                     disabled={switchViewsDisabled}
                                     title={switchViewsDisabled ? undefined : switchViewsTitle}
-                                    className={'flex-none inline-flex items-center gap-1 h-6 px-2 rounded border text-[11px] transition-colors ' + (switchViewsDisabled
-                                        ? 'bg-gray-800/50 border-gray-700 text-gray-600 cursor-not-allowed pointer-events-none'
-                                        : 'bg-gray-800/80 border-gray-600 text-gray-300 hover:bg-gray-700/80 cursor-pointer')}
+                                    className={'flex-none inline-flex items-center gap-1 ' + (switchViewsDisabled
+                                        ? 'h-7 px-2.5 rounded-md border text-[11px] transition-colors bg-gray-800/50 border-gray-700 text-gray-600 cursor-not-allowed pointer-events-none'
+                                        : BTN_SECONDARY + ' cursor-pointer')}
                                 >
                                     <MtlxIcon name="switch-horizontal" className="w-3.5 h-3.5" />
                                     Switch Views
@@ -1272,51 +1396,65 @@ function MaterialCompareApp({ active = true } = {}) {
                                 <span className="text-xs font-medium text-gray-400">Show environment as background</span>
                                 <Toggle checked={envUI.bg} onChange={setEnvBg} />
                             </label>
-                            <div className="flex items-center gap-2">
-                                <button
-                                    onClick={() => envFileInputRef.current && envFileInputRef.current.click()}
-                                    className={BTN_SECONDARY + ' flex-1'}
-                                >
-                                    {'Import .hdr / .exr'}
-                                </button>
-                                <button
-                                    onClick={resetEnv}
-                                    title="Also clears an imported .hdr/.exr and restores the default environment"
-                                    className={BTN_SECONDARY + ' flex-1'}
-                                >
-                                    Reset
-                                </button>
-                                <input
-                                    ref={envFileInputRef}
-                                    type="file"
-                                    accept=".hdr,.exr"
-                                    className="hidden"
-                                    onChange={(e) => {
-                                        const f = e.target.files && e.target.files[0];
-                                        e.target.value = '';
-                                        if (f) importEnv(f);
+                            <FilePickerField
+                                value={envFileName}
+                                placeholder="Default environment"
+                                accept=".hdr,.exr"
+                                icon="file"
+                                onFiles={(files) => {
+                                    const f = files && files[0];
+                                    if (f) importEnv(f);
+                                }}
+                                onClear={clearEnvOverride}
+                            />
+                            {envImportError && <div className="text-xs text-red-400">{envImportError}</div>}
+                            <button
+                                onClick={resetEnv}
+                                title="Also clears an imported .hdr/.exr and restores the default environment"
+                                className={BTN_SECONDARY + ' w-full'}
+                            >
+                                Reset
+                            </button>
+                        </SectionCard>
+
+                        <SectionCard icon="settings-cog" title="Rendering" summary={forceTransparency ? 'Transparency forced' : 'Default'} defaultOpen>
+                            <label
+                                className="flex items-center justify-between cursor-pointer"
+                                title={forceTransparency ? 'Disable forced transparency' : 'Enable forced transparency'}
+                            >
+                                <span className="inline-flex items-center gap-1.5 text-xs font-medium text-gray-400">
+                                    Force Transparency
+                                    <span className="text-[9px] uppercase tracking-wide px-1 py-0.5 rounded bg-amber-600/30 border border-amber-500/50 text-amber-300">Experimental</span>
+                                </span>
+                                <Toggle
+                                    checked={forceTransparency}
+                                    onChange={(next) => {
+                                        setForceTransparency(next);
+                                        window.setForceTransparency && window.setForceTransparency(next);
                                     }}
                                 />
+                            </label>
+                            <div className="mt-1 text-[11px] text-gray-400">
+                                Render opacity/transmission with real alpha blending in previews. When off, previews match the standard MaterialX viewer (opaque). Applies immediately to open previews.
                             </div>
-                            {envImportError && <div className="text-xs text-red-400">{envImportError}</div>}
                         </SectionCard>
 
                         <SectionCard
                             icon="compare"
                             title="Statistics"
-                            pill={bothLive ? <span className="shrink-0 text-[10px] text-gray-500">live</span> : null}
+                            pill={bothLive ? <span className="shrink-0 text-[10px] font-semibold uppercase tracking-[0.08em] text-gray-500">live</span> : null}
                             summary={stats ? stats.metrics.ssim.toFixed(3) : '—'}
                             defaultOpen
                         >
                             <div className="space-y-1 text-[11px] text-gray-300">
-                                <div className="flex justify-between"><span>SSIM</span><span className="font-mono">{stats ? stats.metrics.ssim.toFixed(3) : '—'}</span></div>
-                                <div className="flex justify-between"><span>RMSE</span><span className="font-mono">{stats ? stats.metrics.rmse.toFixed(2) : '—'}</span></div>
+                                <div className="flex justify-between"><span>SSIM</span><span className="font-mono tabular-nums">{stats ? stats.metrics.ssim.toFixed(3) : '—'}</span></div>
+                                <div className="flex justify-between"><span>RMSE</span><span className="font-mono tabular-nums">{stats ? stats.metrics.rmse.toFixed(2) : '—'}</span></div>
                                 <div className="flex justify-between">
                                     <span>PSNR</span>
-                                    <span className="font-mono">{stats ? (stats.metrics.psnr === Infinity ? '∞ dB' : stats.metrics.psnr.toFixed(1) + ' dB') : '—'}</span>
+                                    <span className="font-mono tabular-nums">{stats ? (stats.metrics.psnr === Infinity ? '∞ dB' : stats.metrics.psnr.toFixed(1) + ' dB') : '—'}</span>
                                 </div>
-                                <div className="flex justify-between"><span>Mean abs diff</span><span className="font-mono">{stats ? stats.metrics.meanAbsDiff.toFixed(2) : '—'}</span></div>
-                                {stats && <div className="text-gray-500 text-[10px] pt-1">{'computed at ' + stats.size[0] + '×' + stats.size[1]}</div>}
+                                <div className="flex justify-between"><span>Mean abs diff</span><span className="font-mono tabular-nums">{stats ? stats.metrics.meanAbsDiff.toFixed(2) : '—'}</span></div>
+                                {stats && <div className="text-[10px] font-semibold uppercase tracking-[0.08em] text-gray-500 pt-1">{'computed at ' + stats.size[0] + '×' + stats.size[1]}</div>}
                             </div>
                             <div className="space-y-1.5 text-xs text-gray-500">
                                 <div>
@@ -1339,7 +1477,7 @@ function MaterialCompareApp({ active = true } = {}) {
                 <button
                     onClick={() => setSidebarOpen(true)}
                     title="Expand the panel"
-                    className="absolute top-2 left-2 z-30 h-7 inline-flex items-center gap-1.5 text-[11px] px-2 rounded border bg-gray-800/80 backdrop-blur border-gray-600 text-gray-300 hover:bg-gray-700/80 transition-colors"
+                    className={'absolute top-2 left-2 z-30 ' + HUD_PILL}
                 >
                     <MtlxIcon name="chevrons-right" className="w-4 h-4" />
                     <span className="max-w-[6rem] truncate">Compare</span>

--- a/js/docs-app.jsx
+++ b/js/docs-app.jsx
@@ -610,12 +610,12 @@
                 <div className="relative space-y-4 sm:space-y-6 md:flex-1 md:min-h-0 md:flex md:flex-col">
                     {/* Data source status: visible only while loading or on failure */}
                     {autoLoad === 'loading' && (
-                        <div className="bg-gray-800 p-4 rounded-lg shadow border border-gray-700 text-sm text-gray-400">
+                        <div className="bg-gray-800 p-4 rounded-xl border border-gray-800 text-sm text-gray-400">
                             Loading the node library…
                         </div>
                     )}
                     {autoLoad === 'failed' && (
-                        <div className="bg-gray-800 p-4 rounded-lg shadow border border-amber-700/60 text-sm text-gray-300">
+                        <div className="bg-gray-800 p-4 rounded-xl border border-amber-700/60 text-sm text-gray-300">
                             Could not load the pregenerated node library data
                             (js/gen/nodelib.json, js/gen/nodelib-index.json). Reload the
                             page, or if you're building from source, run
@@ -700,31 +700,31 @@
                                    overflow-y-auto would reserve a second gutter. ?embed=1
                                    keeps the shell's page padding, so it keeps the card. */
                                 + (inline ? ''
-                                    : ' rounded-lg shadow border border-gray-700 md:min-h-0 md:overflow-y-auto custom-scrollbar'
-                                    /* Collapsed (md+) docs pane loses its card chrome — rounded
-                                       corners, border, shadow — so it reads as edge-to-edge
-                                       content against the now-flush (md:-m-6) shell background. */
-                                    + (!chromeless && sidebarCollapsed ? ' md:rounded-none md:border-0 md:shadow-none' : ''))}>
+                                    : ' rounded-xl border border-gray-800 md:min-h-0 md:overflow-y-auto custom-scrollbar'
+                                    /* Collapsed (md+) docs pane loses its card chrome, rounded
+                                       corners and border, so it reads as edge-to-edge content
+                                       against the now-flush (md:-m-6) shell background. */
+                                    + (!chromeless && sidebarCollapsed ? ' md:rounded-none md:border-0' : ''))}>
                                 {selectedNode ? (
                                     <div>
                                         <div className="mb-4">
-                                            <h2 className="text-xl sm:text-3xl font-bold text-white font-mono break-words min-w-0">{selectedNode.name}</h2>
+                                            <div className="inline-flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.08em] text-blue-300 mb-1">
+                                                {selectedNode.lib}<span className="text-gray-600">/</span><span className="text-gray-400">{selectedNode.group}</span>
+                                            </div>
+                                            <h2 className="text-xl sm:text-3xl font-bold text-white font-mono tracking-[-0.01em] break-words min-w-0">{selectedNode.name}</h2>
                                             <div className="flex items-center gap-2 flex-wrap mt-2">
-                                                <span className="bg-gray-700 text-gray-300 text-xs px-2 py-1 rounded border border-gray-600">
-                                                    {selectedNode.lib} / {selectedNode.group}
-                                                </span>
                                                 {selectedNode.info.section && (
-                                                    <span className="bg-gray-700 text-gray-400 text-xs px-2 py-1 rounded border border-gray-600">
+                                                    <span className="inline-flex items-center h-6 px-2 rounded-md border border-gray-700 bg-gray-800/60 text-[11px] font-medium text-gray-400">
                                                         spec: {selectedNode.info.section}
                                                     </span>
                                                 )}
                                                 {isUndocumented(selectedNode.info) ? (
-                                                    // No spec entry exists — a link would
-                                                    // land nowhere useful, so show it
-                                                    // disabled instead.
+                                                    // No spec entry exists, so a link would
+                                                    // land nowhere useful; show it disabled
+                                                    // instead.
                                                     <span
                                                         title="This node has no entry in the official specification documents"
-                                                        className="inline-flex items-center gap-1 bg-gray-800 text-gray-600 text-xs px-2 py-1 rounded border border-gray-700 cursor-not-allowed select-none"
+                                                        className="inline-flex items-center gap-1 h-6 px-2 rounded-md border border-gray-700 bg-gray-800/50 text-[11px] font-medium text-gray-600 cursor-not-allowed select-none"
                                                     >
                                                         Official spec <MtlxIcon name="external-link" className="w-3.5 h-3.5" />
                                                     </span>
@@ -733,7 +733,7 @@
                                                         href={specUrlForNode(selectedNode)}
                                                         target="_blank" rel="noopener noreferrer"
                                                         title="Open this node in the official MaterialX specification on GitHub"
-                                                        className="inline-flex items-center gap-1 bg-gray-700 text-blue-300 hover:text-blue-200 text-xs px-2 py-1 rounded border border-gray-600 hover:border-blue-500/60 transition-colors"
+                                                        className="inline-flex items-center gap-1 h-6 px-2 rounded-md border border-gray-600/50 bg-gray-900/70 text-[11px] font-medium text-blue-300 hover:text-blue-200 hover:border-blue-500/60 transition-colors"
                                                     >
                                                         Official spec <MtlxIcon name="external-link" className="w-3.5 h-3.5" />
                                                     </a>
@@ -745,20 +745,20 @@
                                                 <button
                                                     onClick={copyPermalink}
                                                     title="Copy a direct link to this node"
-                                                    className={`text-xs px-2 py-1 rounded border transition-colors flex items-center gap-1 ${
+                                                    className={'inline-flex items-center gap-1 h-6 px-2 rounded-md border text-[11px] font-medium transition-colors ' + (
                                                         copied
                                                             ? 'bg-green-700/30 border-green-600/60 text-green-300'
-                                                            : 'bg-gray-700 border-gray-600 text-gray-300 hover:text-white hover:border-blue-500/60'
-                                                    }`}
+                                                            : 'border-gray-600/50 bg-gray-900/70 text-gray-400 hover:bg-gray-700 hover:border-gray-600 hover:text-gray-100'
+                                                    )}
                                                 >
                                                     {copied ? (
                                                         <React.Fragment>
-                                                            <svg viewBox="0 0 20 20" className="w-3.5 h-3.5" fill="currentColor" aria-hidden="true"><path fillRule="evenodd" d="M16.7 5.3a1 1 0 010 1.4l-7.5 7.5a1 1 0 01-1.4 0L3.3 9.7a1 1 0 011.4-1.4l3.3 3.29 6.8-6.79a1 1 0 011.4 0z" clipRule="evenodd"/></svg>
+                                                            <MtlxIcon name="copy-check" className="w-3.5 h-3.5" />
                                                             Copied
                                                         </React.Fragment>
                                                     ) : (
                                                         <React.Fragment>
-                                                            <svg viewBox="0 0 20 20" className="w-3.5 h-3.5" fill="currentColor" aria-hidden="true"><path d="M8.5 3A3.5 3.5 0 005 6.5v1a1 1 0 002 0v-1A1.5 1.5 0 018.5 5h5A1.5 1.5 0 0115 6.5v5A1.5 1.5 0 0113.5 13h-1a1 1 0 000 2h1a3.5 3.5 0 003.5-3.5v-5A3.5 3.5 0 0013.5 3h-5z"/><path d="M6.5 7A3.5 3.5 0 003 10.5v5A3.5 3.5 0 006.5 19h5a3.5 3.5 0 003.5-3.5v-1a1 1 0 00-2 0v1a1.5 1.5 0 01-1.5 1.5h-5A1.5 1.5 0 015 15.5v-5A1.5 1.5 0 016.5 9h1a1 1 0 000-2h-1z"/></svg>
+                                                            <MtlxIcon name="copy" className="w-3.5 h-3.5" />
                                                             Copy link
                                                         </React.Fragment>
                                                     )}
@@ -779,7 +779,7 @@
                                                     <div className="ml-auto flex items-center gap-2 flex-wrap justify-end">
                                                         {sigCount > 1 && (
                                                             <React.Fragment>
-                                                                <label className="text-xs font-semibold text-gray-400 uppercase tracking-wider">
+                                                                <label className="text-[10px] font-semibold uppercase tracking-[0.08em] text-gray-500">
                                                                     Signature
                                                                 </label>
                                                                 <MtlxSelect
@@ -800,7 +800,7 @@
                                                         )}
                                                         {showVersionPicker && (
                                                             <React.Fragment>
-                                                                <label className="text-xs font-semibold text-gray-400 uppercase tracking-wider">
+                                                                <label className="text-[10px] font-semibold uppercase tracking-[0.08em] text-gray-500">
                                                                     Version
                                                                 </label>
                                                                 <MtlxSelect
@@ -854,37 +854,42 @@
                                             allTargets={genData ? genData.allTargets : []}
                                         />
 
-                                        {/* Description: paragraphs before the first table */}
-                                        <RichBlocks
-                                            text={selectedNode.info.description}
-                                            refs={refs}
-                                            className="text-gray-300 leading-relaxed mb-8 text-base sm:text-lg"
-                                        />
+                                        {/* Description: paragraphs before the first table, or a
+                                            styled placeholder when the spec has no entry at all. */}
+                                        {isUndocumented(selectedNode.info) ? (
+                                            <div className="flex items-start gap-3 mt-4 mb-4">
+                                                <div className="w-9 h-9 rounded-[9px] bg-blue-500/10 border border-blue-500/25 flex items-center justify-center text-blue-400 shrink-0">
+                                                    <MtlxIcon name="info-circle" className="w-[18px] h-[18px]" />
+                                                </div>
+                                                <div className="min-w-0 text-sm leading-5 text-gray-400 pt-0.5">
+                                                    <div className="text-gray-200 font-medium">No specification entry for this node.</div>
+                                                    <div className="mt-0.5">Ports, types and defaults below are read from its MaterialX nodedef; descriptions are unavailable.</div>
+                                                </div>
+                                            </div>
+                                        ) : (
+                                            <RichBlocks
+                                                text={selectedNode.info.description}
+                                                refs={refs}
+                                                className="text-gray-300 leading-relaxed mb-8 text-base sm:text-lg"
+                                            />
+                                        )}
 
-                                        {/* Port tables: from the spec, or — for
-                                            undocumented nodes — synthesized from
-                                            the MaterialX nodedef with a disclaimer. */}
+                                        {/* Port tables: from the spec, or, for undocumented
+                                            nodes, synthesized from the MaterialX nodedef with
+                                            a disclaimer (suppressed above when already shown). */}
                                         {effectiveTables.length > 0 ? (
                                             <div className="space-y-6">
-                                                {isAutoTable && (
-                                                    <div className="bg-blue-950/40 border border-blue-800/60 text-blue-200/90 text-sm rounded-lg px-4 py-3 flex items-start gap-2">
-                                                        <MtlxIcon name="info-circle" className="w-4 h-4 shrink-0 mt-0.5" />
-                                                        <span>
-                                                            <span className="font-semibold text-blue-200">Auto-generated from the nodedef.</span>{' '}
-                                                            This node has no specification documentation, so its ports,
-                                                            types, and defaults were read directly from the MaterialX
-                                                            node definition. Descriptions are unavailable and the
-                                                            details may differ from an official write-up.
-                                                        </span>
-                                                    </div>
-                                                )}
+                                                {isAutoTable && !isUndocumented(selectedNode.info) && <AutoDocNotice />}
                                                 {displayTables.map((table, i) => (
                                                     <PortTable key={sigCount > 1 ? (sig + ':' + i) : i} table={table} columns={columns} refs={refs}
                                                         defaultsOverride={defaultsOverride} typesOverride={typesOverride} />
                                                 ))}
                                             </div>
                                         ) : (
-                                            <NodeDefPortsTable rows={(genData && selectedNode && genData.nodes[selectedNode.name] && genData.nodes[selectedNode.name].defPorts) || []} />
+                                            <NodeDefPortsTable
+                                                rows={(genData && selectedNode && genData.nodes[selectedNode.name] && genData.nodes[selectedNode.name].defPorts) || []}
+                                                showNotice={!isUndocumented(selectedNode.info)}
+                                            />
                                         )}
 
                                         {/* Notes: prose after/between tables (sub-headings, equations, ...) */}
@@ -899,7 +904,7 @@
                                         {/* References: footnotes cited by this node */}
                                         {references.length > 0 && (
                                             <div className="mt-8 pt-6 border-t border-gray-700">
-                                                <h4 className="text-sm font-semibold text-gray-400 uppercase tracking-wider mb-3">References</h4>
+                                                <h4 className="text-[10px] font-semibold uppercase tracking-[0.08em] text-gray-500 mb-3">References</h4>
                                                 <ol className="space-y-2 text-sm text-gray-400">
                                                     {references.map((r, i) => (
                                                         <li key={r.key} className="flex gap-2">
@@ -920,8 +925,11 @@
                                         )}
                                     </div>
                                 ) : (
-                                    <div className="text-gray-500 flex items-center justify-center h-full">
-                                        Select a node from the tree to view its details.
+                                    <div className="flex flex-col items-center justify-center gap-3 h-full">
+                                        <div className="w-9 h-9 rounded-[9px] bg-blue-500/10 border border-blue-500/25 flex items-center justify-center text-blue-400">
+                                            <MtlxIcon name="file-code" className="w-[18px] h-[18px]" />
+                                        </div>
+                                        <div className="text-sm text-gray-500">Select a node from the tree to view its details.</div>
                                     </div>
                                 )}
                             </div>

--- a/js/docs/impl-matrix.jsx
+++ b/js/docs/impl-matrix.jsx
@@ -48,12 +48,12 @@
             }
 
             const targets = allTargets || [];
-            const badgeBase = 'px-2 py-0.5 rounded border font-mono text-[11px]';
+            const badgeBase = 'px-2 py-0.5 rounded-md border font-mono text-[11px]';
 
             return (
                 <div className="mt-3 mb-2 text-xs">
                     <div className="flex items-start gap-2 flex-wrap">
-                        <span className="text-gray-500 uppercase tracking-wider font-semibold pt-0.5">
+                        <span className="text-[10px] font-semibold uppercase tracking-[0.08em] text-gray-500 pt-0.5">
                             Implementations:
                         </span>
                         <div className="flex flex-col gap-1.5">

--- a/js/docs/port-tables.jsx
+++ b/js/docs/port-tables.jsx
@@ -52,10 +52,34 @@
         const DESCRIPTION_MIN_REM = 8;
         const EXTRA_COL_REM = 8;
         const CELL_STYLES = {
-            port: 'font-medium text-blue-400 font-mono whitespace-nowrap',
-            type: 'font-mono text-xs text-purple-400 break-words',
-            default: 'font-mono text-xs text-yellow-300 break-words',
-            accepted_values: 'font-mono text-xs text-green-400 break-words',
+            port: 'font-medium text-gray-100 font-mono whitespace-nowrap',
+            type: 'font-mono text-xs text-gray-200 break-words',
+            default: 'font-mono text-xs text-gray-300 break-words',
+            accepted_values: 'font-mono text-xs text-gray-400 break-words',
+        };
+
+        // Type column dot: an exact TYPE_COLORS key gets the legend's own
+        // dot + neutral label; family tokens (colorN) or prose ("Same as
+        // ...") fall back to an italic neutral label with no dot.
+        const TypeCell = ({ text }) => {
+            if (!text) return null;
+            const tokens = String(text).split(',').map(t => t.trim()).filter(Boolean);
+            return tokens.map((tok, i) => (
+                <React.Fragment key={tok + i}>
+                    {i > 0 ? ', ' : ''}
+                    {Object.prototype.hasOwnProperty.call(TYPE_COLORS, tok)
+                        ? (
+                            <span className="whitespace-nowrap">
+                                <span
+                                    className="inline-block w-2 h-2 rounded-full mr-1.5 align-middle"
+                                    style={{ background: typeColor(tok) }}
+                                />
+                                {tok}
+                            </span>
+                        )
+                        : <span className="italic text-gray-400">{tok}</span>}
+                </React.Fragment>
+            ));
         };
 
         const unionColumns = (tables) => {
@@ -192,7 +216,7 @@
                 0
             );
             return (
-                <div className="overflow-x-auto rounded-lg border border-gray-700">
+                <div className="overflow-x-auto rounded-xl border border-gray-700">
                     <table
                         style={{ '--tbl-min': `${minRem}rem` }}
                         className="port-table w-full table-auto text-sm text-left text-gray-300"
@@ -202,16 +226,16 @@
                                 <col key={col} className={COL_WIDTHS[col] || ''} />
                             ))}
                         </colgroup>
-                        <thead className="text-xs text-gray-400 uppercase bg-gray-900 border-b border-gray-700">
+                        <thead className="text-[10px] font-semibold uppercase tracking-[0.08em] text-gray-500 bg-gray-900 border-b border-gray-700">
                             <tr>
                                 {columns.map(col => (
-                                    <th key={col} scope="col" className={`px-4 py-3 ${col === 'port' ? 'whitespace-nowrap' : ''}`}>{headerLabel(col)}</th>
+                                    <th key={col} scope="col" className={`px-4 py-3 border-r border-gray-700/50 last:border-r-0 ${col === 'port' ? 'whitespace-nowrap' : ''}`}>{headerLabel(col)}</th>
                                 ))}
                             </tr>
                         </thead>
                         <tbody>
                             {Object.entries(table.ports).map(([portName, portData]) => (
-                                <tr className="border-b border-gray-700 last:border-b-0 hover:bg-gray-750" key={portName}>
+                                <tr className="border-b border-gray-700/50 last:border-b-0 hover:bg-gray-700/40" key={portName}>
                                     {columns.map(col => {
                                         const overridden = col === 'default' && defaultsOverride
                                             && Object.prototype.hasOwnProperty.call(defaultsOverride, portName);
@@ -221,9 +245,11 @@
                                             : typeOverridden ? typesOverride[portName]
                                             : (portData[col] || '');
                                         return (
-                                            <td key={col} className={`px-4 py-3 align-top ${CELL_STYLES[col] || ''}`}>
+                                            <td key={col} className={`px-4 py-3 align-top border-r border-gray-700/50 last:border-r-0 ${CELL_STYLES[col] || ''}`}>
                                                 {col === 'port'
                                                     ? portName
+                                                    : col === 'type'
+                                                    ? <TypeCell text={cellText} />
                                                     : <MathText text={cellText} refs={refs} />}
                                             </td>
                                         );
@@ -236,43 +262,52 @@
             );
         });
 
+        // Shared banner for auto-generated port data (spec-less nodes):
+        // used both here and by js/docs-app.jsx's isAutoTable case, so
+        // the two read as one consistent notice, not two similar ones.
+        function AutoDocNotice() {
+            return (
+                <div className="bg-blue-950/40 border border-blue-800/60 text-blue-200/90 text-sm rounded-xl px-4 py-3 flex items-start gap-2 mb-3">
+                    <MtlxIcon name="info-circle" className="w-4 h-4 shrink-0 mt-0.5" />
+                    <span><span className="font-semibold text-blue-200">Generated from the nodedef.</span> This node's ports, types and defaults were read directly from the MaterialX node definition, not from the specification documents.</span>
+                </div>
+            );
+        }
+
         // Rows: [{name, kind, types[], value, enums}], pregenerated
         // by scripts/lib/nodedef-extract.mjs from the union of every
-        // matching nodedef's ports — no live WASM read here.
-        const NodeDefPortsTable = ({ rows }) => {
+        // matching nodedef's ports, no live WASM read here.
+        const NodeDefPortsTable = ({ rows, showNotice = true }) => {
             rows = rows || [];
             if (!rows.length) {
                 return (
-                    <div className="bg-gray-900 border border-gray-700 rounded p-4 text-sm text-gray-500 italic">
+                    <div className="bg-gray-900 border border-gray-800 rounded-xl p-4 text-sm text-gray-500 italic">
                         No specific ports defined or extracted for this node.
                     </div>
                 );
             }
             return (
                 <div>
-                    <div className="inline-flex items-start gap-1 text-xs text-amber-400/80 bg-amber-950/30 border border-amber-800/40 rounded px-3 py-2 mb-3">
-                        <MtlxIcon name="alert-triangle" className="w-3.5 h-3.5 shrink-0 mt-0.5" />
-                        <span>This table was generated automatically from the node's nodedef in the standard library — it is not part of the official specification documents.</span>
-                    </div>
-                    <div className="overflow-x-auto bg-gray-900 border border-gray-700 rounded-lg">
+                    {showNotice && <AutoDocNotice />}
+                    <div className="overflow-x-auto bg-gray-900 border border-gray-700 rounded-xl">
                         <table className="w-full text-sm">
                             <thead>
-                                <tr className="text-left text-xs uppercase tracking-wider text-gray-400 border-b border-gray-700">
-                                    <th className="px-3 py-2">Port</th>
-                                    <th className="px-3 py-2">Kind</th>
-                                    <th className="px-3 py-2">Type(s)</th>
-                                    <th className="px-3 py-2">Default</th>
-                                    <th className="px-3 py-2">Accepted values</th>
+                                <tr className="text-[10px] font-semibold uppercase tracking-[0.08em] text-gray-500 bg-gray-900 border-b border-gray-700">
+                                    <th className="px-3 py-2 border-r border-gray-700/50 last:border-r-0">Port</th>
+                                    <th className="px-3 py-2 border-r border-gray-700/50 last:border-r-0">Kind</th>
+                                    <th className="px-3 py-2 border-r border-gray-700/50 last:border-r-0">Type(s)</th>
+                                    <th className="px-3 py-2 border-r border-gray-700/50 last:border-r-0">Default</th>
+                                    <th className="px-3 py-2 border-r border-gray-700/50 last:border-r-0">Accepted values</th>
                                 </tr>
                             </thead>
                             <tbody>
                                 {rows.map((r) => (
-                                    <tr key={r.kind + ':' + r.name} className="border-b border-gray-800 last:border-0 align-top">
-                                        <td className="px-3 py-2 font-mono text-blue-300">{r.name}</td>
-                                        <td className="px-3 py-2 text-gray-400">{r.kind}</td>
-                                        <td className="px-3 py-2 font-mono text-purple-300">{r.types.join(', ')}</td>
-                                        <td className="px-3 py-2 font-mono text-amber-300 break-all">{r.value}</td>
-                                        <td className="px-3 py-2 font-mono text-green-300 break-words">{r.enums}</td>
+                                    <tr key={r.kind + ':' + r.name} className="border-b border-gray-700/50 last:border-0 align-top">
+                                        <td className="px-3 py-2 font-mono text-gray-100 border-r border-gray-700/50 last:border-r-0">{r.name}</td>
+                                        <td className="px-3 py-2 text-gray-400 border-r border-gray-700/50 last:border-r-0">{r.kind}</td>
+                                        <td className="px-3 py-2 font-mono text-xs border-r border-gray-700/50 last:border-r-0"><TypeCell text={r.types.join(', ')} /></td>
+                                        <td className="px-3 py-2 font-mono text-gray-300 break-all border-r border-gray-700/50 last:border-r-0">{r.value}</td>
+                                        <td className="px-3 py-2 font-mono text-gray-400 break-words border-r border-gray-700/50 last:border-r-0">{r.enums}</td>
                                     </tr>
                                 ))}
                             </tbody>
@@ -288,5 +323,5 @@
         Object.assign(window, {
             getPortTables, isUndocumented,
             unionColumns, signaturePreviewType, pickTableForType, PortTable,
-            NodeDefPortsTable,
+            NodeDefPortsTable, AutoDocNotice,
         });

--- a/js/docs/sidebar.jsx
+++ b/js/docs/sidebar.jsx
@@ -25,13 +25,13 @@
                 // [scrollbar-gutter:stable]: this element is both the scroll
                 // container and (at md+) the min-content grid column; reserve
                 // the gutter so width stays constant as the scrollbar toggles.
-                <div className={(collapsed ? 'md:hidden ' : 'md:col-span-1 ') + 'bg-gray-800 rounded-lg shadow border border-gray-700 max-h-[45vh] md:max-h-none md:min-h-0 overflow-y-auto custom-scrollbar [scrollbar-gutter:stable]'}>
+                <div className={(collapsed ? 'md:hidden ' : 'md:col-span-1 ') + 'bg-gray-800 rounded-xl border border-gray-800 max-h-[45vh] md:max-h-none md:min-h-0 overflow-y-auto custom-scrollbar [scrollbar-gutter:stable]'}>
                     {/* Sticky header stays visible while the tree scrolls beneath it. The
                         scroll container is unpadded; the sticky block and tree wrapper
                         carry their own padding so the header sits flush at top with no overlap. */}
                     <div className="sticky top-0 z-10 bg-gray-800 px-4 pt-4 pb-1">
                         <div className="flex items-center justify-between mb-3 border-b border-gray-700 pb-2">
-                            <h3 className="text-sm font-semibold text-gray-400 uppercase tracking-wider">
+                            <h3 className="text-[11px] font-semibold uppercase tracking-[0.08em] text-gray-500">
                                 Node Library
                             </h3>
                             <div className="flex items-center gap-1">
@@ -39,7 +39,7 @@
                                     onClick={onShowHelp}
                                     title="How to use this page"
                                     aria-label="Help"
-                                    className="p-1 rounded text-gray-500 hover:text-gray-200 hover:bg-gray-700"
+                                    className="p-1 rounded-md text-gray-500 hover:text-gray-200 hover:bg-gray-700"
                                 >
                                     <MtlxIcon name="help" className="w-4 h-4" />
                                 </button>
@@ -47,7 +47,7 @@
                                     onClick={onCollapse}
                                     title="Collapse the node library panel"
                                     aria-label="Collapse the node library panel"
-                                    className="hidden md:block p-1 rounded text-gray-500 hover:text-gray-200 hover:bg-gray-700"
+                                    className="hidden md:block p-1 rounded-md text-gray-500 hover:text-gray-200 hover:bg-gray-700"
                                 >
                                     <MtlxIcon name="chevrons-left" className="w-4 h-4" />
                                 </button>
@@ -57,17 +57,17 @@
                             Documentation browser and live previews for the MaterialX node libraries.
                         </p>
                         {stats && (
-                            <div className="flex w-full text-xs mb-2">
-                                <span className="flex-1 min-w-0 px-2 py-0.5 rounded-l border border-r-0 border-gray-700 bg-gray-900 text-gray-300 text-center whitespace-nowrap">
-                                    <span className="font-semibold text-white">{stats.total}</span> nodes total
-                                </span>
-                                <span className={`flex-1 min-w-0 px-2 py-0.5 rounded-r border text-center whitespace-nowrap ${
-                                    stats.undoc > 0
-                                        ? 'border-amber-700/60 bg-amber-900/20 text-amber-400'
-                                        : 'border-gray-700 bg-gray-900 text-gray-500'
-                                }`}>
-                                    <span className="font-semibold">{stats.undoc}</span> without docs
-                                </span>
+                            <div className="grid grid-cols-2 gap-1.5 mb-2 text-center">
+                                <div className="rounded-lg border border-blue-500 bg-blue-500/[0.12] px-2 py-1.5 flex flex-col gap-0.5">
+                                    <span className="text-[10px] font-semibold uppercase tracking-[0.08em] text-blue-300">Nodes</span>
+                                    <span className="text-sm font-semibold text-blue-300">{stats.total}</span>
+                                </div>
+                                <div className="rounded-lg border border-amber-700/60 bg-amber-900/20 px-2 py-1.5 flex flex-col gap-0.5">
+                                    <span className="text-[10px] font-semibold uppercase tracking-[0.08em] text-amber-400">
+                                        Without docs
+                                    </span>
+                                    <span className="text-sm font-semibold text-amber-300">{stats.undoc}</span>
+                                </div>
                             </div>
                         )}
                         {/* Both controls are intrinsically sized (invisible-sizer technique,
@@ -83,7 +83,7 @@
                                     const active = docFilter === mode;
                                     const activeCls = mode === 'undocumented'
                                         ? 'bg-amber-900/20 text-amber-400 ring-1 ring-inset ring-amber-700/60'
-                                        : 'bg-blue-600 text-white';
+                                        : 'bg-blue-500/[0.12] text-blue-300 ring-1 ring-inset ring-blue-500/60';
                                     return (
                                         <button
                                             key={mode}
@@ -91,7 +91,7 @@
                                             title={label}
                                             aria-label={label}
                                             aria-pressed={active}
-                                            className={`p-1.5 flex items-center gap-1 transition-colors ${i > 0 ? `border-l ${active && mode === 'undocumented' ? 'border-amber-700/60' : 'border-gray-700'}` : ''} ${
+                                            className={`p-1.5 flex items-center gap-1 transition-colors first:rounded-l-[7px] last:rounded-r-[7px] ${i > 0 ? `border-l ${active && mode === 'undocumented' ? 'border-amber-700/60' : 'border-gray-700'}` : ''} ${
                                                 active
                                                     ? activeCls
                                                     : 'bg-gray-800 text-gray-400 hover:bg-gray-700 hover:text-gray-200'
@@ -120,7 +120,7 @@
                                     : '3D previews are off — click to enable the WebGL node previews'}
                                 className={`shrink-0 p-1.5 rounded-lg border flex items-center gap-1 transition-colors ${
                                     showPreviews
-                                        ? 'bg-blue-600/80 border-blue-500 text-white hover:bg-blue-500/80'
+                                        ? 'bg-blue-500/[0.12] border-blue-500 text-blue-300 hover:bg-blue-500/20'
                                         : 'bg-gray-800 border-amber-700/60 text-amber-400 hover:bg-gray-700'
                                 }`}
                             >
@@ -135,7 +135,7 @@
                                     value={searchQuery}
                                     onChange={(e) => setSearchQuery(e.target.value)}
                                     placeholder="Search nodes..."
-                                    className="w-full bg-gray-900 border border-gray-700 rounded px-3 py-1.5 pr-8 text-sm text-gray-200 placeholder-gray-500 focus:outline-none focus:border-blue-500"
+                                    className="w-full bg-gray-900 border border-gray-700 rounded-md px-3 py-1.5 pr-8 text-sm text-gray-200 placeholder-gray-500 focus:outline-none focus:border-blue-500"
                                 />
                                 {searchQuery && (
                                     <button
@@ -150,7 +150,7 @@
                             <button
                                 onClick={expandAll}
                                 title="Expand all"
-                                className="shrink-0 p-1 rounded text-gray-500 hover:text-gray-200 hover:bg-gray-700"
+                                className="shrink-0 p-1 rounded-md text-gray-500 hover:text-gray-200 hover:bg-gray-700"
                             >
                                 <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M7 5l5 5 5-5M7 14l5 5 5-5" />
@@ -159,7 +159,7 @@
                             <button
                                 onClick={collapseAll}
                                 title="Collapse all"
-                                className="shrink-0 p-1 rounded text-gray-500 hover:text-gray-200 hover:bg-gray-700"
+                                className="shrink-0 p-1 rounded-md text-gray-500 hover:text-gray-200 hover:bg-gray-700"
                             >
                                 <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M7 10l5-5 5 5M7 19l5-5 5 5" />
@@ -219,7 +219,7 @@
                                                                 // isUndocumented (and rebuilding port tables) per keystroke.
                                                                 const undoc = stats && stats.undocKeys.has(`${lib}-${group}-${nodeName}`);
                                                                 const rowCls = isSelected
-                                                                    ? (undoc ? 'bg-amber-600 text-white' : 'bg-blue-600 text-white')
+                                                                    ? 'bg-blue-600 text-white'
                                                                     : (undoc ? 'text-gray-400 hover:bg-amber-900/20 hover:text-amber-300' : 'text-gray-400 hover:bg-blue-900/20 hover:text-blue-300');
                                                                 return (
                                                                     <div
@@ -228,6 +228,7 @@
                                                                         className={`cursor-pointer py-1 px-2 rounded font-mono text-xs break-all ${rowCls}`}
                                                                     >
                                                                         {nodeName}
+                                                                        {undoc && <span className="inline-block w-1.5 h-1.5 rounded-full bg-amber-400/80 ml-1.5 align-middle" />}
                                                                     </div>
                                                                 )
                                                             })}

--- a/js/gen/build-id.json
+++ b/js/gen/build-id.json
@@ -1,3 +1,3 @@
 {
- "id": "ad471e6b4bbf56e8"
+ "id": "c2fe03ec25dbf3b3"
 }

--- a/js/graph-app.jsx
+++ b/js/graph-app.jsx
@@ -363,6 +363,15 @@
                     setScope(next);
                 })();
             };
+            // Steps up one scope level via changeScope; shared by Backspace,
+            // the breadcrumb root, the context menu, and the leave-nodegraph
+            // pill so the pending-selection dance stays in one place.
+            const goUpScope = () => {
+                if (scopeRef.current) {
+                    pendingScopeSelectRef.current = 'g:' + scopeRef.current;
+                    changeScope('');
+                }
+            };
             // { stack: [{xml, scope, tag}], index, savedIndex }. index === -1
             // means an empty stack (no document loaded yet).
             const undoStateRef = React.useRef({ stack: [], index: -1, savedIndex: -1 });
@@ -803,10 +812,7 @@
                         // Backspace steps up one scope level (never
                         // deletes); always preventDefault to block browser
                         // back-navigation. Scope change waits behind changeScope's overlay.
-                        if (scopeRef.current) {
-                            pendingScopeSelectRef.current = 'g:' + scopeRef.current;
-                            changeScope('');
-                        }
+                        goUpScope();
                         e.preventDefault();
                         return;
                     }
@@ -5050,10 +5056,7 @@ onRenameCommit: (id, nm) => inlineRenameCommitRef.current(id, nm),
                 scope !== '' && { separator: true },
                 scope !== '' && {
                     label: 'Exit Nodegraph', icon: 'chevrons-left', keys: 'Backspace',
-                    onSelect: () => {
-                        if (scopeRef.current) pendingScopeSelectRef.current = 'g:' + scopeRef.current;
-                        changeScope('');
-                    } },
+                    onSelect: goUpScope },
                 { separator: true },
                 { label: 'Undo', icon: 'arrow-back-up', keys: 'Ctrl+Z', onSelect: undoDoc },
                 { label: 'Redo', icon: 'arrow-forward-up', keys: 'Ctrl+Shift+Z', onSelect: redoDoc },
@@ -5088,6 +5091,7 @@ onRenameCommit: (id, nm) => inlineRenameCommitRef.current(id, nm),
                                     ref={importInputRef}
                                     type="file"
                                     multiple
+                                    accept=".mtlx,.zip,.png,.jpg,.jpeg,.webp,.gif,.bmp,.tga,.exr,.hdr,.tif,.tiff"
                                     className="hidden"
                                     onChange={onPickFiles}
                                 />
@@ -5124,12 +5128,7 @@ onRenameCommit: (id, nm) => inlineRenameCommitRef.current(id, nm),
                         {parsed ? (
                             <div className="flex items-center h-7 min-w-0">
                                 <div className="text-[11px] font-sans text-gray-400 max-w-full truncate">
-                                    <button className="hover:text-gray-200 underline decoration-dotted" onClick={() => {
-                                        // Cheap ref write stays immediate; changeScope is a
-                                        // no-op (no overlay flash) when already at the root.
-                                        if (scopeRef.current) pendingScopeSelectRef.current = 'g:' + scopeRef.current;
-                                        changeScope('');
-                                    }}>
+                                    <button className="hover:text-gray-200 underline decoration-dotted" onClick={goUpScope}>
                                         {parsed.label}
                                     </button>
                                     {scope && <span className="inline-flex items-center align-middle text-gray-500 mx-1"><MtlxIcon name="chevron-right" className="w-3 h-3" /></span>}
@@ -5383,6 +5382,20 @@ onRenameCommit: (id, nm) => inlineRenameCommitRef.current(id, nm),
                                 <div className="absolute top-2 left-1/2 -translate-x-1/2 z-30 max-w-[min(42rem,85%)] bg-red-950/90 border border-red-800/60 text-red-200 text-sm rounded-lg px-4 py-2.5 break-words shadow-lg">
                                     {error}
                                 </div>
+                            )}
+
+                            {/* Leave-nodegraph pill: centered at the canvas
+                                host's top edge, only while scoped inside a
+                                nodegraph. Same go-up action as Backspace. */}
+                            {scope && (
+                                <button
+                                    onClick={goUpScope}
+                                    title={scope + ' (Backspace)'}
+                                    className={HUD_PILL + ' absolute top-2 left-1/2 -translate-x-1/2 z-30 max-w-[16rem]'}
+                                >
+                                    <MtlxIcon name="arrow-left" className="w-3.5 h-3.5 shrink-0" />
+                                    <span className="truncate">Leave {scope}</span>
+                                </button>
                             )}
 
                             {/* Types window (bottom left): zoom/fit cluster docked

--- a/js/graph/model.jsx
+++ b/js/graph/model.jsx
@@ -239,6 +239,7 @@
                 enumNames: mxElAttr(dIn, 'enum'), enumValues: mxElAttr(dIn, 'enumvalues'),
                 defColorspace: mxElAttr(dIn, 'colorspace'),
                 uifolder: mxElAttr(dIn, 'uifolder'),
+                uiname: mxElAttr(dIn, 'uiname'),
             };
             // Output type(s) resolved before inputs so each input can be
             // flagged colorManaged — colorspace only applies to color3/4

--- a/js/graph/panels.jsx
+++ b/js/graph/panels.jsx
@@ -298,6 +298,10 @@
             const isSpinEvent = (e) => !(e && e.nativeEvent && e.nativeEvent.inputType);
             React.useEffect(() => flush, []); // unmount: don't drop a pending edit
             const commit = () => { flush(); if (draft !== (inp.value || '')) onCommit(draft); };
+            // FilePickerField keeps its own edit draft and hands back the
+            // committed string directly, so this mirrors commit() against
+            // that fresh value instead of the (unrelated) outer `draft`.
+            const commitFilename = (v) => { flush(); setDraft(v); if (v !== (inp.value || '')) onCommit(v); };
 
             const vecN = VEC_SIZE[inp.type] || 0;
             const isColor = inp.type === 'color3' || inp.type === 'color4';
@@ -305,26 +309,30 @@
             const enumValues = splitList(inp.enumValues);
             const boxCls = 'bg-gray-900 border border-gray-600 rounded text-[11px] font-mono text-gray-200 focus:border-blue-500 focus:outline-none';
 
-            // Colorspace is rarely touched, so the picker starts collapsed
-            // and only auto-expands when the instance (or a signature/
-            // version swap) already authors one.
-            const [csOpen, setCsOpen] = React.useState(!!inp.colorspace);
-            React.useEffect(() => { setCsOpen(!!inp.colorspace); }, [nodeId, inp.name, inp.colorspace]);
+            // Hidden file input the FilePickerField's Choose button
+            // clicks (the graph owns its own picker flow, rather than
+            // FilePickerField's own internal-input fallback).
+            const fileInputRef = React.useRef(null);
 
-            // Shared colorspace <select> row — used by the filename branch
-            // (always) and the color3/color4 branch (behind the collapse
-            // toggle) so the two don't drift apart.
+            // Shared colorspace row: always visible for the filename
+            // branch and the color3/color4 branch alike, mirroring
+            // node-preview's MtlxSelect presentation exactly.
             const colorspaceRow = () => (
                 <div className="flex items-center gap-1.5">
-                    <span className="flex-none text-[9px] text-gray-500" title="Color space of the image — baked into the generated shader">colorspace</span>
-                    <select
-                        className={'flex-1 min-w-0 px-1 py-0.5 ' + boxCls}
+                    <span className="text-[10px] text-gray-500 flex-none font-mono">colorspace</span>
+                    <MtlxSelect
                         value={inp.colorspace || ''}
-                        onChange={(e) => { if (onSetColorspace) onSetColorspace(e.target.value); }}
-                    >
-                        <option value="">{'(default' + (inp.defColorspace ? ': ' + inp.defColorspace : '') + ')'}</option>
-                        {COLORSPACES.map((cs) => <option key={cs} value={cs}>{cs}</option>)}
-                    </select>
+                        options={COLORSPACES}
+                        emptyOption={'(nodedef default' + (inp.defColorspace ? ': ' + inp.defColorspace : '') + ')'}
+                        onChange={(v) => { if (onSetColorspace) onSetColorspace(v); }}
+                        size="sm"
+                        variant="field"
+                        icon="palette"
+                        font="mono"
+                        align="left"
+                        block
+                        className="flex-1 min-w-0"
+                    />
                 </div>
             );
 
@@ -354,18 +362,33 @@
                     for (let i = 0; i < enumNames.length; i++) {
                         if (isNum ? parseFloat(valOf(i)) === parseFloat(draft) : valOf(i) === draft) { sel = i; break; }
                     }
+                    // Nodedef-default option (when it's one of the enum's
+                    // own values) gets a "default" badge.
+                    let defIdx = -1;
+                    if (inp.defValue !== undefined && inp.defValue !== '') {
+                        for (let i = 0; i < enumNames.length; i++) {
+                            if (isNum ? parseFloat(valOf(i)) === parseFloat(inp.defValue) : valOf(i) === inp.defValue) { defIdx = i; break; }
+                        }
+                    }
+                    const enumOptions = enumNames.map((nm, i) => ({ value: String(i), label: nm }));
+                    // Current value doesn't match any enum entry (stale or
+                    // authored-only value): show it verbatim as an extra row.
+                    if (sel === -1) enumOptions.unshift({ value: '', label: '(' + (draft === '' ? 'unset' : draft) + ')' });
                     return (
-                        <select
-                            className={'w-full px-1.5 py-0.5 ' + boxCls}
+                        <MtlxSelect
                             value={sel === -1 ? '' : String(sel)}
-                            onChange={(e) => {
-                                const i = parseInt(e.target.value, 10);
+                            options={enumOptions}
+                            badges={defIdx !== -1 ? { [String(defIdx)]: 'default' } : undefined}
+                            onChange={(v) => {
+                                const i = parseInt(v, 10);
                                 if (!isNaN(i)) commitNow(valOf(i));
                             }}
-                        >
-                            {sel === -1 && <option value="">({draft === '' ? 'unset' : draft})</option>}
-                            {enumNames.map((nm, i) => <option key={i} value={String(i)}>{nm}</option>)}
-                        </select>
+                            size="sm"
+                            variant="field"
+                            font="mono"
+                            align="left"
+                            block
+                        />
                     );
                 }
                 if (inp.type === 'boolean') {
@@ -415,14 +438,6 @@
                         <div>
                             <div className="flex items-center gap-1">
                                 {isColor && (
-                                    <button
-                                        type="button"
-                                        onClick={() => setCsOpen((v) => !v)}
-                                        title="Colorspace…"
-                                        className="flex-none flex items-center text-gray-400 hover:text-gray-200 px-0.5 self-stretch"
-                                    ><MtlxIcon name={csOpen ? 'chevron-down' : 'chevron-right'} className="w-3.5 h-3.5" /></button>
-                                )}
-                                {isColor && (
                                     <ColorSwatch
                                         rgb={comps.slice(0, 3)}
                                         className="flex-none w-6 h-6 p-0 bg-transparent border border-gray-600 rounded cursor-pointer"
@@ -453,7 +468,7 @@
                                     />
                                 ))}
                             </div>
-                            {isColor && csOpen && (
+                            {isColor && (
                                 <div className="mt-1">{colorspaceRow()}</div>
                             )}
                         </div>
@@ -501,32 +516,35 @@
                         </div>
                     );
                 }
-                // Filename → image picker (joins session files, binds by
-                // name) + editable name field; the colorspace select
-                // underneath recompiles the shader (a codegen decision).
+                // Filename → the shared FilePickerField (joins session
+                // files, binds by name); the colorspace select underneath
+                // recompiles the shader (a codegen decision).
                 if (inp.type === 'filename') {
                     return (
                         <div className="space-y-1">
-                            <div className="flex items-center gap-1.5">
-                                <label
-                                    className="flex-none text-[10px] px-1.5 py-0.5 rounded bg-gray-700 hover:bg-gray-600 text-gray-200 cursor-pointer"
-                                    title="Load an image file — it joins the session files and binds by name"
-                                >
-                                    Choose{'\u2026'}
-                                    <input
-                                        type="file" accept="image/png,image/jpeg,image/webp,image/gif"
-                                        className="hidden"
-                                        onChange={(e) => {
-                                            const f = e.target.files && e.target.files[0];
-                                            if (f && onPickFile) onPickFile(f);
-                                            // Clear so re-picking the SAME file
-                                            // still fires a change event.
-                                            e.target.value = '';
-                                        }}
-                                    />
-                                </label>
-                                {textField()}
-                            </div>
+                            <FilePickerField
+                                value={draft}
+                                editable
+                                mono
+                                onCommit={commitFilename}
+                                onClear={() => commitFilename('')}
+                                icon="file"
+                                disabled={readOnly}
+                                accept=".png,.jpg,.jpeg,.webp,.gif,.bmp,.tga,.exr,.hdr,.tif,.tiff"
+                                onChoose={() => { if (fileInputRef.current) fileInputRef.current.click(); }}
+                            />
+                            <input
+                                ref={fileInputRef}
+                                type="file" accept=".png,.jpg,.jpeg,.webp,.gif,.bmp,.tga,.exr,.hdr,.tif,.tiff"
+                                className="hidden"
+                                onChange={(e) => {
+                                    const f = e.target.files && e.target.files[0];
+                                    if (f && onPickFile) onPickFile(f);
+                                    // Clear so re-picking the SAME file
+                                    // still fires a change event.
+                                    e.target.value = '';
+                                }}
+                            />
                             {/* Colorspace matters only for color3/4 output,
                                 but stays visible if the instance already
                                 authors one (e.g. after a signature swap). */}
@@ -542,8 +560,8 @@
                 <div className="py-1.5 border-b border-gray-700/60 last:border-b-0">
                     <div className="flex items-center gap-1.5 text-[11px] font-mono">
                         <span className="w-2 h-2 rounded-full flex-none" style={{ background: typeColor(inp.type) }} />
-                        <span className="text-gray-300 truncate">{inp.name}</span>
-                        <span className="ml-auto flex-none text-[9px]" style={{ color: typeColor(inp.type) }}>{inp.type}</span>
+                        <span className="text-gray-300 truncate text-[11px] font-mono" title={inp.uiname ? inp.name : undefined}>{inp.uiname || inp.name}</span>
+                        <span className="ml-auto flex-none text-[9px] font-mono" style={{ color: typeColor(inp.type) }}>{inp.type}</span>
                     </div>
                     {inp.connected ? (
                         sourceId ? (

--- a/js/graph/preview.jsx
+++ b/js/graph/preview.jsx
@@ -794,8 +794,8 @@
             }, [parsed, target, docRev, fileMap, geomMode]);
 
             // Row-1 geometry dropdown, built HERE (not a ViewportControls
-            // built-in slot) so it shares geomMode with the Settings-popover's
-            // own MtlxSelect just below.
+            // built-in slot) so it's the single geometry control for the
+            // graph preview.
             const graphGeomSlot = (
                 <MtlxSelect
                     key="graphGeom"
@@ -852,32 +852,6 @@
                         // Show button labels only in fullscreen, matching the
                         // render's own camera-reset/fullscreen buttons.
                         showLabels={isFullscreen}
-                        settingsChildren={
-                            <div>
-                                {/* Dropdown on its OWN line: label + trigger
-                                    can't share the popup's 288px row without
-                                    overflowing its edge. The Experimental
-                                    badge sits on the Auto ROW (via badges) —
-                                    picking a geometry isn't the experiment,
-                                    the Auto mode is. */}
-                                <div className="text-gray-200">Preview Geometry</div>
-                                <MtlxSelect
-                                    value={geomMode}
-                                    options={GRAPH_GEOM_MODES}
-                                    labels={GRAPH_GEOM_LABELS}
-                                    badges={GRAPH_GEOM_BADGES}
-                                    onChange={setGeomMode}
-                                    title="Global graph-preview geometry"
-                                    size="sm" block className="mt-1.5"
-                                />
-                                <div className="mt-1 text-[11px] text-gray-400">
-                                    Applies to every preview in the graph editor. 3D geometries
-                                    orbit with the mouse; the 2D Buffer stays fixed. "Auto (by
-                                    node type)" flattens an element only when it and everything
-                                    upstream of it are flat (patterns/math).
-                                </div>
-                            </div>
-                        }
                     />
                     <div
                         className={`relative w-full bg-gray-900/60 ${isFullscreen ? 'flex-1 min-h-0' : 'aspect-square'}`}

--- a/js/graph/style.jsx
+++ b/js/graph/style.jsx
@@ -75,45 +75,8 @@
 
         // ---- React Flow node rendering ---------------------------------------
 
-        // MaterialX type -> port/edge color, curated so co-occurring
-        // types are never confusable. Types outside the table hash to
-        // a stable color, so custom/struct/array types stay consistent.
-        const TYPE_COLORS = {
-            boolean: '#d2372b',            // crimson red
-            BSDF: '#2e7d32',               // forest green
-            color3: '#fdd835',             // sunflower yellow
-            color4: '#f4511e',             // coral orange
-            displacementshader: '#8d6e63', // warm taupe
-            EDF: '#cddc39',                // yellow-green
-            filename: '#90a4ae',           // cool blue-gray
-            float: '#3949ab',              // deep indigo blue
-            integer: '#8e24aa',            // royal violet
-            lightshader: '#ff934f',        // warm apricot orange
-            material: '#ff404f',           // vivid red
-            matrix33: '#cfd8dc',           // pale blue-gray
-            matrix44: '#546e7a',           // slate blue-gray
-            string: '#d7c4a3',             // warm sand
-            surfaceshader: '#00897b',      // deep teal
-            vector2: '#5c6bc0',            // muted indigo
-            vector3: '#b388ff',            // soft lavender
-            vector4: '#ec407a',            // rose pink
-            VDF: '#9ccc65',                // fresh green
-            volumeshader: '#00bcd4',       // bright cyan
-            node: '#a1887f',               // muted warm stone
-            nodegraph: '#854d0e'           // bronze brown
-        };
-        // Stable string hash → hue; fixed saturation/lightness keeps hashed
-        // colors legible on the dark stage.
-        const typeHue = (s) => {
-            let h = 0;
-            for (let i = 0; i < s.length; i++) h = ((h << 5) - h + s.charCodeAt(i)) | 0;
-            return ((h % 360) + 360) % 360;
-        };
-        const typeColor = (t) => {
-            if (!t) return '#94a3b8'; // untyped: default slate
-            if (TYPE_COLORS[t]) return TYPE_COLORS[t];
-            return 'hsl(' + typeHue(String(t)) + ', 65%, 62%)';
-        };
+        // TYPE_COLORS, typeHue, typeColor now live in js/shared/ui-commons.js
+        // (loaded eagerly before this file); resolved here via window.
 
         // Node-kind accents (header dot + minimap) derive from TYPE_COLORS so
         // they always track the palette; nodegraph/generic have no MaterialX
@@ -218,6 +181,6 @@
         const CONN_ATTRS = ['interfacename', 'nodegraph', 'nodename', 'output'];
 
 Object.assign(window, {
-    TYPE_COLORS, typeColor, getNodeColor, handleStyle, NODE_W, nodeHeight, layoutScope,
+    getNodeColor, handleStyle, NODE_W, nodeHeight, layoutScope,
     visiblePortsFor, toFlow, toRfEdge, CONN_ATTRS,
 });

--- a/js/home-app.jsx
+++ b/js/home-app.jsx
@@ -300,7 +300,6 @@ function HeroStage({ active, busy, onOpen }) {
     }, [failed]);
 
     const basename = HERO_PRESET.path.split('/').pop();
-    const pillClass = 'inline-flex items-center gap-1.5 h-7 px-2.5 rounded-lg border border-gray-600/50 bg-gray-900/70 text-xs font-medium text-gray-400 hover:bg-gray-700 hover:border-gray-600 hover:text-gray-100 [&:hover_svg]:text-gray-100 transition-colors disabled:opacity-60 disabled:cursor-wait';
 
     return (
         <div className="relative group h-[320px] lg:h-[400px] w-full">
@@ -334,11 +333,11 @@ function HeroStage({ active, busy, onOpen }) {
                 </div>
             )}
             <div className="absolute bottom-2 left-0 right-0 flex justify-center gap-2 transition-all duration-150 opacity-0 translate-y-1 pointer-events-none group-hover:opacity-100 group-hover:translate-y-0 group-hover:pointer-events-auto focus-within:opacity-100 focus-within:translate-y-0 focus-within:pointer-events-auto [@media(hover:none)]:opacity-100 [@media(hover:none)]:translate-y-0 [@media(hover:none)]:pointer-events-auto">
-                <button type="button" disabled={!!busy} onClick={() => onOpen('viewer')} className={pillClass}>
+                <button type="button" disabled={!!busy} onClick={() => onOpen('viewer')} className={PILL_ACTION}>
                     <MtlxIcon name="camera" className="w-3.5 h-3.5 text-gray-500 transition-colors" />
                     {busy === 'viewer' ? 'Loading' : 'Open in Viewer'}
                 </button>
-                <button type="button" disabled={!!busy} onClick={() => onOpen('graph')} className={pillClass}>
+                <button type="button" disabled={!!busy} onClick={() => onOpen('graph')} className={PILL_ACTION}>
                     <MtlxIcon name="share" className="w-3.5 h-3.5 text-gray-500 transition-colors" />
                     {busy === 'graph' ? 'Loading' : 'Open in Graph Editor'}
                 </button>

--- a/js/node-preview.jsx
+++ b/js/node-preview.jsx
@@ -49,6 +49,22 @@
                 try { h.delete(); } catch (e) { /* already deleted / not owned */ }
             }
         };
+        // Graph Editor's ParamRow header idiom (js/graph/panels.jsx ~543-546):
+        // type-color dot, truncated label, right-aligned colored type tag.
+        // Shared here so the ungrouped and foldered param lists can't drift.
+        const ParamLabel = ({ p }) => (
+            <label className="flex items-center gap-1.5 text-[11px] font-mono mb-1">
+                <span className="w-2 h-2 rounded-full flex-none" style={{ background: typeColor(p.type) }} />
+                <span className="text-gray-300 truncate">{p.label}</span>
+                <span className="ml-auto flex-none text-[9px]" style={{ color: typeColor(p.type) }}>{p.type}</span>
+            </label>
+        );
+        // Graph Editor's GROUP_HEADER_CLASS (js/graph-app.jsx ~109-111), scaled
+        // for this panel's p-3 container: -mx-3/w-[calc(100%+1.5rem)] replace
+        // its -mx-2.5/w-[calc(100%+1.25rem)] so the bar still reaches the edge.
+        const FOLDER_HEADER_CLASS = 'w-[calc(100%+1.5rem)] flex items-center gap-1.5 -mx-3 px-2.5 py-1.5 border-t border-b '
+            + 'border-gray-700 bg-gray-900/40 text-[10px] font-semibold uppercase tracking-wider text-gray-400 '
+            + 'hover:bg-gray-900/70 hover:text-gray-200 transition-colors';
         const Node3DPreview = ({ nodeName, library, nodegroup, preferredType, preferredDef, disabledNotice, enabled, onEnable, active = true, embed = EMBED }) => {
             // Lets a future multi-view shell pause this preview's render loop
             // when backgrounded, without unmounting. Standalone index.html
@@ -219,9 +235,9 @@
                     setOverrides((prev) => Object.assign({}, prev, { [p.input]: { value: v, type: p.type } }));
                 }
             };
-            // Colorspace picker for a filename input → override + regen.
-            // '(nodedef default)' removes the override so the nodedef's own
-            // colorspace applies again.
+            // Colorspace picker for a filename/color3 input → override +
+            // regen. '(nodedef default)' clears the override. valueType is
+            // the input's REAL type, passed through to applyOverrides.
             const onColorspacePick = (p, cs) => {
                 if (loadingRef.current) return;
                 valuesRef.current = Object.assign({}, valuesRef.current, { ['cs::' + p.input]: cs || undefined });
@@ -229,7 +245,7 @@
                 overridesNodeRef.current = identKey;
                 setOverrides((prev) => {
                     const next = Object.assign({}, prev);
-                    if (cs) next[p.input] = { value: cs, type: 'colorspace' };
+                    if (cs) next[p.input] = { value: cs, type: 'colorspace', valueType: p.type };
                     else delete next[p.input];
                     return next;
                 });
@@ -255,6 +271,19 @@
                 }, undefined, () => URL.revokeObjectURL(url));
                 valuesRef.current = Object.assign({}, valuesRef.current, { [p.uniform]: file.name });
                 setValues((prev) => Object.assign({}, prev, { [p.uniform]: file.name }));
+            };
+            // Clears one filename param back to its nodedef default sampler
+            // (the same per-field bake onResetDefaults does for every
+            // param, scoped here to just this one).
+            const onClearFilename = (p) => {
+                if (loadingRef.current) return;
+                const rv = viewRef.current;
+                const store = uniformsRef.current;
+                const dtex = rv ? getFilenameDefaultTexture(rv.introspected, p.uniform) : null;
+                if (store && store[p.uniform]) store[p.uniform].value = dtex;
+                delete pickedTexRef.current[p.uniform];
+                valuesRef.current = Object.assign({}, valuesRef.current, { [p.uniform]: null });
+                setValues((prev) => Object.assign({}, prev, { [p.uniform]: null }));
             };
             const onResetDefaults = () => {
                 const next = {};
@@ -572,7 +601,7 @@
                             if (overridesNodeRef.current && overridesNodeRef.current !== identKey) return;
                             const ov = overridesRef.current || {};
                             for (const inputName of Object.keys(ov)) {
-                                const { value, type } = ov[inputName];
+                                const { value, type, valueType } = ov[inputName];
                                 try {
                                     // embind addInput can drop the type arg,
                                     // leaving 'color3' and breaking nodedef
@@ -584,10 +613,10 @@
                                         } catch (e2) { /* best-effort */ }
                                     };
                                     if (type === 'colorspace') {
-                                        // Colorspace is an ATTRIBUTE on the
-                                        // filename input, not its value — the
-                                        // CMS bakes the transform at codegen.
-                                        const inp = ensureTypedInput(doc, nodeInst, inputName, 'filename');
+                                        // Colorspace is an ATTRIBUTE, not a
+                                        // value; valueType is the input's REAL
+                                        // type (filename, color3, ...).
+                                        const inp = ensureTypedInput(doc, nodeInst, inputName, valueType || 'filename');
                                         mxSetColorspace(inp, String(value));
                                         continue;
                                     }
@@ -812,6 +841,10 @@
                         });
                         if (!mounted) return;
                         setKindState(kind);
+                        // MaterialX spec: colorspace applies to "color3- or
+                        // color4-type inputs" and "color image files and
+                        // values" only, mirrors model.jsx's colorManaged.
+                        const isColorSignature = outType === 'color3' || outType === 'color4';
 
                         // Generation + rendering (shared pipeline): resolve
                         // the canvas first — a stale PREVIOUS-node message
@@ -886,7 +919,7 @@
                                         }
                                         if (type === 'filename') {
                                             return { uniform: 'in::' + inputName, input: inputName, label, type: 'filename', def: null,
-                                                colorspace: attrOf(inp, 'colorspace'), live: false, uifolder };
+                                                colorspace: attrOf(inp, 'colorspace'), colorManaged: isColorSignature, live: false, uifolder };
                                         }
                                         if (LIVE_TYPES.indexOf(type) === -1) {
                                             return { uniform: 'in::' + inputName, input: inputName, label, type,
@@ -1147,7 +1180,7 @@
                             if (type === 'filename') {
                                 if (!u || !uniforms[u.name]) return null;
                                 return { uniform: u.name, input: inputName, label, type: 'filename', def: null,
-                                    colorspace: attrOf(inp, 'colorspace'), live: true, uifolder };
+                                    colorspace: attrOf(inp, 'colorspace'), colorManaged: isColorSignature, live: true, uifolder };
                             }
 
                             // NUMERIC / VECTOR / COLOR / BOOLEAN.
@@ -1179,7 +1212,11 @@
                                     if (max <= min) max = min + 1;
                                 }
                                 return { uniform: u.name, input: inputName, label, type, def, min, max,
-                                    enumNames, enumValues, live: true, uifolder };
+                                    enumNames, enumValues, live: true, uifolder,
+                                    // Parity with the filename branch above:
+                                    // color3's colorspace select shows this
+                                    // as the nodedef-default fallback text.
+                                    colorspace: attrOf(inp, 'colorspace') };
                             }
 
                             // No uniform (e.g. a geometric default like
@@ -1403,23 +1440,28 @@
             // color picker, vector → per-component number fields.
             const renderControl = (p) => {
                 const cur = values[p.uniform] !== undefined ? values[p.uniform] : p.def;
-                const numCls = 'w-16 bg-gray-800 border border-gray-600 rounded px-1 py-0.5 text-xs text-gray-200';
+                const numCls = 'w-16 bg-gray-800 border border-gray-600 rounded px-1 py-0.5 text-[11px] font-mono text-gray-200';
                 // Read-only input (e.g. a geometric default like Vworld) —
                 // shown so the input isn't "missing", but not editable.
                 if (p.readonly) {
-                    return <span className="text-xs text-gray-500 italic font-mono">{String(cur)}</span>;
+                    return <span className="text-[11px] text-gray-500 italic font-mono">{String(cur)}</span>;
                 }
                 // String with a fixed set of accepted values → dropdown. The
                 // value IS the selected string (unlike numeric enums below).
                 if (p.type === 'string' && p.options && p.options.length) {
+                    // p.def is the NODEDEF default (read off the nodedef's
+                    // own input, never the live edit): badge it, not `cur`.
+                    const defBadge = p.options.indexOf(p.def) !== -1 ? { [p.def]: 'default' } : undefined;
                     return (
                         <MtlxSelect
                             value={String(cur)}
                             options={p.options}
+                            badges={defBadge}
                             onChange={(v) => onParamChange(p, v)}
                             disabled={loading}
                             size="sm"
                             variant="field"
+                            font="mono"
                             block
                         />
                     );
@@ -1429,7 +1471,7 @@
                     return (
                         <input
                             type="text"
-                            className="w-full bg-gray-800 border border-gray-600 rounded px-2 py-1 text-xs text-gray-200"
+                            className="w-full bg-gray-800 border border-gray-600 rounded px-2 py-1 text-[11px] font-mono text-gray-200"
                             value={String(cur)}
                             onChange={(e) => onParamChange(p, e.target.value)}
                         />
@@ -1441,14 +1483,19 @@
                     for (let i = 0; i < p.enumNames.length; i++) {
                         if (valOf(i) === Number(cur)) { selIdx = i; break; }
                     }
+                    // Badge the NODEDEF-DEFAULT option (p.def), not selIdx's
+                    // current pick, same reset-to-defaults field as above.
+                    const defIdx = p.enumNames.findIndex((nm, i) => valOf(i) === Number(p.def));
                     return (
                         <MtlxSelect
                             value={selIdx}
                             options={p.enumNames.map((nm, i) => ({ value: i, label: nm }))}
+                            badges={defIdx !== -1 ? { [defIdx]: 'default' } : undefined}
                             onChange={(i) => onParamChange(p, valOf(i))}
                             disabled={loading}
                             size="sm"
                             variant="field"
+                            font="mono"
                             block
                         />
                     );
@@ -1457,29 +1504,21 @@
                     const csVal = values['cs::' + p.input] || '';
                     return (
                         <div className="space-y-1">
-                            <div className="flex items-center gap-2">
-                                <label className="text-xs px-2 py-1 rounded bg-gray-700 hover:bg-gray-600 text-gray-200 cursor-pointer flex-none">
-                                    Choose image…
-                                    <input
-                                        type="file" accept="image/png,image/jpeg,image/webp,image/gif"
-                                        className="hidden"
-                                        onChange={(e) => {
-                                            onFilePick(p, e.target.files && e.target.files[0]);
-                                            // Clear so choosing the SAME file
-                                            // later still fires change (an
-                                            // unchanged value emits no event).
-                                            e.target.value = '';
-                                        }}
-                                    />
-                                </label>
-                                <span className="text-xs text-gray-400 truncate min-w-0">
-                                    {cur || 'no file'}
-                                </span>
-                            </div>
+                            <FilePickerField
+                                value={cur}
+                                accept=".png,.jpg,.jpeg,.webp,.gif,.bmp,.tga,.exr,.hdr,.tif,.tiff"
+                                icon="file"
+                                mono
+                                disabled={loading}
+                                onFiles={(files) => onFilePick(p, files && files[0])}
+                                onClear={() => onClearFilename(p)}
+                            />
                             {/* Colorspace: a codegen decision (CMS transform
-                                baked into the shader), so picking regenerates. */}
+                                baked into the shader), so picking regenerates.
+                                Gated to color3/4 signatures, see isColorSignature. */}
+                            {p.colorManaged && (
                             <div className="flex items-center gap-2">
-                                <span className="text-[10px] text-gray-500 flex-none">colorspace</span>
+                                <span className="text-[10px] text-gray-500 flex-none font-mono">colorspace</span>
                                 <MtlxSelect
                                     value={csVal}
                                     options={COLORSPACES}
@@ -1488,9 +1527,14 @@
                                     disabled={loading}
                                     size="sm"
                                     variant="field"
+                                    icon="palette"
+                                    font="mono"
+                                    align="left"
+                                    block
                                     className="flex-1 min-w-0"
                                 />
                             </div>
+                            )}
                         </div>
                     );
                 }
@@ -1542,26 +1586,52 @@
                     // steps (1/255 ~ 0.004).
                     const fmt = (n) => Math.round(Number(n) * 1000) / 1000;
                     const chan = p.type === 'color4' ? 'RGBA' : 'RGB';
+                    // color4 has no colorspace select: only color3 is wired
+                    // through the filename path's colorspace mechanism.
+                    const csVal = p.type === 'color3' ? (values['cs::' + p.input] || '') : '';
                     return (
-                        <div className="flex items-center gap-1">
-                            <ColorSwatch
-                                rgb={rgb}
-                                className="h-7 w-10 bg-transparent border border-gray-600 rounded cursor-pointer flex-none"
-                                title="Linear RGB — hex bytes map 1:1 onto the 0-1 values to the right"
-                                onChange={(nv) => {
-                                    onParamChange(p, p.type === 'color4' ? nv.concat([cur[3]]) : nv);
-                                }}
-                            />
-                            {cur.map((c, i) => (
-                                <input
-                                    key={i} type="number" min="0" max="1" step="0.01"
-                                    title={chan[i] + ' (linear, 0-1)'}
-                                    className="w-full min-w-0 bg-gray-800 border border-gray-600 rounded px-1 py-0.5 text-xs text-gray-200"
-                                    value={fmt(c)}
-                                    onChange={(e) => setComp(i, e.target.value)}
-                                    onBlur={(e) => { e.target.value = String(fmt(cur[i])); }}
+                        <div className="space-y-1">
+                            <div className="flex items-center gap-1">
+                                <ColorSwatch
+                                    rgb={rgb}
+                                    className="flex-none w-6 h-6 p-0 bg-transparent border border-gray-600 rounded cursor-pointer"
+                                    title="Linear RGB — hex bytes map 1:1 onto the 0-1 values to the right"
+                                    onChange={(nv) => {
+                                        onParamChange(p, p.type === 'color4' ? nv.concat([cur[3]]) : nv);
+                                    }}
                                 />
-                            ))}
+                                {cur.map((c, i) => (
+                                    <input
+                                        key={i} type="number" min="0" max="1" step="0.01"
+                                        title={chan[i] + ' (linear, 0-1)'}
+                                        className="w-full min-w-0 bg-gray-800 border border-gray-600 rounded px-1 py-0.5 text-[11px] font-mono text-gray-200"
+                                        value={fmt(c)}
+                                        onChange={(e) => setComp(i, e.target.value)}
+                                        onBlur={(e) => { e.target.value = String(fmt(cur[i])); }}
+                                    />
+                                ))}
+                            </div>
+                            {p.type === 'color3' && (
+                                // Colorspace: a codegen decision (CMS transform
+                                // baked into the shader), so picking regenerates.
+                                <div className="flex items-center gap-2">
+                                    <span className="text-[10px] text-gray-500 flex-none font-mono">colorspace</span>
+                                    <MtlxSelect
+                                        value={csVal}
+                                        options={COLORSPACES}
+                                        emptyOption={'(nodedef default' + (p.colorspace ? ': ' + p.colorspace : '') + ')'}
+                                        onChange={(v) => onColorspacePick(p, v)}
+                                        disabled={loading}
+                                        size="sm"
+                                        variant="field"
+                                        icon="palette"
+                                        font="mono"
+                                        align="left"
+                                        block
+                                        className="flex-1 min-w-0"
+                                    />
+                                </div>
+                            )}
                         </div>
                     );
                 }
@@ -1571,7 +1641,7 @@
                         {cur.map((c, i) => (
                             <input
                                 key={i} type="number" step="0.01"
-                                className="w-full min-w-0 bg-gray-800 border border-gray-600 rounded px-1 py-0.5 text-xs text-gray-200"
+                                className="w-full min-w-0 bg-gray-800 border border-gray-600 rounded px-1 py-0.5 text-[11px] font-mono text-gray-200"
                                 value={c}
                                 onChange={(e) => {
                                     const n = parseFloat(e.target.value);
@@ -1636,30 +1706,6 @@
                     onToggleFullscreen={toggleFullscreenView}
                     containerClassName={compact ? 'absolute top-2 right-2 z-20 flex items-center gap-1.5' : undefined}
                     buttonClassName={compact ? ((active) => 'w-7 h-7 flex-none flex items-center justify-center rounded transition-colors ' + (active ? 'bg-blue-600 text-white hover:bg-blue-500' : 'bg-gray-700 hover:bg-gray-600 text-gray-200')) : undefined}
-                    settingsChildren={
-                        <div>
-                            {/* Dropdown on its OWN line: label + trigger
-                                can't share the popup's 288px row without
-                                overflowing its edge. The Experimental
-                                badge sits on the Auto ROW (via badges) —
-                                picking a geometry isn't the experiment,
-                                the Auto mode is. */}
-                            <div className="text-gray-200">Preview Geometry</div>
-                            <MtlxSelect
-                                value={geomChoice}
-                                options={['default'].concat(PREVIEW_GEOM_LIST)}
-                                labels={GEOM_LABELS}
-                                badges={GEOM_BADGES}
-                                onChange={setGeomChoice}
-                                title="Global preview-geometry choice (all docs previews)"
-                                size="sm" block className="mt-1.5"
-                            />
-                            <div className="mt-1 text-[11px] text-gray-400">
-                                Applies to all node docs previews. "Auto (by node type)"
-                                is experimental: it picks a geometry per node type.
-                            </div>
-                        </div>
-                    }
                 />
             );
             // Parameters panel header/body, shared between the normal
@@ -1674,36 +1720,42 @@
                             onClick={onExportMtlx}
                             disabled={loading}
                             title="Download this node with the current values as a .mtlx document"
-                            className="w-7 h-7 flex-none flex items-center justify-center rounded bg-gray-700 hover:bg-gray-600 text-gray-200 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                            className={BTN_TOOLBAR + ' font-sans disabled:opacity-40 disabled:cursor-not-allowed'}
                         >
                             <MtlxIcon name="file-download" className="w-3.5 h-3.5" />
+                            <span>Download .mtlx</span>
                         </button>
                         {!IN_VSCODE && (
                         <button
                             onClick={sendToEditor}
                             disabled={loading}
                             title="Open this node in the node graph editor"
-                            className="w-7 h-7 flex-none flex items-center justify-center rounded bg-gray-700 hover:bg-gray-600 text-gray-200 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                            className={BTN_TOOLBAR + ' font-sans disabled:opacity-40 disabled:cursor-not-allowed'}
                         >
                             <MtlxIcon name="transfer" className="w-3.5 h-3.5" />
+                            <span>Send to Editor</span>
                         </button>
                         )}
                         <button
                             onClick={onResetDefaults}
                             disabled={loading}
                             title="Reset to default"
-                            className="w-7 h-7 flex-none flex items-center justify-center rounded bg-gray-700 hover:bg-gray-600 text-gray-200 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                            className={BTN_TOOLBAR + ' font-sans disabled:opacity-40 disabled:cursor-not-allowed'}
                         >
                             <MtlxIcon name="restore" className="w-3.5 h-3.5" />
+                            <span>Reset</span>
                         </button>
                         {kindState === 'translation' && (
                         <button
                             onClick={() => setCompareOn((v) => !v)}
                             disabled={loading}
                             title={compareOn ? 'Show only the translated shader' : 'Compare against the source shader (swipe)'}
-                            className={'w-7 h-7 flex-none flex items-center justify-center rounded transition-colors disabled:opacity-40 disabled:cursor-not-allowed ' + (compareOn ? 'bg-blue-600 text-white hover:bg-blue-500' : 'bg-gray-700 hover:bg-gray-600 text-gray-200')}
+                            className={(compareOn
+                                ? 'h-7 inline-flex items-center gap-1 text-[11px] px-2 rounded border bg-blue-600/80 border-blue-500 text-white transition-colors whitespace-nowrap shrink-0'
+                                : BTN_TOOLBAR) + ' font-sans disabled:opacity-40 disabled:cursor-not-allowed'}
                         >
                             <MtlxIcon name="compare" className="w-3.5 h-3.5" />
+                            <span>Compare</span>
                         </button>
                         )}
                         {extraButtons}
@@ -1722,35 +1774,31 @@
                         // share input names (e.g. `file`), and a
                         // reused file input won't re-fire on repick
                         <div key={identKey + ':' + p.uniform + ':' + resetNonce}>
-                            <label className="block text-xs text-gray-400 mb-1">
-                                {p.label} <span className="text-gray-600">({p.type})</span>
-                            </label>
+                            <ParamLabel p={p} />
                             {renderControl(p)}
                         </div>
                     ))}
                     {paramGroups.folders.map((f, fi) => {
                         const open = paramFoldersOpen[f.name] !== false;
-                        // A folder that opens the body (no ungrouped
-                        // params above it) gets no divider/top gap — the
-                        // border-t is a separator BETWEEN sections only.
+                        // A folder that opens the body (no ungrouped params
+                        // above it) uses -mt-3 to cancel the scroll body's
+                        // top padding, so the header bar sits flush with the panel header.
                         const firstItem = fi === 0 && paramGroups.ungrouped.length === 0;
                         return (
-                            <div key={'folder:' + f.name} className={(firstItem ? '' : 'border-t border-gray-700/70 mt-2 pt-2') + (wide ? ' col-span-full' : '')}>
+                            <div key={'folder:' + f.name} className={(firstItem ? '-mt-3' : 'mt-2') + (wide ? ' col-span-full' : '')}>
                                 <button
                                     type="button"
                                     onClick={() => setParamFoldersOpen((prev) => Object.assign({}, prev, { [f.name]: !open }))}
-                                    className="w-full flex items-center gap-1.5 text-xs text-gray-400 hover:text-gray-200"
+                                    className={FOLDER_HEADER_CLASS}
                                 >
-                                    <MtlxIcon name={open ? 'chevron-down' : 'chevron-right'} className="flex-none w-3.5 h-3.5" />
+                                    <MtlxIcon name={open ? 'chevron-down' : 'chevron-right'} className="flex-none w-3.5 h-3.5 text-gray-500" />
                                     <span className="truncate">{f.name}</span>
                                 </button>
                                 {open && (
                                     <div className={wide ? 'mt-2 grid grid-cols-1 sm:grid-cols-2 2xl:grid-cols-3 gap-x-4 gap-y-3' : 'mt-2 space-y-3'}>
                                         {f.params.map((p) => (
                                             <div key={identKey + ':' + p.uniform + ':' + resetNonce}>
-                                                <label className="block text-xs text-gray-400 mb-1">
-                                                    {p.label} <span className="text-gray-600">({p.type})</span>
-                                                </label>
+                                                <ParamLabel p={p} />
                                                 {renderControl(p)}
                                             </div>
                                         ))}
@@ -1851,9 +1899,10 @@
                                     <button
                                         onClick={() => setFsParamsOpen(false)}
                                         title="Collapse the parameters sidebar"
-                                        className="w-7 h-7 flex-none flex items-center justify-center rounded bg-gray-700 hover:bg-gray-600 text-gray-200 transition-colors"
+                                        className={BTN_TOOLBAR + ' font-sans'}
                                     >
                                         <MtlxIcon name="chevrons-right" className="w-3.5 h-3.5" />
+                                        <span>Collapse</span>
                                     </button>
                                 )}
                                 {renderParamsBody()}
@@ -1862,7 +1911,7 @@
                             <button
                                 onClick={() => setFsParamsOpen(true)}
                                 title="Show the parameters sidebar"
-                                className="absolute top-12 right-2 z-20 h-7 inline-flex items-center gap-1 text-[11px] px-2 rounded border bg-gray-800/80 backdrop-blur border-gray-600 text-gray-300 hover:bg-gray-700/80 transition-colors whitespace-nowrap"
+                                className="absolute top-12 right-2 z-20 h-7 inline-flex items-center gap-1 text-[11px] font-sans px-2 rounded border bg-gray-800/80 backdrop-blur border-gray-600 text-gray-300 hover:bg-gray-700/80 transition-colors whitespace-nowrap"
                             >
                                 <MtlxIcon name="chevrons-left" className="w-3.5 h-3.5" />
                                 Parameters

--- a/js/shared/compare-ui.jsx
+++ b/js/shared/compare-ui.jsx
@@ -72,7 +72,7 @@ const CompareLabel = ({ side, children, version, className, style }) => (
         style={style}
     >
         {children}
-        {version && <span className="ml-1.5 text-white/50">{version}</span>}
+        {version && <span className="ml-1.5 font-mono text-white/50">{version}</span>}
     </div>
 );
 

--- a/js/shared/mtlx-ui.jsx
+++ b/js/shared/mtlx-ui.jsx
@@ -10,8 +10,8 @@
 // Recurring Tailwind button strings, pulled out because the exact same
 // string (verbatim) repeats across files. Near-twin variants elsewhere
 // (different opacity/sizing) are NOT this — leave those inline.
-const BTN_SECONDARY = 'h-7 inline-flex items-center justify-center text-[11px] px-2.5 rounded border bg-gray-800/80 border-gray-600 text-gray-300 hover:bg-gray-700/80 transition-colors';
-const BTN_PRIMARY = 'h-7 inline-flex items-center justify-center text-[11px] px-2.5 rounded border bg-blue-600/70 border-blue-500 text-white hover:bg-blue-500/70 transition-colors';
+const BTN_SECONDARY = 'h-7 inline-flex items-center justify-center text-[11px] px-2.5 rounded-md border bg-gray-800/80 border-gray-600 text-gray-300 hover:bg-gray-700/80 transition-colors';
+const BTN_PRIMARY = 'h-7 inline-flex items-center justify-center text-[11px] px-2.5 rounded-md border bg-blue-600/70 border-blue-500 text-white hover:bg-blue-500/70 transition-colors';
 // Graph editor toolbar button style. `whitespace-nowrap shrink-0` matters:
 // js/graph-app.jsx's label-collapse measurement needs buttons that don't
 // flex-shrink, so overflow is visible to it instead of silently absorbed.
@@ -21,6 +21,11 @@ const BTN_TOOLBAR = 'h-7 inline-flex items-center gap-1 text-[11px] px-2 rounded
 // the button never changes size between states. No backdrop-blur: the
 // menu bar it sits on is opaque, so there is nothing to blur.
 const BTN_MENUBAR = 'h-7 inline-flex items-center gap-1 text-[11px] px-2 rounded border border-transparent bg-transparent text-gray-300 hover:bg-gray-700/80 hover:border-gray-600 transition-colors whitespace-nowrap shrink-0';
+// Labeled overlay pills for the tool HUDs (viewer/compare) and the
+// collapsed-sidebar pills: deliberately 11px normal weight, not the
+// bolder PILL_ACTION, to match the sidebar's own labeled pills.
+const HUD_PILL = 'h-7 inline-flex items-center gap-1.5 text-[11px] px-2 rounded-lg border border-gray-600/50 bg-gray-900/70 backdrop-blur text-gray-300 hover:bg-gray-700 hover:border-gray-600 hover:text-gray-100 transition-colors whitespace-nowrap';
+const HUD_PILL_ACTIVE = 'h-7 inline-flex items-center gap-1.5 text-[11px] px-2 rounded-lg border border-blue-500 bg-blue-600/80 backdrop-blur text-white transition-colors whitespace-nowrap';
 
 // Formats a caught value for display: an Error's .message, or the value
 // itself stringified (some rejections/throws aren't Error instances).
@@ -906,13 +911,13 @@ const EnvDialog = ({
     rotation, onRotationChange,
     exposure, onExposureChange,
     onImportFile, onReset,
+    envFileName, onClearEnv,
     importError,
     placement,
     edgeRef,
 }) => {
     const popRef = React.useRef(null);
     const [pos, setPos] = React.useState(null);
-    const fileInputRef = React.useRef(null);
     // Key-light extraction toggle: window.getKeyLightEnabled/setKeyLightEnabled
     // live in js/mtlx-engine.js and may be absent (standalone/older builds),
     // so the control degrades to disabled rather than throwing.
@@ -1035,34 +1040,31 @@ const EnvDialog = ({
                     className="w-full accent-blue-500"
                 />
             </div>
-            <div className="flex items-center gap-1.5 pt-1 border-t border-gray-700">
-                <button
-                    onClick={() => fileInputRef.current && fileInputRef.current.click()}
-                    className="flex-1 h-6 rounded border bg-gray-800/80 border-gray-600 text-gray-300 hover:bg-gray-700/80 transition-colors"
-                >
-                    Import…
-                </button>
-                <button
-                    onClick={onReset}
-                    className="flex-1 h-6 rounded border bg-gray-800/80 border-gray-600 text-gray-300 hover:bg-gray-700/80 transition-colors"
-                >
-                    Reset
-                </button>
-                <input
-                    ref={fileInputRef}
-                    type="file"
+            <div>
+                <FilePickerField
+                    value={envFileName}
+                    placeholder="Default environment"
                     accept=".hdr,.exr"
-                    className="hidden"
-                    onChange={(e) => {
-                        const f = e.target.files && e.target.files[0];
-                        e.target.value = '';
+                    icon="file"
+                    onFiles={(files) => {
+                        const f = files && files[0];
                         if (f) onImportFile(f);
                     }}
+                    onClear={onClearEnv}
                 />
             </div>
             {importError && (
                 <div className="text-red-400">{importError}</div>
             )}
+            {/* Bottom-most: resets rotation/exposure too, so it must not
+                sit beside the file picker above (which only clears the
+                imported environment). */}
+            <button
+                onClick={onReset}
+                className="w-full h-6 rounded border bg-gray-800/80 border-gray-600 text-gray-300 hover:bg-gray-700/80 transition-colors"
+            >
+                Reset
+            </button>
         </div>,
         fullscreenPortalRoot()
     );
@@ -1253,6 +1255,90 @@ function GeometryTile({ label, icon, selected, disabled, title, onClick, badge }
     );
 }
 
+// Joined file-picker row (read-only path display + a Choose button), one
+// field-height (~26px) control matching the graph sidebar's field rows.
+// `onChoose` drives a caller's own file dialog; else a hidden file input.
+// `editable`/`onCommit` swap the path area for a real text input; `onClear`
+// adds an x button inside the field when `value` is non-empty.
+function FilePickerField({
+    value, placeholder = 'No file selected', accept, multiple, onFiles, onChoose,
+    editable, onCommit, onClear, disabled, buttonLabel = 'Choose...', icon,
+    // Mono typography is opt-in: only the graph editor's and node specs'
+    // parameter-editing rows want it. Everyone else gets the app's sans.
+    mono = false,
+}) {
+    const buttonCls = 'inline-flex items-center gap-1 border border-l-0 border-gray-700 rounded-r-md bg-gray-800 hover:bg-gray-700 text-[11px] px-2 text-gray-300 whitespace-nowrap'
+        + (mono ? ' font-mono' : '');
+    const [draft, setDraft] = React.useState(value || '');
+    // A ref (not state) so blurring alone never re-triggers the seed
+    // effect below -- only an actual `value` change should re-seed.
+    const focusedRef = React.useRef(false);
+    React.useEffect(() => { if (!focusedRef.current) setDraft(value || ''); }, [value]);
+    const commit = () => {
+        if (draft !== (value || '') && onCommit) onCommit(draft);
+    };
+    const showClear = !!onClear && !!value;
+    const fieldBase = 'bg-gray-900 border border-gray-700 rounded-l-md px-2 text-[11px] text-gray-300 h-full w-full'
+        + (mono ? ' font-mono' : '') + (showClear ? ' pr-6' : '');
+    return (
+        <div className="flex h-[26px]">
+            {/* Wrapper so the clear button can sit INSIDE the field's own
+                right edge (overlay) instead of adding its own bordered slot. */}
+            <div className="relative min-w-0 flex-1">
+                {editable ? (
+                    <input
+                        type="text"
+                        value={draft}
+                        placeholder={placeholder}
+                        disabled={disabled}
+                        onFocus={() => { focusedRef.current = true; }}
+                        onChange={(e) => setDraft(e.target.value)}
+                        onBlur={() => { focusedRef.current = false; commit(); }}
+                        onKeyDown={(e) => { if (e.key === 'Enter') { e.currentTarget.blur(); } }}
+                        className={fieldBase + ' placeholder-gray-500 focus:outline-none'}
+                    />
+                ) : (
+                    <div title={value} className={fieldBase + ' flex items-center'}>
+                        <span className="truncate">
+                            {value || <span className="text-gray-500">{placeholder}</span>}
+                        </span>
+                    </div>
+                )}
+                {showClear && (
+                    <button
+                        type="button"
+                        title="Clear"
+                        disabled={disabled}
+                        onClick={onClear}
+                        className="absolute right-1.5 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-200"
+                    >
+                        <MtlxIcon name="x" className="w-3 h-3" />
+                    </button>
+                )}
+            </div>
+            {onChoose ? (
+                <button type="button" onClick={onChoose} disabled={disabled} className={buttonCls + (disabled ? ' opacity-50 cursor-not-allowed' : '')}>
+                    {icon && <MtlxIcon name={icon} className="w-3.5 h-3.5" />}
+                    {buttonLabel}
+                </button>
+            ) : (
+                <label className={buttonCls + ' cursor-pointer' + (disabled ? ' opacity-50 pointer-events-none' : '')}>
+                    {icon && <MtlxIcon name={icon} className="w-3.5 h-3.5" />}
+                    {buttonLabel}
+                    <input
+                        type="file" accept={accept} multiple={multiple} className="hidden" disabled={disabled}
+                        onChange={(e) => {
+                            if (onFiles) onFiles(e.target.files);
+                            // Clear so re-picking the SAME file still fires a change event.
+                            e.target.value = '';
+                        }}
+                    />
+                </label>
+            )}
+        </div>
+    );
+}
+
 const ViewportControls = ({
     geomList = ['shaderball', 'shaderball-scene', 'shaderball-mtlx', 'sphere', 'cube', 'cloth'],
     geom, onGeomChange,
@@ -1309,6 +1395,8 @@ const ViewportControls = ({
     const [envRotation, setEnvRotation] = React.useState(0);   // degrees, 0-360
     const [envExposure, setEnvExposure] = React.useState(1.0);
     const [envImportError, setEnvImportError] = React.useState(null);
+    // Imported environment's filename, shown by EnvDialog's FilePickerField.
+    const [envFileName, setEnvFileName] = React.useState('');
     const [settingsOpen, setSettingsOpen] = React.useState(false);
 
     // Re-apply rotation/exposure to the current view on every (re)build
@@ -1333,9 +1421,19 @@ const ViewportControls = ({
             // one) via the engine's LIVE_VIEWS registry — no need to also
             // call viewRef.current.setEnvironment here.
             window.setEnvOverride(env);
+            setEnvFileName(file.name);
         } catch (e) {
             setEnvImportError(errMsg(e));
         }
+    };
+
+    // FilePickerField's own x button: clears the imported environment back
+    // to the default WITHOUT touching rotation/exposure -- that stays the
+    // Reset button's job below.
+    const handleClearEnv = () => {
+        window.setEnvOverride(null);
+        setEnvImportError(null);
+        setEnvFileName('');
     };
 
     const handleReset = () => {
@@ -1344,6 +1442,7 @@ const ViewportControls = ({
         // needed here.
         window.setEnvOverride(null);
         setEnvImportError(null);
+        setEnvFileName('');
         setEnvRotation(0);
         setEnvExposure(1.0);
         if (viewRef && viewRef.current) {
@@ -1442,6 +1541,8 @@ const ViewportControls = ({
                                 }}
                                 onImportFile={handleImportFile}
                                 onReset={handleReset}
+                                envFileName={envFileName}
+                                onClearEnv={handleClearEnv}
                                 importError={envImportError}
                             />
                         )}
@@ -1920,7 +2021,7 @@ const MtlxSelect = ({
     icon, icons, titles, disabledOptions, disabled, placeholder, emptyOption,
     size = 'sm', variant = 'toolbar', block, font,
     popMaxHeight, theme,
-    commitFocus = 'trigger', ariaLabel,
+    commitFocus = 'trigger', ariaLabel, align,
 }) => {
     const [open, setOpen] = React.useState(false);
     const [pos, setPos] = React.useState(null);
@@ -2133,9 +2234,16 @@ const MtlxSelect = ({
     // its own chrome from size/variant, and className is appended for
     // positioning/flex sizing/margins on top of that.
     const chrome = 'rounded ' + (SELECT_SIZE_CLS[size] || SELECT_SIZE_CLS.sm) + ' ' + (SELECT_VARIANT_CLS[variant] || SELECT_VARIANT_CLS.toolbar);
+    // Default (no `align`, i.e. today's every call site): `justify-between`
+    // across icon/label/chevron splits the free width into two roughly
+    // equal gaps, which visually centers the label once an icon is
+    // present -- that's the reported "centered" look. `align="left"`
+    // drops justify-between so icon+label pack flush left; the chevron
+    // gets ml-auto below to stay pinned at the right edge instead.
+    const alignLeft = align === 'left';
     const triggerClassName = [
         chrome, 'inline-flex items-center gap-1',
-        block && 'w-full justify-between',
+        block && (alignLeft ? 'w-full' : 'justify-between'),
         fontCls,
         disabled && 'opacity-50 pointer-events-none',
         className,
@@ -2223,7 +2331,7 @@ const MtlxSelect = ({
                         {o.badge && (
                             <span
                                 style={o.badge.tone === 'warn' ? { color: MXS_BADGE_WARN } : undefined}
-                                className={'flex-none text-[9px] uppercase tracking-wide px-1 py-0.5 rounded border ' + SELECT_BADGE_TONE_CLS[o.badge.tone]}
+                                className={'flex-none font-sans text-[9px] uppercase tracking-wide px-1 py-0.5 rounded border ' + SELECT_BADGE_TONE_CLS[o.badge.tone]}
                             >{o.badge.text}</span>
                         )}
                     </button>
@@ -2253,7 +2361,7 @@ const MtlxSelect = ({
             >
                 {icon && <MtlxIcon name={icon} className="w-3.5 h-3.5 flex-none" />}
                 <span className="truncate" style={{ color: showPlaceholder ? MXS_MUTED : undefined }}>{triggerLabel}</span>
-                <MtlxIcon name="chevron-down" className="w-3 h-3 flex-none opacity-70" />
+                <MtlxIcon name="chevron-down" className={'w-3 h-3 flex-none opacity-70' + (alignLeft ? ' ml-auto' : '')} />
             </button>
             {popover && ReactDOM.createPortal(popover, fullscreenPortalRoot())}
         </React.Fragment>
@@ -2621,8 +2729,9 @@ Object.assign(window, {
     ColorSwatch, MtlxSelect, MtlxMenu, MtlxMenuBar, PreviewErrorBoundary,
     fullscreenPortalRoot,
     BTN_MENUBAR,
+    HUD_PILL, HUD_PILL_ACTIVE,
     DialogFrame, PresetsDialog, SettingsDialog, MTLX_PRESETS, MTLX_PRESETS_BASE,
     fetchPresetFiles, fetchRemoteDocumentFiles, copyTextToClipboard, ShaderExportDialog,
-    TEXT_INPUT_CLS, FieldLabel, Toggle, SliderField, Chip, SectionCard, GeometryTile,
+    TEXT_INPUT_CLS, FieldLabel, Toggle, SliderField, Chip, SectionCard, GeometryTile, FilePickerField,
     EV_MIN, EV_MAX, EV_STEP, evToLinear, linearToEv, formatEv,
 });

--- a/js/shared/ui-commons.js
+++ b/js/shared/ui-commons.js
@@ -63,6 +63,8 @@ const MTLX_ICON_PATHS = {
     'file-check': { filled: false, inner: '<path d="M14 3v4a1 1 0 0 0 1 1h4" /><path d="M17 21h-10a2 2 0 0 1 -2 -2v-14a2 2 0 0 1 2 -2h7l5 5v11a2 2 0 0 1 -2 2z" /><path d="M9 15l2 2l4 -4" />' },
     'file-x': { filled: false, inner: '<path d="M14 3v4a1 1 0 0 0 1 1h4" /><path d="M17 21h-10a2 2 0 0 1 -2 -2v-14a2 2 0 0 1 2 -2h7l5 5v11a2 2 0 0 1 -2 2z" /><path d="M10 12l4 4m0 -4l-4 4" />' },
     'file-infinity': { filled: false, inner: '<path d="M15.536 17.586a2.123 2.123 0 0 0 -2.929 0a1.951 1.951 0 0 0 0 2.828c.809 .781 2.12 .781 2.929 0c.809 -.781 -.805 .778 0 0l1.46 -1.41l1.46 -1.419" /><path d="M15.54 17.582l1.46 1.42l1.46 1.41c.809 .78 -.805 -.779 0 0s2.12 .781 2.929 0a1.951 1.951 0 0 0 0 -2.828a2.123 2.123 0 0 0 -2.929 0" /><path d="M14 3v4a1 1 0 0 0 1 1h4" /><path d="M9.5 21h-2.5a2 2 0 0 1 -2 -2v-14a2 2 0 0 1 2 -2h7l5 5v6" />' },
+    file: { filled: false, inner: '<path d="M14 3v4a1 1 0 0 0 1 1h4" /><path d="M17 21h-10a2 2 0 0 1 -2 -2v-14a2 2 0 0 1 2 -2h7l5 5v11a2 2 0 0 1 -2 2z" />' },
+    files: { filled: false, inner: '<path d="M15 3v4a1 1 0 0 0 1 1h4" /><path d="M18 17h-7a2 2 0 0 1 -2 -2v-10a2 2 0 0 1 2 -2h4l5 5v7a2 2 0 0 1 -2 2z" /><path d="M16 17v2a2 2 0 0 1 -2 2h-7a2 2 0 0 1 -2 -2v-10a2 2 0 0 1 2 -2h2" />' },
     'book': { filled: false, inner: '<path d="M3 19a9 9 0 0 1 9 0a9 9 0 0 1 9 0"/><path d="M3 6a9 9 0 0 1 9 0a9 9 0 0 1 9 0"/><path d="M3 6l0 13"/><path d="M12 6l0 13"/><path d="M21 6l0 13"/>' },
     'plug': { filled: false, inner: '<path d="M9.785 6l8.215 8.215l-2.054 2.054a5.81 5.81 0 1 1 -8.215 -8.215l2.054 -2.054z"/><path d="M4 20l3.5 -3.5"/><path d="M15 4l-3.5 3.5"/><path d="M20 9l-3.5 3.5"/>' },
     'puzzle': { filled: false, inner: '<path d="M4 7h3a1 1 0 0 0 1 -1v-1a2 2 0 0 1 4 0v1a1 1 0 0 0 1 1h3a1 1 0 0 1 1 1v3a1 1 0 0 0 1 1h1a2 2 0 0 1 0 4h-1a1 1 0 0 0 -1 1v3a1 1 0 0 1 -1 1h-3a1 1 0 0 1 -1 -1v-1a2 2 0 0 0 -4 0v1a1 1 0 0 1 -1 1h-3a1 1 0 0 1 -1 -1v-3a1 1 0 0 1 1 -1h1a2 2 0 0 0 0 -4h-1a1 1 0 0 1 -1 -1v-3a1 1 0 0 1 1 -1"/>' },
@@ -117,7 +119,54 @@ const MtlxIcon = (props) => {
     });
 };
 
-Object.assign(window, { MtlxIcon, MTLX_ICON_PATHS });
+// Shared floating-pill family for controls overlaid on 3D stages, two
+// sizes: PILL_ACTION (default) and PILL_ACTION_SM (compact variant).
+const PILL_ACTION = 'inline-flex items-center gap-1.5 h-7 px-2.5 rounded-lg border border-gray-600/50 bg-gray-900/70 text-xs font-medium text-gray-400 hover:bg-gray-700 hover:border-gray-600 hover:text-gray-100 [&:hover_svg]:text-gray-100 transition-colors disabled:opacity-60 disabled:cursor-wait';
+const PILL_ACTION_SM = 'inline-flex items-center gap-1 h-6 px-2 rounded-md border border-gray-600/50 bg-gray-900/70 text-[11px] font-medium text-gray-400 hover:bg-gray-700 hover:border-gray-600 hover:text-gray-100 [&:hover_svg]:text-gray-100 transition-colors disabled:opacity-60 disabled:cursor-wait';
+
+Object.assign(window, { MtlxIcon, MTLX_ICON_PATHS, PILL_ACTION, PILL_ACTION_SM });
+
+// Shared node-type palette: single source for the graph legend and
+// the docs port tables, so a type's dot color always matches its
+// legend color no matter which view renders it.
+const TYPE_COLORS = {
+    boolean: '#d2372b',            // crimson red
+    BSDF: '#2e7d32',               // forest green
+    color3: '#fdd835',             // sunflower yellow
+    color4: '#f4511e',             // coral orange
+    displacementshader: '#8d6e63', // warm taupe
+    EDF: '#cddc39',                // yellow-green
+    filename: '#90a4ae',           // cool blue-gray
+    float: '#3949ab',              // deep indigo blue
+    integer: '#8e24aa',            // royal violet
+    lightshader: '#ff934f',        // warm apricot orange
+    material: '#ff404f',           // vivid red
+    matrix33: '#cfd8dc',           // pale blue-gray
+    matrix44: '#546e7a',           // slate blue-gray
+    string: '#d7c4a3',             // warm sand
+    surfaceshader: '#00897b',      // deep teal
+    vector2: '#5c6bc0',            // muted indigo
+    vector3: '#b388ff',            // soft lavender
+    vector4: '#ec407a',            // rose pink
+    VDF: '#9ccc65',                // fresh green
+    volumeshader: '#00bcd4',       // bright cyan
+    node: '#a1887f',               // muted warm stone
+    nodegraph: '#854d0e'           // bronze brown
+};
+// Stable string hash → hue; fixed saturation/lightness keeps hashed
+// colors legible on the dark stage.
+const typeHue = (s) => {
+    let h = 0;
+    for (let i = 0; i < s.length; i++) h = ((h << 5) - h + s.charCodeAt(i)) | 0;
+    return ((h % 360) + 360) % 360;
+};
+const typeColor = (t) => {
+    if (!t) return '#94a3b8'; // untyped: default slate
+    if (TYPE_COLORS[t]) return TYPE_COLORS[t];
+    return 'hsl(' + typeHue(String(t)) + ', 65%, 62%)';
+};
+
+Object.assign(window, { TYPE_COLORS, typeHue, typeColor });
 
 // ------------------------------------------------------------------
 // Global error capture (browser-side). Until now there was no

--- a/js/viewer-app.jsx
+++ b/js/viewer-app.jsx
@@ -656,15 +656,18 @@
                     });
             }, []);
 
-            const onPickFiles = (e) => {
+            const onPickFileList = (fileList) => {
                 const map = {};
-                for (const f of Array.from(e.target.files || [])) {
+                for (const f of Array.from(fileList || [])) {
                     // webkitdirectory inputs carry relative paths
                     map[f.webkitRelativePath || f.name] = f;
                 }
-                e.target.value = '';
                 setPresetPick('');
                 ingest(map);
+            };
+            const onPickFiles = (e) => {
+                onPickFileList(e.target.files);
+                e.target.value = '';
             };
 
             const loadDocument = async (path, mapArg, versionArg) => {
@@ -790,6 +793,71 @@
                 };
             }, [renderables, chosenMat, geom]);
 
+            // Backs the Scene card's transparency-forcing toggle (browser
+            // only): local mirror of the engine's persisted value, replacing
+            // the old HUD settings popover's only built-in block.
+            const [forceTransparency, setForceTransparency] = React.useState(
+                () => !!(window.getForceTransparency && window.getForceTransparency())
+            );
+
+            // Environment card state (browser only): envBg stays the
+            // existing hook state above; rotation/exposure live here since
+            // the HUD's env cluster is gone in the browser.
+            const [envUI, setEnvUI] = React.useState({ rotation: 0, exposure: 1 });
+            const [envImportError, setEnvImportError] = React.useState(null);
+            const [envFileName, setEnvFileName] = React.useState('');
+
+            const setEnvRotationDeg = (v) => {
+                setEnvUI((s) => ({ ...s, rotation: v }));
+                if (viewRef.current && viewRef.current.setEnvRotation) viewRef.current.setEnvRotation(v * Math.PI / 180);
+            };
+            const setEnvExposureVal = (v) => {
+                setEnvUI((s) => ({ ...s, exposure: v }));
+                if (viewRef.current && viewRef.current.setEnvExposure) viewRef.current.setEnvExposure(v);
+            };
+            const importEnv = async (file) => {
+                setEnvImportError(null);
+                try {
+                    const env = await loadEnvironmentFromFile(file);
+                    setEnvOverride(env);
+                    setEnvFileName(file.name);
+                } catch (e) {
+                    setEnvImportError(errMsg(e));
+                }
+            };
+            // Clears an imported environment back to the default WITHOUT
+            // touching rotation/exposure: that stays the Reset button's job.
+            const clearEnvOverride = () => {
+                setEnvOverride(null);
+                setEnvImportError(null);
+                setEnvFileName('');
+            };
+            const resetEnv = () => {
+                setEnvOverride(null);
+                setEnvImportError(null);
+                setEnvFileName('');
+                setEnvUI({ rotation: 0, exposure: 1 });
+                if (viewRef.current) {
+                    if (viewRef.current.setEnvRotation) viewRef.current.setEnvRotation(0);
+                    if (viewRef.current.setEnvExposure) viewRef.current.setEnvExposure(1.0);
+                }
+            };
+            const envSummary = (envUI.rotation === 0 && envUI.exposure === 1)
+                ? 'Default'
+                : Math.round(envUI.rotation) + '°, ' + formatEv(linearToEv(envUI.exposure));
+
+            // Re-applies the sidebar's env sliders to a freshly (re)built
+            // view; chromeless has no sidebar, so this no-ops there and the
+            // render effect's own controlled-prop application stands alone.
+            React.useEffect(() => {
+                if (chromeless) return;
+                const v = viewRef.current;
+                if (!v) return;
+                if (v.setEnvRotation) v.setEnvRotation(envUI.rotation * Math.PI / 180);
+                if (v.setEnvExposure) v.setEnvExposure(envUI.exposure);
+                // eslint-disable-next-line react-hooks/exhaustive-deps
+            }, [viewEpoch]);
+
             const fileCount = Object.keys(fileMap).length;
             const texCount = Object.keys(fileMap).filter((k) => IMG_EXT.test(k)).length;
 
@@ -820,6 +888,20 @@
             // hidden when there's nothing to switch between.
             const showMaterial = showCtl('material') && renderables.length > 1;
             const anyCtlVisible = Object.values(ctlFlags).some(Boolean) || showMaterial;
+            // Non-chromeless HUD cluster layout: geometry/env/settings moved
+            // into the sidebar's Scene/Environment cards in the browser, so
+            // only IN_VSCODE (no sidebar there) keeps those in its clusters.
+            const hudClusters = IN_VSCODE
+                ? [
+                    ['geom', 'rotate', 'cameraReset', 'env'],
+                    ['screenshot', 'shaderCode', 'sendToGraph'],
+                    ['presets', 'settings', 'fullscreen'],
+                ]
+                : [
+                    ['rotate', 'cameraReset'],
+                    ['screenshot', 'shaderCode', 'sendToGraph'],
+                    ['presets', 'fullscreen'],
+                ];
             // Page-transparency CSS: requested AND resolved away from the
             // room. Belt-and-suspenders alongside resolveViewerGeom's own
             // guard above, in case geom ever drifts back to the room.
@@ -834,37 +916,41 @@
 
             // 28px HUD chip classes, shared by ViewportControls' built-in
             // slots (via buttonClassName) and the custom sendToGraph/
-            // presets/shaderCode buttons below.
-            const hudChipClass = (active) => `h-7 w-7 inline-flex items-center justify-center rounded border transition-colors ${
-                active
-                    ? 'bg-blue-600/80 border-blue-500 text-white'
-                    : 'bg-gray-800/80 border-gray-600 text-gray-300 hover:bg-gray-700/80'
-            }`;
+            // presets/shaderCode buttons below. VS Code stays icon-only and
+            // square; the browser HUD grows labels via HUD_PILL/HUD_PILL_ACTIVE.
+            const hudChipClass = (active) => IN_VSCODE
+                ? `h-7 w-7 justify-center inline-flex items-center rounded-lg border transition-colors ${
+                    active
+                        ? 'bg-blue-600/80 border-blue-500 text-white'
+                        : 'border-gray-600/50 bg-gray-900/70 text-gray-400 hover:bg-gray-700 hover:border-gray-600 hover:text-gray-100'
+                }`
+                : (active ? HUD_PILL_ACTIVE : HUD_PILL);
 
             // Files sidebar body: Document/Materials/Textures cards, split
             // out so the docked panel's own JSX (below) stays flat.
             const filesPanelBody = (
                 <div className="flex-1 overflow-y-auto custom-scrollbar p-3.5 space-y-4">
                     <SectionCard icon="file-text" title="Document" summary={docBasename} defaultOpen>
-                        <div
-                            className={`rounded-lg border-2 border-dashed p-4 text-center transition-colors ${
-                                dragOver ? 'border-blue-500 bg-blue-950/30' : 'border-gray-600 bg-gray-800'
-                            }`}
-                        >
-                            <MtlxIcon name="file-upload" className="w-8 h-8 block mx-auto mb-2 text-gray-400" />
-                            <div className="text-sm text-gray-300 font-medium">Drop .mtlx, textures, a folder or a .zip</div>
-                            <div className="text-xs text-gray-500 mt-1">anywhere on the page, or</div>
-                            <div className="flex items-center justify-center gap-2 mt-3 flex-wrap">
-                                <label className={BTN_SECONDARY + ' cursor-pointer'}>
-                                    Choose files
-                                    <input type="file" multiple className="hidden" onChange={onPickFiles} />
-                                </label>
-                                <label className={BTN_SECONDARY + ' cursor-pointer'}>
-                                    Choose folder
-                                    <input type="file" webkitdirectory="" directory="" multiple className="hidden" onChange={onPickFiles} />
-                                </label>
+                        <div className="flex items-center gap-1">
+                            <div className="flex-1 min-w-0">
+                                <FilePickerField
+                                    value={currentMtlxPath ? docBasename : ''}
+                                    placeholder="No document loaded"
+                                    multiple
+                                    icon="files"
+                                    accept=".mtlx,.zip,.png,.jpg,.jpeg,.webp,.gif,.bmp,.tga,.exr,.hdr,.tif,.tiff"
+                                    onFiles={onPickFileList}
+                                />
                             </div>
+                            <label
+                                title="Choose a folder"
+                                className="h-[26px] w-[26px] shrink-0 inline-flex items-center justify-center border border-gray-700 rounded-md bg-gray-800 hover:bg-gray-700 text-gray-300 cursor-pointer"
+                            >
+                                <MtlxIcon name="folder" className="w-3.5 h-3.5" />
+                                <input type="file" webkitdirectory="" directory="" multiple className="hidden" onChange={onPickFiles} />
+                            </label>
                         </div>
+                        <div className="text-xs text-gray-500">or drag-and-drop anywhere on the page</div>
 
                         {chosenMtlx && (
                             <div className="text-xs text-gray-500">
@@ -939,7 +1025,7 @@
                     </SectionCard>
 
                     {renderables.length > 1 && (
-                        <SectionCard icon="color-swatch" title="Materials" summary={currentMaterialName}>
+                        <SectionCard icon="color-swatch" title="Materials" summary={currentMaterialName} defaultOpen>
                             <MtlxSelect
                                 value={chosenMat}
                                 options={renderables.map((r, i) => ({ value: i, label: r.name }))}
@@ -951,8 +1037,83 @@
                         </SectionCard>
                     )}
 
+                    <SectionCard icon="cube" title="Scene" summary={GEOM_LABELS[geom] || geom} defaultOpen>
+                        <div className="grid grid-cols-2 gap-2">
+                            {VIEWER_GEOM_NAMES.map((g) => (
+                                <GeometryTile
+                                    key={g}
+                                    label={GEOM_LABELS[g] || g}
+                                    icon={GEOM_ICONS[g]}
+                                    selected={geom === g}
+                                    onClick={() => setGeom(g)}
+                                    badge={g === 'shaderball-scene' ? 'Default' : undefined}
+                                />
+                            ))}
+                        </div>
+                    </SectionCard>
+
+                    <SectionCard icon="sun" title="Environment" summary={envSummary} defaultOpen dense>
+                        <SliderField
+                            label="Environment rotation" unit="deg"
+                            value={envUI.rotation} min={0} max={360} step={1}
+                            onSlider={(v) => setEnvRotationDeg(Number(v))}
+                            onNumber={(v) => setEnvRotationDeg(Number(v))}
+                        />
+                        <SliderField
+                            label="Exposure" unit="EV"
+                            value={linearToEv(envUI.exposure)} min={EV_MIN} max={EV_MAX} step={EV_STEP}
+                            onSlider={(v) => setEnvExposureVal(evToLinear(v))}
+                            onNumber={(v) => setEnvExposureVal(evToLinear(v))}
+                        />
+                        <label className="flex items-center justify-between cursor-pointer">
+                            <span className="text-xs font-medium text-gray-400">Show environment as background</span>
+                            <Toggle checked={envBg} onChange={() => toggleEnvBg()} />
+                        </label>
+                        <FilePickerField
+                            value={envFileName}
+                            placeholder="Default environment"
+                            accept=".hdr,.exr"
+                            icon="file"
+                            onFiles={(files) => {
+                                const f = files && files[0];
+                                if (f) importEnv(f);
+                            }}
+                            onClear={clearEnvOverride}
+                        />
+                        {envImportError && <div className="text-xs text-red-400">{envImportError}</div>}
+                        <button
+                            onClick={resetEnv}
+                            title="Also clears an imported .hdr/.exr and restores the default environment"
+                            className={BTN_SECONDARY + ' w-full'}
+                        >
+                            Reset
+                        </button>
+                    </SectionCard>
+
+                    <SectionCard icon="settings-cog" title="Rendering" summary={forceTransparency ? 'Transparency forced' : 'Default'} defaultOpen>
+                        <label
+                            className="flex items-center justify-between cursor-pointer"
+                            title={forceTransparency ? 'Disable forced transparency' : 'Enable forced transparency'}
+                        >
+                            <span className="inline-flex items-center gap-1.5 text-xs font-medium text-gray-400">
+                                Force Transparency
+                                <span className="text-[9px] uppercase tracking-wide px-1 py-0.5 rounded bg-amber-600/30 border border-amber-500/50 text-amber-300">Experimental</span>
+                            </span>
+                            <Toggle
+                                checked={forceTransparency}
+                                onChange={(next) => {
+                                    setForceTransparency(next);
+                                    window.setForceTransparency && window.setForceTransparency(next);
+                                }}
+                            />
+                        </label>
+                        <div className="mt-1 text-[11px] text-gray-400">
+                            Render opacity/transmission with real alpha blending in previews. When off, previews match the standard MaterialX viewer (opaque). Applies immediately to open previews.
+                        </div>
+                    </SectionCard>
+
                     {texReport && texReport.missing.length > 0 && (
-                        <SectionCard icon="alert-triangle" title="Textures" summary={texReport.missing.length + ' unresolved'}>
+                        <SectionCard icon="alert-triangle" title="Textures" summary={texReport.missing.length + ' unresolved'} defaultOpen>
                             <div className="space-y-2">
                                 {texReport.missing.map((m, i) => (
                                     <div key={'m' + i} className="flex items-start gap-1 text-amber-300/90 font-mono text-xs break-all" title="Referenced by the document but not found among the dropped files, so the image node's default color is shown instead.">
@@ -1043,14 +1204,18 @@
                                     />
                                     ) : (
                                     <ViewportControls
-                                        containerClassName="absolute top-2 right-2 z-10 flex items-center gap-2.5"
+                                        containerClassName={IN_VSCODE
+                                            ? 'absolute top-2 right-2 z-10 flex items-center gap-2.5'
+                                            : 'absolute top-2 right-2 z-10 flex items-center gap-2.5 flex-wrap justify-end max-w-[calc(100%-5rem)]'}
                                         clusterClassName="flex items-center gap-1"
                                         selectSize="md"
                                         buttonClassName={hudChipClass}
                                         geom={geom}
                                         onGeomChange={setGeom}
                                         geomBadges={{ 'shaderball-scene': 'Default' }}
-                                        showGeomSelect={showCtl('geometry')}
+                                        // Geometry now lives in the sidebar's Scene card in the
+                                        // browser; VS Code has no sidebar, so it keeps the select.
+                                        showGeomSelect={IN_VSCODE}
                                         rotating={rotating}
                                         onToggleRotating={toggleRotating}
                                         // Engine no-ops auto-rotate for the full scene, and the
@@ -1059,22 +1224,22 @@
                                         showRotate={showCtl('rotate') && geom !== 'shaderball-scene'}
                                         showBackgroundToggle={geom !== 'shaderball-scene'}
                                         onCameraReset={showCtl('reset') ? handleCameraReset : undefined}
-                                        envAvail={showCtl('env')}
+                                        // Env cluster moved into the sidebar's Environment card in
+                                        // the browser; VS Code keeps the HUD's own env popover.
+                                        envAvail={IN_VSCODE}
                                         envBg={envBg}
                                         onToggleEnvBg={toggleEnvBg}
                                         viewRef={viewRef}
                                         viewEpoch={viewEpoch}
                                         onScreenshot={takeScreenshot}
                                         showScreenshot={showCtl('screenshot')}
-                                        showSettings={showCtl('settings')}
+                                        // Settings cog's only content (the transparency
+                                        // toggle) moved into the sidebar's Scene card.
+                                        showSettings={IN_VSCODE}
                                         isFullscreen={isFullscreen}
                                         onToggleFullscreen={showCtl('fullscreen') ? onToggleFullscreen : undefined}
-                                        showLabels={false}
-                                        clusters={[
-                                            ['geom', 'rotate', 'cameraReset', 'env'],
-                                            ['screenshot', 'shaderCode', 'sendToGraph'],
-                                            ['presets', 'settings', 'fullscreen'],
-                                        ]}
+                                        showLabels={!IN_VSCODE}
+                                        clusters={hudClusters}
                                         slots={{
                                             // Graph and viewer are always in sync in the
                                             // extension (one opened .mtlx file), so this
@@ -1085,9 +1250,10 @@
                                                     onClick={sendToEditor}
                                                     title="Open this material in the Node Graph Editor"
                                                     disabled={!renderables.length}
-                                                    className={hudChipClass(false) + ' disabled:opacity-40'}
+                                                    className={hudChipClass(false)}
                                                 >
                                                     <MtlxIcon name="transfer" className="w-3.5 h-3.5" />
+                                                    {!IN_VSCODE && <span className="ml-1.5 whitespace-nowrap">Send to Editor</span>}
                                                 </button>
                                             ) : null,
                                             // Presets: browser-only (VS Code is bound to the open file).
@@ -1099,6 +1265,7 @@
                                                     className={hudChipClass(false)}
                                                 >
                                                     <MtlxIcon name="presets" className="w-3.5 h-3.5" />
+                                                    {!IN_VSCODE && <span className="ml-1.5 whitespace-nowrap">Presets</span>}
                                                 </button>
                                             ) : null,
                                             // Not VS Code-gated: generating shader source
@@ -1109,9 +1276,10 @@
                                                     onClick={() => setShaderExportOpen(true)}
                                                     title="Generate this material's shader source for a chosen target language (GLSL, OSL, MDL, ...)"
                                                     disabled={!renderables.length}
-                                                    className={hudChipClass(false) + ' disabled:opacity-40'}
+                                                    className={hudChipClass(false)}
                                                 >
                                                     <MtlxIcon name="file-code" className="w-3.5 h-3.5" />
+                                                    {!IN_VSCODE && <span className="ml-1.5 whitespace-nowrap">Shader Code</span>}
                                                 </button>
                                             ),
                                         }}
@@ -1159,7 +1327,15 @@
                                     return (
                                         <div className="absolute bottom-2 left-2 z-10 pointer-events-none flex items-center gap-2 px-2 py-1 rounded-full bg-black/60 text-[11px] text-white/90">
                                             <span className="w-1.5 h-1.5 rounded-full bg-green-400 shrink-0" />
-                                            <span>{segments.join(' | ')}</span>
+                                            {segments.map((seg, i) => {
+                                                const isVersion = i === segments.length - 1 && seg.charAt(0) === 'v';
+                                                return (
+                                                    <React.Fragment key={i}>
+                                                        {i > 0 && <span className="text-white/40">/</span>}
+                                                        <span className={isVersion ? 'font-mono' : undefined}>{seg}</span>
+                                                    </React.Fragment>
+                                                );
+                                            })}
                                         </div>
                                     );
                                 })()}
@@ -1182,11 +1358,11 @@
                     {!IN_VSCODE && !chromeless && !sidebarOpen && (
                         <button
                             onClick={() => setSidebarOpen(true)}
-                            title="Expand the files panel"
-                            className="absolute top-2 left-2 z-30 h-7 inline-flex items-center gap-1.5 text-[11px] px-2 rounded border bg-gray-800/80 backdrop-blur border-gray-600 text-gray-300 hover:bg-gray-700/80 transition-colors"
+                            title="Expand the viewer panel"
+                            className={'absolute top-2 left-2 z-30 ' + HUD_PILL}
                         >
                             <MtlxIcon name="chevrons-right" className="w-4 h-4" />
-                            <span className="max-w-[5rem] md:max-w-[8rem] truncate">Files</span>
+                            <span className="max-w-[5rem] md:max-w-[8rem] truncate">Viewer</span>
                         </button>
                     )}
                 </React.Fragment>
@@ -1217,10 +1393,10 @@
                     {!IN_VSCODE && !chromeless && sidebarOpen && (
                         <div className="flex-none w-80 max-w-[90%] flex flex-col bg-gray-900 border-r border-gray-700 overflow-hidden">
                             <div className="flex-none flex items-center px-3 py-2 border-b border-gray-700">
-                                <span className="text-[13px] font-semibold text-gray-200">Files</span>
+                                <span className="text-[13px] font-semibold text-gray-200">Viewer</span>
                                 <button
                                     onClick={() => setSidebarOpen(false)}
-                                    title="Collapse the files panel"
+                                    title="Collapse the viewer panel"
                                     className="flex-none ml-auto text-gray-400 hover:text-gray-200 px-1 leading-none text-sm"
                                 ><MtlxIcon name="chevrons-left" className="w-4 h-4" /></button>
                             </div>

--- a/js/what-is-materialx.jsx
+++ b/js/what-is-materialx.jsx
@@ -14,11 +14,6 @@ const TRANSPARENT_PIXEL = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAA
 // so a portrait pane on narrow screens still can't clip, well inside 3.6.
 const HERO_CAMERA = '0,0.35,2.8,0,0,0';
 
-// ViewerPane's hover-action pill: a smaller variant of home-app.jsx's
-// HeroStage pillClass, used on every preview on this page (hero, showcase,
-// "See it") so they all read as one consistent family, just smaller.
-const PILL_CLASS = 'inline-flex items-center gap-1 h-6 px-2 rounded-md border border-gray-600/50 bg-gray-900/70 text-[11px] font-medium text-gray-400 hover:bg-gray-700 hover:border-gray-600 hover:text-gray-100 [&:hover_svg]:text-gray-100 transition-colors disabled:opacity-60 disabled:cursor-wait';
-
 // "What it actually is", four pillar cards in reading order.
 const WHAT_PILLARS = [
     { icon: 'article', title: 'An open standard', desc: (<>MaterialX is an open standard, with <code className={CODE_CLASS}>.mtlx</code> as its XML file format for writing a look down and moving it between applications.</>) },
@@ -32,9 +27,7 @@ const WHAT_NOT = [
     { title: 'Not a renderer', desc: 'MaterialX does not render anything itself. It describes a look; a renderer or engine turns that description into pixels.' },
     { title: 'Not a DCC or authoring app', desc: 'There is no MaterialX modeling or animation tool. Artists build looks inside a DCC, or a tool like this Playground, then save the result as .mtlx.' },
     { title: 'Not a single fixed shading model', desc: (<><code className={CODE_CLASS}>standard_surface</code>, OpenPBR Surface, glTF PBR and the others are all node graphs built from the standard library, not hardcoded modes.</>) },
-    { title: 'No promise of identical pixels', desc: (<>The spec asks implementations to support standard nodes{' '}
-        <a href={window.SITE_LINKS.spec} target="_blank" rel="noopener noreferrer" className="text-blue-400 hover:text-blue-300 underline decoration-blue-500/40">"to the degree their architecture and capabilities allow."</a>{' '}
-        A look transfers without being rebuilt; rendering it in two engines is not guaranteed to look pixel-identical.</>) },
+    { title: 'No promise of identical pixels', desc: 'A look transfers without being rebuilt and should render closely everywhere; two engines still are not guaranteed to produce identical pixels.' },
 ];
 
 // Glossary cards: an artist-readable line first, a precise one second.
@@ -277,7 +270,7 @@ function ViewerPane({ src, label, glow, className, geometry, transparent, autoro
                             {actions && actions.length > 0 && (
                                 <div className="absolute bottom-2 left-0 right-0 flex justify-center gap-2 transition-all duration-150 opacity-0 translate-y-1 pointer-events-none group-hover:opacity-100 group-hover:translate-y-0 group-hover:pointer-events-auto focus-within:opacity-100 focus-within:translate-y-0 focus-within:pointer-events-auto [@media(hover:none)]:opacity-100 [@media(hover:none)]:translate-y-0 [@media(hover:none)]:pointer-events-auto">
                                     {actions.map((a) => (
-                                        <button key={a.label} type="button" disabled={actionsBusy} onClick={a.onClick} className={PILL_CLASS}>
+                                        <button key={a.label} type="button" disabled={actionsBusy} onClick={a.onClick} className={PILL_ACTION_SM}>
                                             <MtlxIcon name={a.icon} className="w-3 h-3 text-gray-500 transition-colors" />
                                             {a.busy ? 'Loading' : a.label}
                                         </button>
@@ -569,11 +562,11 @@ function WhatIsMaterialXApp({ active } = {}) {
                            clears both the graph's own React Flow attribution and the
                            3D column's reset button, which both sit at the far right. */}
                         <div className="absolute bottom-2 left-0 right-0 flex justify-center gap-2 transition-all duration-150 opacity-0 translate-y-1 pointer-events-none group-hover:opacity-100 group-hover:translate-y-0 group-hover:pointer-events-auto focus-within:opacity-100 focus-within:translate-y-0 focus-within:pointer-events-auto [@media(hover:none)]:opacity-100 [@media(hover:none)]:translate-y-0 [@media(hover:none)]:pointer-events-auto">
-                            <button type="button" disabled={!!seeItBusy} onClick={() => openSeeItIn('viewer')} className={PILL_CLASS}>
+                            <button type="button" disabled={!!seeItBusy} onClick={() => openSeeItIn('viewer')} className={PILL_ACTION_SM}>
                                 <MtlxIcon name="camera" className="w-3 h-3 text-gray-500 transition-colors" />
                                 {seeItBusy === 'viewer' ? 'Loading' : 'Open in Viewer'}
                             </button>
-                            <button type="button" disabled={!!seeItBusy} onClick={() => openSeeItIn('graph')} className={PILL_CLASS}>
+                            <button type="button" disabled={!!seeItBusy} onClick={() => openSeeItIn('graph')} className={PILL_ACTION_SM}>
                                 <MtlxIcon name="share" className="w-3 h-3 text-gray-500 transition-colors" />
                                 {seeItBusy === 'graph' ? 'Loading' : 'Open in Graph Editor'}
                             </button>
@@ -748,12 +741,14 @@ function WhatIsMaterialXApp({ active } = {}) {
                         </div>
                         <div className="bg-gray-800 border border-gray-800 rounded-xl px-5 py-[18px] flex flex-col gap-1">
                             <h3 className="text-[15px] font-semibold text-gray-100 mb-1.5">Official sources</h3>
-                            {officialLinks.map((l) => (
-                                <a key={l.href} href={l.href} target="_blank" rel="noopener noreferrer" className="group flex items-center gap-2.5 py-1.5 text-sm text-gray-300 hover:text-gray-100 transition-colors">
-                                    <span className="flex-1 min-w-0">{l.title}</span>
-                                    <MtlxIcon name="external-link" className="w-3.5 h-3.5 text-gray-600 group-hover:text-gray-400 transition-colors" />
-                                </a>
-                            ))}
+                            <div className="flex-1 flex flex-col justify-evenly">
+                                {officialLinks.map((l) => (
+                                    <a key={l.href} href={l.href} target="_blank" rel="noopener noreferrer" className="group flex items-center gap-2.5 py-1.5 text-sm text-gray-300 hover:text-gray-100 transition-colors">
+                                        <span className="flex-1 min-w-0">{l.title}</span>
+                                        <MtlxIcon name="external-link" className="w-3.5 h-3.5 text-gray-600 group-hover:text-gray-400 transition-colors" />
+                                    </a>
+                                ))}
+                            </div>
                         </div>
                     </div>
                 </section>

--- a/materials/standard_surface_carpaint_to_openpbr.mtlx
+++ b/materials/standard_surface_carpaint_to_openpbr.mtlx
@@ -1,0 +1,57 @@
+<?xml version="1.0"?>
+<materialx version="1.39" colorspace="lin_rec709">
+  <!-- Compare example pair Document B: the carpaint values from
+       StandardSurface/standard_surface_carpaint.mtlx (v1.39.5) fed through
+       the stdlib standard_surface_to_open_pbr_surface graph. -->
+  <standard_surface_to_open_pbr_surface name="carpaint_to_openpbr" type="multioutput">
+    <input name="base" type="float" value="0.5" />
+    <input name="base_color" type="color3" value="0.1037792, 0.59212029, 0.85064936" />
+    <input name="specular" type="float" value="1.0" />
+    <input name="specular_color" type="color3" value="1.0, 1.0, 1.0" />
+    <input name="specular_roughness" type="float" value="0.4" />
+    <input name="specular_anisotropy" type="float" value="0.5" />
+    <input name="coat" type="float" value="1" />
+    <input name="coat_roughness" type="float" value="0" />
+  </standard_surface_to_open_pbr_surface>
+  <open_pbr_surface name="SR_carpaint_openpbr" type="surfaceshader">
+    <input name="base_weight" type="float" nodename="carpaint_to_openpbr" output="base_weight_out" />
+    <input name="base_color" type="color3" nodename="carpaint_to_openpbr" output="base_color_out" />
+    <input name="base_diffuse_roughness" type="float" nodename="carpaint_to_openpbr" output="base_diffuse_roughness_out" />
+    <input name="base_metalness" type="float" nodename="carpaint_to_openpbr" output="base_metalness_out" />
+    <input name="specular_weight" type="float" nodename="carpaint_to_openpbr" output="specular_weight_out" />
+    <input name="specular_color" type="color3" nodename="carpaint_to_openpbr" output="specular_color_out" />
+    <input name="specular_roughness" type="float" nodename="carpaint_to_openpbr" output="specular_roughness_out" />
+    <input name="specular_ior" type="float" nodename="carpaint_to_openpbr" output="specular_ior_out" />
+    <input name="specular_roughness_anisotropy" type="float" nodename="carpaint_to_openpbr" output="specular_roughness_anisotropy_out" />
+    <input name="transmission_weight" type="float" nodename="carpaint_to_openpbr" output="transmission_weight_out" />
+    <input name="transmission_color" type="color3" nodename="carpaint_to_openpbr" output="transmission_color_out" />
+    <input name="transmission_depth" type="float" nodename="carpaint_to_openpbr" output="transmission_depth_out" />
+    <input name="transmission_scatter" type="color3" nodename="carpaint_to_openpbr" output="transmission_scatter_out" />
+    <input name="transmission_scatter_anisotropy" type="float" nodename="carpaint_to_openpbr" output="transmission_scatter_anisotropy_out" />
+    <input name="transmission_dispersion_scale" type="float" nodename="carpaint_to_openpbr" output="transmission_dispersion_scale_out" />
+    <input name="subsurface_weight" type="float" nodename="carpaint_to_openpbr" output="subsurface_weight_out" />
+    <input name="subsurface_color" type="color3" nodename="carpaint_to_openpbr" output="subsurface_color_out" />
+    <input name="subsurface_radius" type="float" nodename="carpaint_to_openpbr" output="subsurface_radius_out" />
+    <input name="subsurface_radius_scale" type="color3" nodename="carpaint_to_openpbr" output="subsurface_radius_scale_out" />
+    <input name="subsurface_scatter_anisotropy" type="float" nodename="carpaint_to_openpbr" output="subsurface_scatter_anisotropy_out" />
+    <input name="fuzz_weight" type="float" nodename="carpaint_to_openpbr" output="fuzz_weight_out" />
+    <input name="fuzz_color" type="color3" nodename="carpaint_to_openpbr" output="fuzz_color_out" />
+    <input name="fuzz_roughness" type="float" nodename="carpaint_to_openpbr" output="fuzz_roughness_out" />
+    <input name="coat_weight" type="float" nodename="carpaint_to_openpbr" output="coat_weight_out" />
+    <input name="coat_color" type="color3" nodename="carpaint_to_openpbr" output="coat_color_out" />
+    <input name="coat_roughness" type="float" nodename="carpaint_to_openpbr" output="coat_roughness_out" />
+    <input name="coat_roughness_anisotropy" type="float" nodename="carpaint_to_openpbr" output="coat_roughness_anisotropy_out" />
+    <input name="coat_ior" type="float" nodename="carpaint_to_openpbr" output="coat_ior_out" />
+    <input name="coat_darkening" type="float" nodename="carpaint_to_openpbr" output="coat_darkening_out" />
+    <input name="thin_film_weight" type="float" nodename="carpaint_to_openpbr" output="thin_film_weight_out" />
+    <input name="thin_film_thickness" type="float" nodename="carpaint_to_openpbr" output="thin_film_thickness_out" />
+    <input name="thin_film_ior" type="float" nodename="carpaint_to_openpbr" output="thin_film_ior_out" />
+    <input name="emission_luminance" type="float" nodename="carpaint_to_openpbr" output="emission_luminance_out" />
+    <input name="emission_color" type="color3" nodename="carpaint_to_openpbr" output="emission_color_out" />
+    <input name="geometry_opacity" type="float" nodename="carpaint_to_openpbr" output="geometry_opacity_out" />
+    <input name="geometry_thin_walled" type="boolean" nodename="carpaint_to_openpbr" output="geometry_thin_walled_out" />
+  </open_pbr_surface>
+  <surfacematerial name="Car_Paint_OpenPBR" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="SR_carpaint_openpbr" />
+  </surfacematerial>
+</materialx>

--- a/vscode_extension/media/webview.html
+++ b/vscode_extension/media/webview.html
@@ -130,7 +130,7 @@
             }
         })();
     </script>
-    <script>window.__MTLX_BUILD = 'ad471e6b4bbf56e8';</script>
+    <script>window.__MTLX_BUILD = 'c2fe03ec25dbf3b3';</script>
     <!-- Build-id probe. Lives here, beside the stamp, deliberately: every
          other script (shell.jsx, mtlx-assets.js) is separately cached and
          may itself be the stale file this is meant to detect. -->


### PR DESCRIPTION
A full design pass bringing the three remaining product pages onto the design language defined by the home, What is MaterialX, and VS Code pages, followed by a deep consistency pass over the two parameter editors (Node Specs previewer and Graph Editor sidebar), which had drifted apart visually despite their overlap.

## General UI Changes

- One floating-pill family for controls overlaid on 3D stages, exported from `ui-commons.js`; home, What-is, Viewer and Compare all consume the same constants instead of near-identical local strings.
- The node-type palette (`TYPE_COLORS` / `typeColor`) moved to `ui-commons.js` as the single source; the graph legend, graph ports, docs port tables and both parameter editors now share one color coding system.
- New `FilePickerField` component: a joined path field + `Choose...` button with optional editing, a clear x, per-context icons (`file` / `files`), dialog `accept` filtering and a sans/mono font switch. Used by every file input in the app: parameter filenames, document loading, environment maps.
- `MtlxSelect` gained left-aligned trigger content (`align`) and sans badges, fixing the centered colorspace dropdowns and enabling default-option badges.

## Node Specs

- Port tables: full grid lines, legend-dot type coloring (family tokens and prose types stay neutral), quiet neutral columns, and a fixed dead hover class.
- Parameter editing now mirrors the Graph Editor: same row idiom (type dot, mono label, colored type tag), same section headers, same fields, fonts, square swatches, colorspace selects and file picker.
- Colorspace correctness fix: filename colorspace only renders for color3/color4 signatures, per the spec (a float image no longer offers one). Color3 values gained colorspace support, which also fixed a bug where the override path hardcoded the filename type.
- Enum dropdowns badge their nodedef default;
- selection is always blue with amber reserved for status dots.

## Viewer and Compare

- The Viewer adopted Compare's control model: the sidebar owns Scene, Environment and Rendering cards; the labeled HUD covers viewpoint and document actions; every group starts expanded. The VS Code extension viewer deliberately keeps its compact icon HUD.
- Adds a one-click example pair loading the Standard Surface carpaint against the same values run through the stdlib `standard_surface_to_open_pbr_surface` translation graph into an OpenPBR shader.
- Both pages use the shared pickers for documents (with a fused folder button) and environment maps (clear x restores the default environment; Reset moved to the bottom of the card since it resets more than the file). File dialogs filter to the types each flow actually ingests.

## Graph Editor

- Parameters show MaterialX `uiname`s when available (port names stay on the node cards and in tooltips).
- A floating `Leave <nodegraph>` pill appears inside nodegraphs, sharing one `goUpScope` with Backspace, the context menu and the breadcrumb.
- Colorspace is always visible on color params; the settings popover lost its duplicate geometry select; File > Import now filters its dialog; the last native `<select>` in the parameter rows moved to the shared dropdown.