### PR TITLE
Incremental Gallery Thumbnail Genration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -136,11 +136,38 @@ jobs:
 
       # Generated straight into the staged site; gitignored locally (see
       # docs/local/GALLERY.md). Same release-or-dispatch gate as above.
+      #
+      # On dispatch the staging step above did not run, so there is no
+      # $RUNNER_TEMP/site to generate into. Generation still runs (that is
+      # the point of the dry run) but targets its own directory, which also
+      # stops the dispatch path from looking like it exercised
+      # generate-after-stage when it did not.
+      #
+      # Captures run SEQUENTIALLY on purpose. Concurrency measured 1.33x
+      # faster but silently produced 8 blank thumbnails out of 54 (the
+      # screenshot races the first paint); see scripts/gallery-shots.mjs.
+      # A blank tile that exits 0 is worse than a slow job.
+      #
+      # A release reuses the thumbnails already published on the live site
+      # for every material whose fingerprint is unchanged, so it renders
+      # only what actually changed (54 materials at ~13s each otherwise:
+      # the runner has no GPU, so WebGL falls back to SwiftShader and the
+      # cost is software rasterization we cannot optimise away).
+      #
+      # A dispatch deliberately does NOT reuse: it is the dry run, and it
+      # is only worth anything if it exercises real rendering.
       - name: Generate gallery data
         if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
         run: |
-          node scripts/build-gallery.mjs --out "$RUNNER_TEMP/site/gallery"
-          node scripts/gallery-shots.mjs --manifest "$RUNNER_TEMP/site/gallery/manifest.json" --out "$RUNNER_TEMP/site/gallery"
+          if [ "${{ github.event_name }}" = "release" ]; then
+            DEST="$RUNNER_TEMP/site/gallery"
+            REUSE="--reuse-from https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}"
+          else
+            DEST="$RUNNER_TEMP/gallery-dryrun"
+            REUSE=""
+          fi
+          node scripts/build-gallery.mjs --out "$DEST"
+          node scripts/gallery-shots.mjs --manifest "$DEST/manifest.json" --out "$DEST" $REUSE
 
       # Not committed: the tag isn't knowable ahead of release, and the
       # build-id gate byte-compares committed artifacts. vsix name/url are

--- a/scripts/build-gallery.mjs
+++ b/scripts/build-gallery.mjs
@@ -11,6 +11,7 @@
 
 import { readFile, writeFile, mkdir, readdir, stat } from "node:fs/promises";
 import { existsSync } from "node:fs";
+import { createHash } from "node:crypto";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -223,6 +224,11 @@ function extractLineComment(xml, lineNumber) {
 async function collectDocument(rootPath, rootXml) {
   const seenRefs = new Set();
   const refs = [];
+  // Fingerprint of everything this material renders from. A deploy reuses
+  // the previously published thumbnail when this is unchanged, so it has
+  // to cover the root doc, every include, and every texture byte.
+  const hash = createHash("sha256");
+  hash.update(rootXml);
   const pieces = [rootXml];
   const visited = new Set([rootPath]);
   const queue = [{ dir: path.dirname(rootPath), xml: rootXml }];
@@ -238,6 +244,8 @@ async function collectDocument(rootPath, rootXml) {
         continue;
       }
       const incXml = await readFile(incPath, "utf8");
+      hash.update(href);
+      hash.update(incXml);
       pieces.push(incXml);
       queue.push({ dir: path.dirname(incPath), xml: incXml });
     }
@@ -256,6 +264,8 @@ async function collectDocument(rootPath, rootXml) {
       const st = await stat(abs);
       textureCount++;
       textureBytes += st.size;
+      hash.update(ref);
+      hash.update(await readFile(abs));
     } catch (e) {
       console.warn(`warning: texture ref not found on disk: ${abs} (ref "${ref}")`);
     }
@@ -265,6 +275,7 @@ async function collectDocument(rootPath, rootXml) {
   return {
     textureCount,
     textureBytes,
+    hash: hash.digest("hex").slice(0, 16),
     renderables: extractRenderables(combinedXml),
     shader: extractShaderCategory(combinedXml) || "unknown",
   };
@@ -300,7 +311,7 @@ async function listExampleFiles() {
 async function buildExampleEntry(family, fileName, absPath) {
   const xml = await readFile(absPath, "utf8");
   const stats = await stat(absPath);
-  const { textureCount, textureBytes, renderables, shader } = await collectDocument(absPath, xml);
+  const { textureCount, textureBytes, hash, renderables, shader } = await collectDocument(absPath, xml);
 
   const id = fileName.replace(/\.mtlx$/, "");
   const familyLabel = FAMILY_LABELS[family] || family;
@@ -324,6 +335,7 @@ async function buildExampleEntry(family, fileName, absPath) {
     shader,
     tags: dedupe([familyLabel, textured ? "Textured" : "Procedural", shader]),
     thumb: `thumbs/${id}.jpg`,
+    hash,
     license: MATERIALX_LICENSE,
   };
   if (id === "standard_surface_chess_set") {
@@ -336,7 +348,7 @@ async function buildExampleEntry(family, fileName, absPath) {
 async function buildPlaygroundEntry(def) {
   const xml = await readFile(def.absPath, "utf8");
   const stats = await stat(def.absPath);
-  const { textureCount, textureBytes, renderables, shader } = await collectDocument(def.absPath, xml);
+  const { textureCount, textureBytes, hash, renderables, shader } = await collectDocument(def.absPath, xml);
   const textured = textureCount > 0;
   const familyLabel = "Playground";
 
@@ -355,6 +367,7 @@ async function buildPlaygroundEntry(def) {
     shader,
     tags: dedupe([familyLabel, textured ? "Textured" : "Procedural", shader]),
     thumb: `thumbs/${def.id}.jpg`,
+    hash,
     license: def.license || REPO_LICENSE,
   };
   if (def.note) entry.note = def.note;

--- a/scripts/gallery-shots.mjs
+++ b/scripts/gallery-shots.mjs
@@ -7,11 +7,27 @@
 // tests/embed/lib/test-base.mjs uses), and screenshots one <materialx-
 // viewer> per material into <out>/thumbs/<id>.jpg.
 //
+// Captures run on a pool of workers pulling from a shared cursor. Each
+// capture still gets a FRESH page and a fresh viewer: reusing one warm
+// viewer and swapping documents through the embed's load() command was
+// measured slower (the long-lived page degrades: 13.3s -> ~16s per
+// material) and it hangs outright on xi:include documents, which the
+// `src` path resolves by crawling. See docs/local/GALLERY-ASSETS.md.
+//
 // Usage: node scripts/gallery-shots.mjs [--manifest <path>] [--out <dir>]
-//                                       [--limit N] [--only <id>]
+//                                       [--limit N] [--only <id>] [--jobs N]
+//                                       [--reuse-from <site base url>]
+//
+// --reuse-from makes a deploy incremental: it reads the manifest already
+// published at that site and re-downloads every thumbnail whose material
+// fingerprint is unchanged, so only new or edited materials get rendered.
+// Rendering is CPU-bound software rasterization on a GPU-less runner
+// (~13s each), so NOT rendering is worth far more than rendering faster.
+// Any failure falls back to a full capture: slow, never wrong.
 
-import { readFile, mkdir } from "node:fs/promises";
+import { readFile, writeFile, mkdir } from "node:fs/promises";
 import path from "node:path";
+import os from "node:os";
 import { fileURLToPath } from "node:url";
 import { chromium } from "@playwright/test";
 import { startServer } from "../tests/embed/lib/server.mjs";
@@ -21,9 +37,13 @@ const __dirname = path.dirname(__filename);
 const REPO_ROOT = path.resolve(__dirname, "..");
 
 const HARNESS_PATH = "/tests/embed/fixtures/harness.html";
-const PER_MATERIAL_TIMEOUT_MS = 60000;
+// Scaled by --jobs below: N workers sharing the CPU inflate each
+// capture roughly N-fold, and a fixed 60s budget turns that into mass
+// timeouts rather than a slower-but-correct run.
+const PER_MATERIAL_TIMEOUT_BASE_MS = 60000;
 const READY_WAIT_TIMEOUT_MS = 45000;
 const SETTLE_WAIT_MS = 1500;
+const MAX_ATTEMPTS = 3;
 
 function log(...args) {
   console.log(...args);
@@ -34,6 +54,23 @@ function parseArgs(argv) {
   let outDir = path.join(REPO_ROOT, "gallery");
   let limit = null;
   let only = null;
+  // DEFAULT 1, deliberately. Concurrency is implemented and works, but it
+  // is NOT safe with the current capture: mtlx-ready fires before the first
+  // paint, and the fixed SETTLE_WAIT_MS below is a wall-clock guess. Under
+  // CPU contention the render misses that window and the screenshot catches
+  // an unpainted viewport, which is SILENT corruption (exit 0, black tile).
+  // Measured at --jobs 2 over all 54: 543s vs 720s (1.33x) but 8 thumbnails
+  // came back blank (mean brightness ~25/255 against ~200 expected). The
+  // same 8 are pixel-perfect at --jobs 1.
+  //
+  // Stability polling cannot rescue it either: a black frame is stable.
+  // Making concurrency safe needs a real paint signal, and one exists --
+  // the embed's snapshot() command routes to mtlx-engine.js's
+  // handle.snapshot(), which does setUniforms(); renderFrame(); toDataURL()
+  // synchronously, so it cannot return an unpainted frame. Switching the
+  // capture to that is the prerequisite for raising this default.
+  let jobs = 1;
+  let reuseFrom = null;
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
     if (arg === "--manifest" && argv[i + 1]) {
@@ -44,9 +81,13 @@ function parseArgs(argv) {
       limit = Number(argv[++i]);
     } else if (arg === "--only" && argv[i + 1]) {
       only = argv[++i];
+    } else if (arg === "--jobs" && argv[i + 1]) {
+      jobs = Math.max(1, Number(argv[++i]) || 1);
+    } else if (arg === "--reuse-from" && argv[i + 1]) {
+      reuseFrom = String(argv[++i]).replace(/\/+$/, "");
     }
   }
-  return { manifestPath, outDir, limit, only };
+  return { manifestPath, outDir, limit, only, jobs, reuseFrom };
 }
 
 /** Races `promise` against a timeout, rejecting with a labeled error if
@@ -57,6 +98,44 @@ function withTimeout(promise, ms, label) {
     timer = setTimeout(() => reject(new Error(`timed out after ${ms}ms capturing "${label}"`)), ms);
   });
   return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+}
+
+/** Downloads thumbnails whose fingerprint matches the already-published
+ * manifest, and returns the materials that still need rendering. Never
+ * throws: an unreachable or absent previous deploy just means capturing
+ * everything, which is what the very first release does anyway. */
+async function reusePublished(reuseFrom, materials, outDir) {
+  const reused = [];
+  let prev = null;
+  try {
+    const res = await fetch(`${reuseFrom}/gallery/manifest.json`);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    prev = await res.json();
+  } catch (err) {
+    log(`reuse: no usable manifest at ${reuseFrom} (${String((err && err.message) || err)}); rendering everything.`);
+    return { reused, remaining: materials };
+  }
+
+  const prevHash = new Map((prev.materials || []).map((m) => [m.id, m.hash]));
+  const remaining = [];
+  for (const m of materials) {
+    if (!m.hash || prevHash.get(m.id) !== m.hash) {
+      remaining.push(m);
+      continue;
+    }
+    try {
+      const res = await fetch(`${reuseFrom}/gallery/thumbs/${m.id}.jpg`);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const buf = Buffer.from(await res.arrayBuffer());
+      if (buf.length === 0) throw new Error("empty body");
+      await writeFile(path.join(outDir, "thumbs", `${m.id}.jpg`), buf);
+      reused.push(m.id);
+    } catch (err) {
+      remaining.push(m); // published tile missing or corrupt: render it again
+    }
+  }
+  log(`reuse: ${reused.length} unchanged thumbnail(s) downloaded, ${remaining.length} to render.`);
+  return { reused, remaining };
 }
 
 function docUrlFor(baseURL, material) {
@@ -96,7 +175,7 @@ async function captureOne(context, baseURL, outDir, material) {
 }
 
 async function main() {
-  const { manifestPath, outDir, limit, only } = parseArgs(process.argv.slice(2));
+  const { manifestPath, outDir, limit, only, jobs, reuseFrom } = parseArgs(process.argv.slice(2));
 
   const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
   let materials = manifest.materials;
@@ -110,34 +189,88 @@ async function main() {
 
   await mkdir(path.join(outDir, "thumbs"), { recursive: true });
 
+  const overallStarted = Date.now();
+  let reusedCount = 0;
+  if (reuseFrom) {
+    const { reused, remaining } = await reusePublished(reuseFrom, materials, outDir);
+    reusedCount = reused.length;
+    materials = remaining;
+    if (materials.length === 0) {
+      log(`gallery thumbnails: ${reusedCount} reused, 0 rendered. Nothing changed.`);
+      return; // no browser, no server: the whole point of reusing
+    }
+  }
+
   const { baseURL, close } = await startServer({ root: REPO_ROOT });
-  const browser = await chromium.launch({ headless: true });
+  const browser = await chromium.launch({
+    headless: true,
+    // Chromium's default /dev/shm is 64MB under Docker, which surfaces as
+    // "Target crashed" mid-screenshot. Harmless outside a container.
+    args: ["--disable-dev-shm-usage"],
+  });
   const ok = [];
   const failed = [];
+  const started = Date.now();
+
+  // Shared cursor rather than fixed slices: materials vary from ~7s to
+  // ~25s, so a static split would leave workers idle at the tail.
+  let cursor = 0;
+  const workerCount = Math.min(jobs, materials.length);
+
+  async function runWorker() {
+    const context = await browser.newContext();
+    try {
+      for (;;) {
+        const index = cursor++;
+        if (index >= materials.length) break;
+        const material = materials[index];
+        log(`capturing ${material.id} ...`);
+
+        let lastErr = null;
+        for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+          try {
+            await withTimeout(captureOne(context, baseURL, outDir, material), PER_MATERIAL_TIMEOUT_BASE_MS * workerCount, material.id);
+            lastErr = null;
+            break;
+          } catch (err) {
+            lastErr = err;
+            if (attempt < MAX_ATTEMPTS) {
+              console.error(`  retry ${attempt}/${MAX_ATTEMPTS - 1} for ${material.id}: ${String((err && err.message) || err)}`);
+            }
+          }
+        }
+
+        if (lastErr) {
+          const msg = String((lastErr && lastErr.message) || lastErr);
+          failed.push({ id: material.id, message: msg });
+          console.error(`  failed: ${material.id}: ${msg}`);
+        } else {
+          ok.push(material.id);
+        }
+      }
+    } finally {
+      await context.close().catch(() => {});
+    }
+  }
 
   try {
-    const context = await browser.newContext();
-    for (const material of materials) {
-      log(`capturing ${material.id} ...`);
-      try {
-        await withTimeout(captureOne(context, baseURL, outDir, material), PER_MATERIAL_TIMEOUT_MS, material.id);
-        ok.push(material.id);
-      } catch (err) {
-        failed.push({ id: material.id, message: String((err && err.message) || err) });
-        console.error(`  failed: ${material.id}: ${String((err && err.message) || err)}`);
-      }
-    }
+    await Promise.all(Array.from({ length: workerCount }, () => runWorker()));
   } finally {
     await browser.close().catch(() => {});
     await close().catch(() => {});
   }
 
+  const elapsed = (Date.now() - started) / 1000;
   log("");
-  log(`gallery thumbnails: ${ok.length} ok, ${failed.length} failed (of ${materials.length}).`);
+  log(`gallery thumbnails: ${ok.length} ok, ${failed.length} failed (of ${materials.length} rendered)${reusedCount ? `, ${reusedCount} reused` : ""}.`);
+  log(`elapsed ${elapsed.toFixed(1)}s with ${workerCount} worker(s), ${(elapsed / materials.length).toFixed(2)}s per rendered material.`);
+  if (reusedCount) log(`total including reuse: ${((Date.now() - overallStarted) / 1000).toFixed(1)}s`);
   if (failed.length > 0) {
     log("failed: " + failed.map((f) => f.id).join(", "));
+    // A partial run must fail the build: in CI the output directory is
+    // fresh, so a missing tile would ship as a placeholder with a green check.
+    process.exit(1);
   }
-  if (ok.length === 0) process.exit(1);
 }
 
 await main();


### PR DESCRIPTION
Releases would spend several minutes rendering all gallery thumbnails, almost none of which changed. This PR makes a release reuse what's already published and render only what actually changed. It also fixes a capture bug that could ship a broken gallery with a green check.

### The published site is the cache

Every release publishes tiles to `<site>/gallery/thumbs/<id>.jpg`, and they stay there until the next release. That's the cache: no infrastructure, no expiry, no scoping rules.

- `build-gallery.mjs` emits a per-material `hash`, a sha256 over the root document, every `xi:include` and every texture byte.
- `gallery-shots.mjs --reuse-from <site>` reads the live manifest, downloads tiles whose fingerprint is unchanged, and renders only the rest. If nothing changed it returns before launching a browser or a server.
- `deploy.yml` passes `--reuse-from` on **release only**, with the URL derived from the repo rather than hardcoded. A `workflow_dispatch` deliberately does not reuse, so the dry run still exercises real rendering.

Every failure path degrades to a full capture: unreachable host, missing manifest, 404 tile, empty body.

## Correctness fixes

- **Partial runs now fail the build.**

- Adds 2 retries per material, a per-material timeout that scales with worker count, and `--disable-dev-shm-usage`.

## Rejected Speedup Alternatives

- **Swapping documents into one warm viewer**: 1202 s against a 720 s baseline. A long-lived page degrades (9 s early, 25 s late), and it hangs outright on `xi:include` documents, since `load()` takes the root document as a string with no location to resolve includes against.
- **Parallel capture**: 1.33x faster but produced **8 blank thumbnails out of 54**. `mtlx-ready` fires before the first paint and the settle is a wall-clock guess that contention blows through. Stability polling can't rescue it because a black frame is stable. Concurrency stays behind `--jobs`, defaulted to 1, documented at the flag.__
- **Smaller thumbnails**: cards render at 228-241 CSS px, so 512 is already exactly 2x for retina. 256 renders 3x faster and looks soft on most laptops.

## Notes for the first release

The first release after this merges still takes ~12 minutes, because there's no published gallery to reuse from yet. Every release after that is incremental.